### PR TITLE
Slice 2 Phase H: agent-stuck detection + duration escalate_after

### DIFF
--- a/.ai-devkit.json
+++ b/.ai-devkit.json
@@ -1,0 +1,39 @@
+{
+  "version": "0.21.1",
+  "environments": [
+    "claude"
+  ],
+  "phases": [
+    "requirements",
+    "design",
+    "planning",
+    "implementation",
+    "testing",
+    "deployment",
+    "monitoring"
+  ],
+  "createdAt": "2026-04-11T17:22:43.813Z",
+  "updatedAt": "2026-04-11T17:23:13.891Z",
+  "skills": [
+    {
+      "registry": "codeaholicguy/ai-devkit",
+      "name": "dev-lifecycle"
+    },
+    {
+      "registry": "codeaholicguy/ai-devkit",
+      "name": "debug"
+    },
+    {
+      "registry": "codeaholicguy/ai-devkit",
+      "name": "memory"
+    },
+    {
+      "registry": "codeaholicguy/ai-devkit",
+      "name": "verify"
+    },
+    {
+      "registry": "codeaholicguy/ai-devkit",
+      "name": "tdd"
+    }
+  ]
+}

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -36,7 +36,7 @@
 use crate::{
     error::Result,
     events::{OrchestratorEvent, TerminationReason},
-    reaction_engine::{status_to_reaction_key, ReactionEngine},
+    reaction_engine::{parse_duration, status_to_reaction_key, ReactionEngine},
     reactions::{ReactionAction, ReactionOutcome},
     scm::{CiStatus, MergeReadiness, PrState, ReviewDecision},
     scm_transitions::{derive_scm_status, ScmObservation},
@@ -44,7 +44,11 @@ use crate::{
     traits::{Agent, Runtime, Scm},
     types::{ActivityState, Session, SessionId, SessionStatus},
 };
-use std::{collections::HashSet, sync::Arc, time::Duration};
+use std::{
+    collections::{HashMap, HashSet},
+    sync::{Arc, Mutex},
+    time::{Duration, Instant},
+};
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
 
@@ -76,6 +80,25 @@ pub struct LifecycleManager {
     /// — SCM polling is off. This matches how tests and `ao-rs watch`
     /// without a configured plugin should behave.
     scm: Option<Arc<dyn Scm>>,
+    /// Slice 2 Phase H bookkeeping for agent-stuck detection.
+    ///
+    /// Records the `Instant` at which each session first entered an idle
+    /// activity state (`Idle` / `Blocked`). `check_stuck` reads this map
+    /// to decide whether the session has been idle longer than the
+    /// configured `agent-stuck.threshold`.
+    ///
+    /// - An entry is **inserted** the first tick activity flips into
+    ///   `Idle`/`Blocked` and **preserved** across subsequent idle ticks
+    ///   so `elapsed()` grows monotonically.
+    /// - An entry is **removed** as soon as activity flips back to any
+    ///   non-idle state, so the next idle streak restarts the clock.
+    /// - `terminate` also clears the entry to bound memory for long-
+    ///   running watch loops (Task 2.7).
+    ///
+    /// `Mutex<HashMap>` mirrors how `ReactionEngine::trackers` is stored —
+    /// short critical sections around pure read/modify/write, no nested
+    /// locking.
+    idle_since: Mutex<HashMap<SessionId, Instant>>,
 }
 
 impl LifecycleManager {
@@ -93,6 +116,7 @@ impl LifecycleManager {
             poll_interval: DEFAULT_POLL_INTERVAL,
             reaction_engine: None,
             scm: None,
+            idle_since: Mutex::new(HashMap::new()),
         }
     }
 
@@ -274,11 +298,32 @@ impl LifecycleManager {
             });
         }
 
+        // Phase H: maintain the idle-since timestamp used by
+        // `check_stuck`. Unconditional every tick — the helper itself
+        // decides whether to insert, preserve, or remove.
+        self.update_idle_since(&session.id, activity);
+
+        // Snapshot the status BEFORE any transitioning step runs, so
+        // step 6 (`check_stuck`) can yield the tick if an earlier step
+        // already mutated `session.status`. Matches the TS reference's
+        // `determineStatus` contract of one transition per call — see
+        // Design Decision 8 in docs/ai/design/feature-agent-stuck-detection.md
+        // and the "one transition per tick" entry in memory.
+        let pre_transition_status = session.status;
+
         // ---- 4. Status transitions driven by activity ----
         // Slice 1 Phase C handles the happy-path Spawning → Working flip.
         // Phase F layers SCM-driven transitions on top (see step 5).
-        if session.status == SessionStatus::Spawning
-            && matches!(activity, ActivityState::Active | ActivityState::Ready)
+        // Phase H extends this with the symmetric `Stuck → Working`
+        // recovery: a session that went idle long enough to park in
+        // `Stuck` should exit the moment the agent starts producing
+        // activity again. `transition` auto-clears the `agent-stuck`
+        // tracker via `status_to_reaction_key(Stuck) = Some("agent-stuck")`
+        // so there's no bespoke cleanup needed here.
+        if matches!(
+            session.status,
+            SessionStatus::Spawning | SessionStatus::Stuck
+        ) && matches!(activity, ActivityState::Active | ActivityState::Ready)
         {
             self.transition(&mut session, SessionStatus::Working)
                 .await?;
@@ -291,6 +336,18 @@ impl LifecycleManager {
         // kill the whole tick.
         if self.scm.is_some() {
             self.poll_scm(&mut session).await?;
+        }
+
+        // ---- 6. Agent-stuck detection (Phase H) ----
+        // Gated on the pre-transition snapshot: if step 4 or 5 already
+        // mutated `session.status` this tick, we yield and let the next
+        // tick decide whether stuck still applies. Also gated on a
+        // reaction engine being configured — without one, there's no
+        // `agent-stuck` config to read and no way to emit the tracker
+        // event, so the early-return in `check_stuck` would fire anyway
+        // but checking here keeps the happy path one branch shorter.
+        if self.reaction_engine.is_some() && session.status == pre_transition_status {
+            self.check_stuck(&mut session).await?;
         }
 
         Ok(())
@@ -396,6 +453,14 @@ impl LifecycleManager {
         if let Some(engine) = self.reaction_engine.as_ref() {
             engine.clear_all_for_session(&session.id);
         }
+        // Phase H: purge the idle-since bookkeeping so a long-running
+        // watch loop doesn't accumulate entries for every session it
+        // has ever seen. Runs unconditionally — the map lookup is a
+        // no-op if no entry was ever inserted.
+        self.idle_since
+            .lock()
+            .expect("lifecycle idle_since mutex poisoned")
+            .remove(&session.id);
         self.emit(OrchestratorEvent::Terminated {
             id: session.id.clone(),
             reason,
@@ -505,6 +570,117 @@ impl LifecycleManager {
             to,
         });
         Ok(())
+    }
+
+    /// Phase H agent-stuck detection. Called from `poll_one` as the
+    /// final transitioning step, gated on the pre-transition snapshot
+    /// and the presence of a reaction engine.
+    ///
+    /// Early-returns (without erroring) in every "nothing to do" case:
+    ///
+    /// 1. Status is not stuck-eligible (terminal, already `Stuck`,
+    ///    `NeedsInput`, etc.). Keeps us from double-firing and from
+    ///    stuck-classifying states where idleness is expected.
+    /// 2. No `idle_since` entry exists — the session is actively doing
+    ///    something, so the stuck clock isn't running.
+    /// 3. No `agent-stuck` reaction is configured. Missing config is a
+    ///    deliberate "disabled" signal, not an error.
+    /// 4. The configured `threshold` is absent or unparseable.
+    ///    Malformed strings log a one-shot `tracing::warn!` via
+    ///    `ReactionEngine::warn_once_parse_failure`, but do not panic.
+    /// 5. The idle elapsed time has not yet *strictly* exceeded the
+    ///    threshold (`elapsed <= threshold` early-returns; the flip
+    ///    fires only on `elapsed > threshold`). Exactly-equal holds
+    ///    the clock for one more tick, matching the strict `>` that
+    ///    `ReactionEngine::dispatch` uses on `first_triggered_at`.
+    ///
+    /// Only when all five guards pass do we call `transition` into
+    /// `SessionStatus::Stuck`, which in turn dispatches the
+    /// `agent-stuck` reaction. Subsequent ticks see `Stuck` (not
+    /// stuck-eligible) and stay stable until activity flips back.
+    async fn check_stuck(&self, session: &mut Session) -> Result<()> {
+        // Guard 1: stuck-eligible status?
+        if !is_stuck_eligible(session.status) {
+            return Ok(());
+        }
+
+        // Guard 2: has this session been idle long enough to even
+        // have a clock running?
+        let idle_started = {
+            let map = self
+                .idle_since
+                .lock()
+                .expect("lifecycle idle_since mutex poisoned");
+            map.get(&session.id).copied()
+        };
+        let Some(idle_started) = idle_started else {
+            return Ok(());
+        };
+
+        // Guard 3: is a reaction engine attached with an agent-stuck
+        // config? The earlier `self.reaction_engine.is_some()` check
+        // in `poll_one` already handled the `None` case, but we
+        // re-check here so the helper is safe to call in isolation.
+        let Some(engine) = self.reaction_engine.as_ref() else {
+            return Ok(());
+        };
+        let Some(cfg) = engine.reaction_config("agent-stuck") else {
+            return Ok(());
+        };
+
+        // Guard 4: parse the threshold. Missing → silent no-op
+        // (stuck detection disabled). Malformed → one-shot warn via
+        // the engine's warn_once helper so operators see it once in
+        // the logs but don't get spammed every tick.
+        let Some(raw) = cfg.threshold.as_deref() else {
+            return Ok(());
+        };
+        let Some(threshold) = parse_duration(raw) else {
+            engine.warn_once_parse_failure("agent-stuck", "threshold", raw);
+            return Ok(());
+        };
+
+        // Guard 5: has enough wall-clock time elapsed?
+        if idle_started.elapsed() <= threshold {
+            return Ok(());
+        }
+
+        // All guards passed: park the session in `Stuck`. The
+        // `transition` helper handles `agent-stuck` dispatch via the
+        // existing `status_to_reaction_key` path and emits
+        // `StatusChanged` on the event bus, so there is nothing
+        // extra to do here.
+        self.transition(session, SessionStatus::Stuck).await
+    }
+
+    /// Maintain the `idle_since` map in response to a fresh activity
+    /// reading.
+    ///
+    /// - `Idle` or `Blocked` → insert `Instant::now()` **only if** the
+    ///   session isn't already in the map. Preserving the older timestamp
+    ///   means an entry that has been idle for three ticks is still
+    ///   three-ticks-old on the fourth tick, so `elapsed()` grows
+    ///   monotonically across the idle streak.
+    /// - Any other activity state → remove the entry so the next idle
+    ///   streak restarts the clock from zero.
+    ///
+    /// Called unconditionally from `poll_one` after the persist-activity
+    /// block. Terminal activities (`Exited`) never reach this helper —
+    /// `poll_one` short-circuits to `terminate` beforehand, which clears
+    /// the entry via `idle_since.remove` (Task 2.7).
+    fn update_idle_since(&self, session_id: &SessionId, activity: ActivityState) {
+        let mut map = self
+            .idle_since
+            .lock()
+            .expect("lifecycle idle_since mutex poisoned");
+        match activity {
+            ActivityState::Idle | ActivityState::Blocked => {
+                map.entry(session_id.clone()).or_insert_with(Instant::now);
+            }
+            _ => {
+                map.remove(session_id);
+            }
+        }
     }
 
     /// Fire an event into the broadcast channel. A send error only means
@@ -631,6 +807,70 @@ fn clear_tracker_on_transition(
     // Default rule: clear the `from` reaction's tracker on exit.
     if let Some(prev_key) = status_to_reaction_key(from) {
         engine.clear_tracker(session_id, prev_key);
+    }
+}
+
+/// Is `status` eligible for stuck detection? I.e., if a session in
+/// this status has been observed with `Idle`/`Blocked` activity for
+/// longer than the `agent-stuck` reaction's `threshold`, should it be
+/// flipped to `Stuck`?
+///
+/// Phase H. The set matches the "work in progress" statuses where a
+/// silent agent is genuinely unexpected:
+///
+/// - `Working`: happy path coder lost its train of thought.
+/// - `PrOpen` / `CiFailed` / `ReviewPending` / `ChangesRequested`
+///   / `Approved` / `Mergeable`: PR-track states where the agent is
+///   waiting on or reacting to CI / a reviewer, and should be
+///   actively working (applying review comments, re-running tests,
+///   responding to CI failures).
+///
+/// Excluded statuses — and why each is excluded — are enumerated
+/// exhaustively in the match below. The match has **no wildcard**: a
+/// future `SessionStatus` variant will fail the build here until
+/// stuck-eligibility is decided for it. Same discipline as the
+/// `ALL_SESSION_STATUSES` exhaustiveness test in `scm_transitions.rs`.
+const fn is_stuck_eligible(status: SessionStatus) -> bool {
+    match status {
+        // Stuck-eligible: active work or PR-track where progress is expected.
+        SessionStatus::Working
+        | SessionStatus::PrOpen
+        | SessionStatus::CiFailed
+        | SessionStatus::ReviewPending
+        | SessionStatus::ChangesRequested
+        | SessionStatus::Approved
+        | SessionStatus::Mergeable => true,
+
+        // Not stuck-eligible:
+        //
+        // - Spawning: agent hasn't had its first activity poll yet;
+        //   idle_since would never populate for this state anyway.
+        // - Idle: the dedicated "no task assigned / waiting for work"
+        //   status, distinct from "currently working and momentarily
+        //   gone idle". A session in `Idle` is idle by design.
+        // - NeedsInput: already a known-blocked-on-human state with
+        //   its own (future) `agent-needs-input` reaction.
+        // - Stuck: already stuck. Re-entry is handled by the
+        //   `Stuck → Working` exit branch in `poll_one` step 4.
+        // - MergeFailed: Phase G parking state with its own retry
+        //   budget via the `approved-and-green` tracker. Conflating
+        //   with stuck would double-charge retries and confuse the
+        //   parking-loop accounting.
+        // - Terminal states (`Killed`, `Terminated`, `Done`,
+        //   `Cleanup`, `Errored`, `Merged`): filtered out by the
+        //   `tick()` pre-filter long before `check_stuck` is called.
+        //   Listed here so the exhaustive match stays exhaustive.
+        SessionStatus::Spawning
+        | SessionStatus::Idle
+        | SessionStatus::NeedsInput
+        | SessionStatus::Stuck
+        | SessionStatus::MergeFailed
+        | SessionStatus::Killed
+        | SessionStatus::Terminated
+        | SessionStatus::Done
+        | SessionStatus::Cleanup
+        | SessionStatus::Errored
+        | SessionStatus::Merged => false,
     }
 }
 
@@ -1295,6 +1535,548 @@ mod tests {
                 .iter()
                 .any(|e| matches!(e, OrchestratorEvent::ReactionTriggered { .. })),
             "unexpected ReactionTriggered on Working transition: {events:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // ---------- Phase H: is_stuck_eligible classification ---------- //
+
+    /// Every `SessionStatus` variant, in declaration order. Mirrors the
+    /// same-named constant in `scm_transitions.rs` — we keep a local
+    /// copy rather than re-exporting so each module's exhaustiveness
+    /// test is self-contained. Adding a new variant breaks the
+    /// `all_session_statuses_list_is_exhaustive_for_stuck_check` test
+    /// below until classification is decided.
+    const ALL_SESSION_STATUSES: &[SessionStatus] = &[
+        SessionStatus::Spawning,
+        SessionStatus::Working,
+        SessionStatus::NeedsInput,
+        SessionStatus::Idle,
+        SessionStatus::Stuck,
+        SessionStatus::PrOpen,
+        SessionStatus::CiFailed,
+        SessionStatus::ReviewPending,
+        SessionStatus::ChangesRequested,
+        SessionStatus::Approved,
+        SessionStatus::Mergeable,
+        SessionStatus::MergeFailed,
+        SessionStatus::Cleanup,
+        SessionStatus::Merged,
+        SessionStatus::Killed,
+        SessionStatus::Terminated,
+        SessionStatus::Done,
+        SessionStatus::Errored,
+    ];
+
+    #[test]
+    fn all_session_statuses_list_is_exhaustive_for_stuck_check() {
+        // Compile-time exhaustiveness: if a new `SessionStatus` variant
+        // lands, this match fails to compile until it's added. That
+        // forces a conscious classification decision for
+        // `is_stuck_eligible` at the same time. Matches the pattern in
+        // `scm_transitions.rs::all_session_statuses_list_is_exhaustive`.
+        for status in ALL_SESSION_STATUSES {
+            match status {
+                SessionStatus::Spawning
+                | SessionStatus::Working
+                | SessionStatus::NeedsInput
+                | SessionStatus::Idle
+                | SessionStatus::Stuck
+                | SessionStatus::PrOpen
+                | SessionStatus::CiFailed
+                | SessionStatus::ReviewPending
+                | SessionStatus::ChangesRequested
+                | SessionStatus::Approved
+                | SessionStatus::Mergeable
+                | SessionStatus::MergeFailed
+                | SessionStatus::Cleanup
+                | SessionStatus::Merged
+                | SessionStatus::Killed
+                | SessionStatus::Terminated
+                | SessionStatus::Done
+                | SessionStatus::Errored => {}
+            }
+        }
+    }
+
+    #[test]
+    fn is_stuck_eligible_classifies_every_variant() {
+        // Lock in the Phase H classification. Any change to
+        // `is_stuck_eligible` that flips a variant's answer must update
+        // this assertion table alongside — it's the contract for which
+        // statuses can emit the `agent-stuck` reaction.
+        for &status in ALL_SESSION_STATUSES {
+            let expected = matches!(
+                status,
+                SessionStatus::Working
+                    | SessionStatus::PrOpen
+                    | SessionStatus::CiFailed
+                    | SessionStatus::ReviewPending
+                    | SessionStatus::ChangesRequested
+                    | SessionStatus::Approved
+                    | SessionStatus::Mergeable
+            );
+            assert_eq!(
+                is_stuck_eligible(status),
+                expected,
+                "is_stuck_eligible({status:?}) classification mismatch"
+            );
+        }
+    }
+
+    #[test]
+    fn is_stuck_eligible_excludes_merge_failed() {
+        // Phase G parking state must not be stuck-eligible or the
+        // parking loop's retry accounting would double-charge with
+        // the stuck path. Explicit named test because the planning
+        // doc lists this as a specific regression risk.
+        assert!(!is_stuck_eligible(SessionStatus::MergeFailed));
+    }
+
+    #[test]
+    fn is_stuck_eligible_excludes_needs_input() {
+        // Needs-input is a known-blocked-on-human state and will get
+        // its own `agent-needs-input` reaction in a later phase.
+        // Conflating with stuck would fire two reactions on every
+        // idle-NeedsInput session.
+        assert!(!is_stuck_eligible(SessionStatus::NeedsInput));
+    }
+
+    // ---------- idle_since bookkeeping (Phase H) ---------- //
+
+    #[tokio::test]
+    async fn update_idle_since_inserts_preserves_and_clears() {
+        let (lifecycle, _sessions, _rt, _agent, _base) =
+            setup("idle_since_helper", ActivityState::Idle).await;
+        let id = SessionId("sess-idle".into());
+
+        let read_entry = |lm: &LifecycleManager| -> Option<Instant> {
+            lm.idle_since
+                .lock()
+                .expect("idle_since mutex poisoned")
+                .get(&id)
+                .copied()
+        };
+
+        // Fresh lifecycle — nothing recorded yet.
+        assert!(read_entry(&lifecycle).is_none());
+
+        // First Idle flip inserts a timestamp.
+        lifecycle.update_idle_since(&id, ActivityState::Idle);
+        let t1 = read_entry(&lifecycle).expect("first idle should insert");
+
+        // Second Idle call preserves the existing timestamp — we want
+        // `elapsed()` to grow across a streak of idle ticks, not reset.
+        lifecycle.update_idle_since(&id, ActivityState::Idle);
+        let t2 = read_entry(&lifecycle).expect("second idle should keep entry");
+        assert_eq!(t1, t2, "idle → idle must not reset the timestamp");
+
+        // Blocked is also stuck-eligible and must not reset the clock.
+        lifecycle.update_idle_since(&id, ActivityState::Blocked);
+        let t3 = read_entry(&lifecycle).expect("blocked should keep entry");
+        assert_eq!(t1, t3, "idle → blocked must not reset the timestamp");
+
+        // Any non-idle activity clears the entry so the next streak
+        // starts the clock over.
+        lifecycle.update_idle_since(&id, ActivityState::Active);
+        assert!(
+            read_entry(&lifecycle).is_none(),
+            "active activity must clear idle_since"
+        );
+
+        // A fresh Idle afterwards re-inserts (different timestamp — but
+        // we only need to know an entry exists).
+        lifecycle.update_idle_since(&id, ActivityState::Idle);
+        assert!(
+            read_entry(&lifecycle).is_some(),
+            "idle after clear must re-insert"
+        );
+
+        // WaitingInput is NOT stuck-eligible — a session prompting the
+        // human is not silently stuck, so it should reset the idle
+        // clock just like Active. Ready behaves the same way.
+        lifecycle.update_idle_since(&id, ActivityState::WaitingInput);
+        assert!(
+            read_entry(&lifecycle).is_none(),
+            "waiting_input must clear idle_since"
+        );
+
+        lifecycle.update_idle_since(&id, ActivityState::Idle);
+        lifecycle.update_idle_since(&id, ActivityState::Ready);
+        assert!(
+            read_entry(&lifecycle).is_none(),
+            "ready must clear idle_since"
+        );
+    }
+
+    #[tokio::test]
+    async fn update_idle_since_tracks_sessions_independently() {
+        let (lifecycle, _sessions, _rt, _agent, _base) =
+            setup("idle_since_multi", ActivityState::Idle).await;
+        let a = SessionId("sess-a".into());
+        let b = SessionId("sess-b".into());
+
+        lifecycle.update_idle_since(&a, ActivityState::Idle);
+        lifecycle.update_idle_since(&b, ActivityState::Idle);
+
+        // Clearing one does not touch the other — different sessions
+        // have independent idle streaks.
+        lifecycle.update_idle_since(&a, ActivityState::Active);
+
+        let map = lifecycle
+            .idle_since
+            .lock()
+            .expect("idle_since mutex poisoned");
+        assert!(!map.contains_key(&a), "sess-a should have been cleared");
+        assert!(map.contains_key(&b), "sess-b should still be idle");
+    }
+
+    // ---------- Phase H: agent-stuck detection integration ---------- //
+
+    /// Build a `LifecycleManager` with a MockAgent in `Idle`, plus a
+    /// reaction engine configured with `agent-stuck` → Notify and the
+    /// given threshold string.
+    ///
+    /// `threshold` is accepted verbatim so tests can exercise malformed
+    /// input; callers that want to disable stuck detection entirely
+    /// should not call this helper.
+    async fn setup_stuck(
+        label: &str,
+        threshold: Option<&str>,
+    ) -> (
+        Arc<LifecycleManager>,
+        Arc<SessionManager>,
+        Arc<MockAgent>,
+        PathBuf,
+    ) {
+        let base = unique_temp_dir(label);
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent = Arc::new(MockAgent::new(ActivityState::Idle));
+
+        let lifecycle =
+            LifecycleManager::new(sessions.clone(), runtime, agent.clone() as Arc<dyn Agent>);
+
+        let mut cfg = ReactionConfig::new(ReactionAction::Notify);
+        cfg.message = Some("stuck!".into());
+        cfg.threshold = threshold.map(String::from);
+        let mut map = std::collections::HashMap::new();
+        map.insert("agent-stuck".into(), cfg);
+        let engine_runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let engine = Arc::new(ReactionEngine::new(
+            map,
+            engine_runtime,
+            lifecycle.events_sender(),
+        ));
+        let lifecycle = Arc::new(lifecycle.with_reaction_engine(engine));
+        (lifecycle, sessions, agent, base)
+    }
+
+    /// Build a lifecycle without an `agent-stuck` reaction configured
+    /// at all. Used to prove `check_stuck` is a strict no-op when no
+    /// config exists, independent of whether any other reactions are
+    /// set up.
+    async fn setup_stuck_no_config(
+        label: &str,
+    ) -> (
+        Arc<LifecycleManager>,
+        Arc<SessionManager>,
+        Arc<MockAgent>,
+        PathBuf,
+    ) {
+        let base = unique_temp_dir(label);
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent = Arc::new(MockAgent::new(ActivityState::Idle));
+
+        let lifecycle =
+            LifecycleManager::new(sessions.clone(), runtime, agent.clone() as Arc<dyn Agent>);
+
+        // Engine with an UNRELATED reaction keyed — not `agent-stuck`.
+        let mut cfg = ReactionConfig::new(ReactionAction::Notify);
+        cfg.message = Some("other".into());
+        let mut map = std::collections::HashMap::new();
+        map.insert("ci-failed".into(), cfg);
+        let engine_runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let engine = Arc::new(ReactionEngine::new(
+            map,
+            engine_runtime,
+            lifecycle.events_sender(),
+        ));
+        let lifecycle = Arc::new(lifecycle.with_reaction_engine(engine));
+        (lifecycle, sessions, agent, base)
+    }
+
+    /// Collect every event currently buffered on `rx`, draining with a
+    /// short timeout so the test doesn't hang on an empty channel.
+    async fn drain_events(
+        rx: &mut broadcast::Receiver<OrchestratorEvent>,
+    ) -> Vec<OrchestratorEvent> {
+        let mut out = Vec::new();
+        while let Some(e) = recv_timeout(rx).await {
+            out.push(e);
+        }
+        out
+    }
+
+    /// Rewind the idle_since entry for `session_id` by `by` so the
+    /// next `check_stuck` sees an already-elapsed threshold without a
+    /// real `tokio::time::sleep`. The helper inserts the entry if it
+    /// doesn't exist yet. Tests call this AFTER tick 1 has already
+    /// populated the map.
+    fn rewind_idle_since(lifecycle: &LifecycleManager, session_id: &SessionId, by: Duration) {
+        let mut map = lifecycle
+            .idle_since
+            .lock()
+            .expect("idle_since mutex poisoned");
+        let rewound = Instant::now()
+            .checked_sub(by)
+            .expect("test clock rewind underflowed Instant");
+        map.insert(session_id.clone(), rewound);
+    }
+
+    #[tokio::test]
+    async fn stuck_detection_fires_on_working_after_threshold() {
+        // Session starts in Working, MockAgent reports Idle. After the
+        // threshold has elapsed we expect a transition to Stuck and
+        // the agent-stuck reaction to fire on the shared event bus.
+        //
+        // Rather than sleep, we rewind `idle_since` to simulate a
+        // long idle streak — deterministic and fast.
+        let (lifecycle, sessions, _agent, base) =
+            setup_stuck("stuck_from_working", Some("1s")).await;
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::Working;
+        sessions.save(&s).await.unwrap();
+
+        let mut seen = HashSet::new();
+        // First tick: activity flips to Idle, idle_since is set, but
+        // elapsed is microseconds — no stuck transition yet.
+        lifecycle.tick(&mut seen).await.unwrap();
+        let early = drain_events(&mut rx).await;
+        assert!(
+            !early.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "stuck transition must not fire before threshold elapses: {early:?}"
+        );
+
+        // Simulate the session having been idle for 2s (> 1s threshold).
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let later = drain_events(&mut rx).await;
+        assert!(
+            later.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    from: SessionStatus::Working,
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "expected Working → Stuck transition after threshold; got {later:?}"
+        );
+        assert!(
+            later
+                .iter()
+                .any(|e| matches!(e, OrchestratorEvent::ReactionTriggered { .. })),
+            "expected ReactionTriggered for agent-stuck; got {later:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn stuck_detection_fires_on_pr_open_after_threshold() {
+        // PrOpen is stuck-eligible — an agent that opened a PR and
+        // then went silent is just as stuck as one stuck in Working.
+        let (lifecycle, sessions, _agent, base) =
+            setup_stuck("stuck_from_pr_open", Some("1s")).await;
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s2", "demo");
+        s.status = SessionStatus::PrOpen;
+        sessions.save(&s).await.unwrap();
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    from: SessionStatus::PrOpen,
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "expected PrOpen → Stuck after threshold; got {events:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn stuck_recovers_to_working_on_active_activity() {
+        // After parking in Stuck, flipping the agent back to Active
+        // should flip status back to Working on the next tick via
+        // the Spawning|Stuck → Working branch in poll_one step 4.
+        let (lifecycle, sessions, agent, base) = setup_stuck("stuck_recovery", Some("1s")).await;
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s3", "demo");
+        s.status = SessionStatus::Working;
+        sessions.save(&s).await.unwrap();
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        // Sanity check: session is now parked in Stuck.
+        let reloaded = sessions.list().await.unwrap();
+        assert_eq!(reloaded[0].status, SessionStatus::Stuck);
+
+        // Drain events so we can isolate what the recovery tick emits.
+        let _ = drain_events(&mut rx).await;
+
+        // Flip activity → Active, tick once.
+        agent.set(ActivityState::Active);
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    from: SessionStatus::Stuck,
+                    to: SessionStatus::Working,
+                    ..
+                }
+            )),
+            "expected Stuck → Working recovery; got {events:?}"
+        );
+
+        // After recovery the idle_since entry should be gone — Active
+        // is not an idle state, so update_idle_since removed it on
+        // this tick. The next idle streak will restart the clock.
+        let map = lifecycle
+            .idle_since
+            .lock()
+            .expect("idle_since mutex poisoned");
+        assert!(
+            !map.contains_key(&s.id),
+            "idle_since should be cleared after recovery"
+        );
+        drop(map);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn stuck_not_triggered_without_agent_stuck_config() {
+        // No `agent-stuck` key in the engine → check_stuck is a no-op
+        // even after the session has been Idle for a long time.
+        let (lifecycle, sessions, _agent, base) = setup_stuck_no_config("stuck_no_config").await;
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s4", "demo");
+        s.status = SessionStatus::Working;
+        sessions.save(&s).await.unwrap();
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "no agent-stuck config means no stuck transition; got {events:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn stuck_not_triggered_before_threshold_elapses() {
+        // Threshold is deliberately long — repeated ticks within the
+        // window should never flip to Stuck because idle_since has
+        // only aged by microseconds between ticks.
+        let (lifecycle, sessions, _agent, base) =
+            setup_stuck("stuck_before_threshold", Some("10s")).await;
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s5", "demo");
+        s.status = SessionStatus::Working;
+        sessions.save(&s).await.unwrap();
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+        lifecycle.tick(&mut seen).await.unwrap();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "stuck transition must not fire before 10s threshold; got {events:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn merge_failed_does_not_become_stuck() {
+        // Phase G parking state is NOT stuck-eligible: a session
+        // parked in MergeFailed is waiting for the retry loop, not
+        // stuck on the agent. Even with idle activity and an
+        // elapsed threshold, check_stuck must stay a no-op.
+        let (lifecycle, sessions, _agent, base) =
+            setup_stuck("merge_failed_no_stuck", Some("1s")).await;
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s6", "demo");
+        s.status = SessionStatus::MergeFailed;
+        sessions.save(&s).await.unwrap();
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "MergeFailed must not be stuck-eligible; got {events:?}"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/crates/ao-core/src/reaction_engine.rs
+++ b/crates/ao-core/src/reaction_engine.rs
@@ -43,12 +43,22 @@
 //!   was ready when the lifecycle tick saw it, but CI just flipped red)
 //!   aborts without merging, and the next tick can retry.
 //!
+//! ## Phase H additions
+//!
+//! - Duration-based `escalate_after` is now honoured. `TrackerState`
+//!   gained a `first_triggered_at: Instant` set on first dispatch; the
+//!   duration gate compares `entry.first_triggered_at.elapsed()` against
+//!   `parse_duration(escalate_after)` and flips `should_escalate` when
+//!   over. Parsing uses the same `^\d+(s|m|h)$` contract as TS
+//!   `parseDuration`, returning `None` on garbage.
+//! - Garbage duration strings no longer panic and do not cause escalate
+//!   to fire. They trigger a one-shot `tracing::warn!` per
+//!   `(reaction_key, field)` pair via `warned_parse_failures` — a
+//!   process-local `HashSet` that bounds log noise to a single warn per
+//!   misconfigured field.
+//!
 //! ## What the engine still does NOT do
 //!
-//! - Duration-based escalation (`escalate-after: 10m`) is recognised but
-//!   not honoured: the engine logs-once and only escalates on attempt
-//!   counts. Adding a wall-clock parser belongs next to the duration use
-//!   in the future `agent-stuck` reaction.
 //! - Notifier plugins. `Notify` just emits `ReactionTriggered` on the
 //!   broadcast channel — CLI subscribers turn that into `println!`. A
 //!   proper notifier trait (Slack, desktop, …) is post-Slice-2.
@@ -61,8 +71,9 @@ use crate::{
     types::{Session, SessionId, SessionStatus},
 };
 use std::{
-    collections::HashMap,
+    collections::{HashMap, HashSet},
     sync::{Arc, Mutex},
+    time::{Duration, Instant},
 };
 use tokio::sync::broadcast;
 
@@ -73,29 +84,85 @@ struct TrackerState {
     /// Incremented *before* the action runs, so a dispatch that errored
     /// still counts.
     attempts: u32,
+    /// Monotonic `Instant` at which this `(session, reaction_key)` pair
+    /// was first observed. Populated on the `or_insert_with` path during
+    /// the first dispatch and **never updated** on subsequent dispatches
+    /// — that's deliberate, so duration-based escalation (`escalate_after:
+    /// 10m`) measures wall-clock time since the first trigger of a given
+    /// episode, not since the last attempt.
+    ///
+    /// Cleared-and-recreated semantics: `clear_tracker` removes the whole
+    /// entry, so if a session leaves and re-enters a triggering status
+    /// (e.g. `ci-failed` → `working` → `ci-failed`) the next dispatch
+    /// gets a fresh `first_triggered_at`. That's correct: a second
+    /// episode shouldn't inherit the first episode's elapsed clock.
+    first_triggered_at: Instant,
 }
 
 /// Map a `SessionStatus` to the reaction key that should fire on entry.
 ///
 /// Returns `None` for statuses that don't map to a reaction today. The
-/// three Phase D reactions are `ci-failed`, `changes-requested`,
-/// `approved-and-green`; everything else returns `None` so the engine
-/// is a no-op on unrelated transitions.
+/// four currently-wired reactions are `ci-failed`, `changes-requested`,
+/// `approved-and-green`, and `agent-stuck` (Phase H); everything else
+/// returns `None` so the engine is a no-op on unrelated transitions.
 ///
 /// Public so `LifecycleManager` can peek at the mapping without having
-/// to duplicate it — and so Phase E tests can assert additional mappings
-/// (e.g. `Stuck` → `"agent-stuck"`) by extending this one spot.
+/// to duplicate it — both on entry (what reaction to fire) and on exit
+/// (which tracker to clear via `clear_tracker_on_transition`).
+///
+/// Phase H note: `Stuck` is the first status whose entry is driven by
+/// an auxiliary in-memory clock (`LifecycleManager::idle_since`) rather
+/// than by `derive_scm_status`'s pure state-machine ladder. The mapping
+/// is still a straightforward one-liner here; the "when does Stuck
+/// become reachable" logic lives in `LifecycleManager::check_stuck`.
 pub const fn status_to_reaction_key(status: SessionStatus) -> Option<&'static str> {
     match status {
         SessionStatus::CiFailed => Some("ci-failed"),
         SessionStatus::ChangesRequested => Some("changes-requested"),
         SessionStatus::Mergeable => Some("approved-and-green"),
-        // TODO(PhaseE): add Stuck → "agent-stuck" and Errored → "agent-errored".
-        // agent-stuck needs auxiliary state (time entered Idle) that the
-        // engine doesn't track today — the pure status-to-key mapping will
-        // work, but the engine side needs a `status_entered_at` tracker.
+        SessionStatus::Stuck => Some("agent-stuck"),
         _ => None,
     }
+}
+
+/// Parse a duration string matching the TS reference's `parseDuration`:
+/// `^\d+(s|m|h)$`. Returns `None` on any other shape so callers can no-op.
+///
+/// This is the honest contract used by both the reaction engine's
+/// `escalate_after` duration form and `LifecycleManager::check_stuck`'s
+/// stuck-threshold comparison. Kept `pub(crate)` because neither caller
+/// is outside `ao-core`.
+///
+/// Accepted: `"0s"`, `"1s"`, `"10m"`, `"24h"`, etc. Zero is allowed —
+/// `threshold: "0s"` is a legitimate test fixture, matching the
+/// requirements doc's "no clamping, no floor" decision.
+///
+/// Rejected (return `None`): compound forms like `"1m30s"`, non-digit
+/// prefixes like `"fast"`, missing suffix (`"10"`), empty string, and
+/// anything that would overflow `u64` seconds (`checked_mul`).
+///
+/// Mirrors `packages/core/src/lifecycle-manager.ts` `parseDuration`
+/// which returns `0` on garbage — the Rust `None` short-circuits at
+/// the callsite the same way.
+pub(crate) fn parse_duration(s: &str) -> Option<Duration> {
+    if s.is_empty() {
+        return None;
+    }
+    let bytes = s.as_bytes();
+    let suffix = *bytes.last()?;
+    let multiplier_secs: u64 = match suffix {
+        b's' => 1,
+        b'm' => 60,
+        b'h' => 3600,
+        _ => return None,
+    };
+    let digits = &s[..s.len() - 1];
+    if digits.is_empty() || !digits.bytes().all(|b| b.is_ascii_digit()) {
+        return None;
+    }
+    let n: u64 = digits.parse().ok()?;
+    let total_secs = n.checked_mul(multiplier_secs)?;
+    Some(Duration::from_secs(total_secs))
 }
 
 /// The reaction dispatcher. Holds config, attempt trackers, and the
@@ -117,6 +184,14 @@ pub struct ReactionEngine {
     /// Per-(session, reaction) attempt state. `Mutex` (not async) because
     /// the critical sections are tiny map mutations — no awaiting.
     trackers: Mutex<HashMap<(SessionId, String), TrackerState>>,
+    /// Process-local set of `"{reaction_key}.{field}"` keys that have
+    /// already emitted a one-shot `tracing::warn!` for a malformed
+    /// duration string (`threshold` or `escalate_after`). Subsequent
+    /// parse failures for the same key are silent. Reset on
+    /// `ao-rs watch` restart — same non-persistence trade-off as
+    /// `trackers` and `idle_since`. Size bounded by the number of
+    /// reaction keys in the user's config (≤ 10 in practice).
+    warned_parse_failures: Mutex<HashSet<String>>,
     /// Optional Phase F SCM plugin. When set, `dispatch_auto_merge`
     /// actually calls `Scm::merge` (after re-verifying readiness with a
     /// fresh `mergeability` probe). When unset, `auto-merge` degrades to
@@ -138,6 +213,7 @@ impl ReactionEngine {
             runtime,
             events_tx,
             trackers: Mutex::new(HashMap::new()),
+            warned_parse_failures: Mutex::new(HashSet::new()),
             scm: None,
         }
     }
@@ -151,6 +227,20 @@ impl ReactionEngine {
     pub fn with_scm(mut self, scm: Arc<dyn Scm>) -> Self {
         self.scm = Some(scm);
         self
+    }
+
+    /// Read-only accessor so the lifecycle layer can peek at a single
+    /// reaction config without taking ownership of the whole map.
+    ///
+    /// Phase H uses this in `LifecycleManager::check_stuck` to read the
+    /// `agent-stuck` threshold; it returns `None` when the user has not
+    /// configured that reaction, which `check_stuck` treats as "stuck
+    /// detection is disabled for this session" and silently skips.
+    ///
+    /// Deliberately `pub(crate)` — this is an internal contract with
+    /// the lifecycle manager, not a public extension point.
+    pub(crate) fn reaction_config(&self, reaction_key: &str) -> Option<&ReactionConfig> {
+        self.config.get(reaction_key)
     }
 
     /// Fire the reaction configured for `reaction_key` against `session`,
@@ -195,6 +285,23 @@ impl ReactionEngine {
             return Ok(None);
         }
 
+        // Resolve the duration-form `escalate_after` gate BEFORE the
+        // tracker lock. `parse_duration` is pure and `warn_once_parse_failure`
+        // takes its own independent lock — parsing outside avoids nested
+        // locking. A `None` result here either means "no duration gate
+        // configured" or "garbage string, already warned" — in both cases
+        // the duration gate contributes nothing to escalation this dispatch.
+        let duration_gate: Option<Duration> = match cfg.escalate_after {
+            Some(EscalateAfter::Duration(ref s)) => match parse_duration(s) {
+                Some(d) => Some(d),
+                None => {
+                    self.warn_once_parse_failure(reaction_key, "escalate_after", s);
+                    None
+                }
+            },
+            _ => None,
+        };
+
         // Bump attempts under the lock and decide escalation inside the
         // same critical section so two concurrent dispatches can't both
         // escape the retry budget.
@@ -205,30 +312,35 @@ impl ReactionEngine {
                 .expect("reaction tracker mutex poisoned");
             let entry = trackers
                 .entry((session.id.clone(), reaction_key.to_string()))
-                .or_insert(TrackerState { attempts: 0 });
+                .or_insert_with(|| TrackerState {
+                    attempts: 0,
+                    first_triggered_at: Instant::now(),
+                });
             entry.attempts += 1;
             let attempts = entry.attempts;
 
-            // TS semantics: `retries` is the MAX number of attempts the
-            // engine will make before escalating. Unset = infinite.
+            // Gate 1: `retries` budget. TS semantics — this is the MAX
+            // number of attempts the engine will make before escalating.
+            // Unset = infinite.
             let max_attempts = cfg.retries;
             let mut escalate = max_attempts.is_some_and(|n| attempts > n);
 
-            // `escalate-after: N` (Attempts form) is an independent gate
-            // with the same `>` comparison. Duration form is a no-op in
-            // Phase D — see module comment.
+            // Gate 2: `escalate_after`. Either the attempts form (`N`)
+            // with the same `>` comparison as retries, or the duration
+            // form honoured via `first_triggered_at.elapsed()`. Only
+            // one variant fires per dispatch because `escalate_after`
+            // is a single `Option<enum>`.
             if let Some(EscalateAfter::Attempts(n)) = cfg.escalate_after {
                 if attempts > n {
                     escalate = true;
                 }
-            } else if matches!(cfg.escalate_after, Some(EscalateAfter::Duration(_))) {
-                // Duration-based escalation is Phase E — see module doc.
-                // Logged at `trace!` to avoid spamming a watcher running
-                // with `RUST_LOG=debug` once per poll tick.
-                tracing::trace!(
-                    reaction = reaction_key,
-                    "duration-based escalate-after not implemented; ignoring"
-                );
+            } else if let Some(d) = duration_gate {
+                // `>=` would fire on `0s` with zero elapsed too, but
+                // that's not a sensible config and TS uses strict `>`.
+                // We match TS: `elapsed > d` fires, `elapsed == d` doesn't.
+                if entry.first_triggered_at.elapsed() > d {
+                    escalate = true;
+                }
             }
 
             (attempts, escalate)
@@ -307,6 +419,52 @@ impl ReactionEngine {
             .get(&(session_id.clone(), reaction_key.to_string()))
             .map(|t| t.attempts)
             .unwrap_or(0)
+    }
+
+    /// Return the `Instant` at which this `(session, reaction_key)` pair
+    /// was first triggered, or `None` if no tracker exists yet. Used by
+    /// tests to assert the timestamp survives multiple dispatches — in
+    /// production, `dispatch` reads the field inside the mutex-held
+    /// critical section directly, so no external accessor is needed
+    /// outside test code.
+    #[cfg(test)]
+    fn first_triggered_at(&self, session_id: &SessionId, reaction_key: &str) -> Option<Instant> {
+        self.trackers
+            .lock()
+            .expect("reaction tracker mutex poisoned")
+            .get(&(session_id.clone(), reaction_key.to_string()))
+            .map(|t| t.first_triggered_at)
+    }
+
+    /// Emit a `tracing::warn!` exactly once per `(reaction_key, field)`
+    /// pair for a duration-parse failure, then remember we've warned so
+    /// subsequent parse failures for the same pair are silent.
+    ///
+    /// Used by two call sites:
+    ///
+    /// - `dispatch` for malformed `escalate_after` strings.
+    /// - `LifecycleManager::check_stuck` (via the engine's config
+    ///   accessor) for malformed `threshold` strings on the
+    ///   `agent-stuck` reaction.
+    ///
+    /// See Design Decision 9 in
+    /// `docs/ai/design/feature-agent-stuck-detection.md` and the
+    /// warn-once observability note in the non-functional requirements
+    /// section of the same doc.
+    pub(crate) fn warn_once_parse_failure(&self, reaction_key: &str, field: &str, raw: &str) {
+        let key = format!("{reaction_key}.{field}");
+        let mut warned = self
+            .warned_parse_failures
+            .lock()
+            .expect("reaction warned_parse_failures mutex poisoned");
+        if warned.insert(key) {
+            tracing::warn!(
+                reaction = reaction_key,
+                field = field,
+                value = raw,
+                "ignoring unparseable duration string; expected `^\\d+(s|m|h)$`"
+            );
+        }
     }
 
     // ---------- action implementations ---------- //
@@ -750,7 +908,7 @@ mod tests {
     // ---------- Tests ---------- //
 
     #[test]
-    fn status_map_covers_phase_d_reactions() {
+    fn status_map_covers_reactions_through_phase_h() {
         assert_eq!(
             status_to_reaction_key(SessionStatus::CiFailed),
             Some("ci-failed")
@@ -763,8 +921,181 @@ mod tests {
             status_to_reaction_key(SessionStatus::Mergeable),
             Some("approved-and-green")
         );
+        assert_eq!(
+            status_to_reaction_key(SessionStatus::Stuck),
+            Some("agent-stuck")
+        );
+        // Negative cases — statuses that deliberately don't map to a
+        // reaction today. If any of these ever gain a reaction, update
+        // this test alongside the match arm above so the mapping stays
+        // honest.
         assert_eq!(status_to_reaction_key(SessionStatus::Working), None);
         assert_eq!(status_to_reaction_key(SessionStatus::Approved), None);
+        assert_eq!(status_to_reaction_key(SessionStatus::NeedsInput), None);
+        assert_eq!(status_to_reaction_key(SessionStatus::MergeFailed), None);
+        assert_eq!(status_to_reaction_key(SessionStatus::Errored), None);
+    }
+
+    // ---------- Phase H: parse_duration ---------- //
+
+    #[test]
+    fn parse_duration_accepts_seconds() {
+        assert_eq!(parse_duration("1s"), Some(Duration::from_secs(1)));
+        assert_eq!(parse_duration("10s"), Some(Duration::from_secs(10)));
+        assert_eq!(parse_duration("300s"), Some(Duration::from_secs(300)));
+    }
+
+    #[test]
+    fn parse_duration_accepts_minutes() {
+        assert_eq!(parse_duration("1m"), Some(Duration::from_secs(60)));
+        assert_eq!(parse_duration("10m"), Some(Duration::from_secs(600)));
+    }
+
+    #[test]
+    fn parse_duration_accepts_hours() {
+        assert_eq!(parse_duration("1h"), Some(Duration::from_secs(3600)));
+        assert_eq!(parse_duration("24h"), Some(Duration::from_secs(24 * 3600)));
+    }
+
+    #[test]
+    fn parse_duration_accepts_zero() {
+        // Matches the "no clamping, no floor" decision in the requirements
+        // doc — zero is a legitimate test-fixture value (fires on the first
+        // idle tick the session observes).
+        assert_eq!(parse_duration("0s"), Some(Duration::ZERO));
+        assert_eq!(parse_duration("0m"), Some(Duration::ZERO));
+        assert_eq!(parse_duration("0h"), Some(Duration::ZERO));
+    }
+
+    #[test]
+    fn parse_duration_rejects_missing_suffix() {
+        assert_eq!(parse_duration("10"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_empty() {
+        assert_eq!(parse_duration(""), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_non_numeric() {
+        assert_eq!(parse_duration("fast"), None);
+        assert_eq!(parse_duration("ten seconds"), None);
+        assert_eq!(parse_duration("abc"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_compound_form() {
+        // TS `parseDuration` doesn't accept `1m30s` — neither do we.
+        // Matches the regex `^\d+(s|m|h)$` exactly.
+        assert_eq!(parse_duration("1m30s"), None);
+        assert_eq!(parse_duration("1h30m"), None);
+        assert_eq!(parse_duration("2d"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_negative_and_decimals() {
+        assert_eq!(parse_duration("-5m"), None);
+        assert_eq!(parse_duration("1.5h"), None);
+        assert_eq!(parse_duration("0.5s"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_suffix_only() {
+        assert_eq!(parse_duration("s"), None);
+        assert_eq!(parse_duration("m"), None);
+        assert_eq!(parse_duration("h"), None);
+    }
+
+    #[test]
+    fn parse_duration_rejects_overflow() {
+        // `u64::MAX` seconds parsed fine, but multiplying the digits of
+        // an unbounded hours string must short-circuit to None rather
+        // than panic or wrap.
+        assert_eq!(parse_duration("99999999999999999999h"), None);
+    }
+
+    #[tokio::test]
+    async fn tracker_first_triggered_at_persists_across_dispatches() {
+        // Invariant for Task 1.2: the first dispatch populates
+        // `first_triggered_at`; subsequent dispatches bump `attempts`
+        // but DO NOT reset the timestamp. This is what duration-based
+        // escalation will rely on (Task 2.1) — escalate_after: 10m
+        // must measure from the first trigger, not from the last
+        // attempt.
+        let mut config = ReactionConfig::new(ReactionAction::Notify);
+        config.message = Some("hi".into());
+        let mut map = HashMap::new();
+        map.insert("ci-failed".into(), config);
+
+        let (engine, _runtime, _rx) = build(map);
+        let session = fake_session("s1");
+
+        // Never-triggered: attempts = 0, no tracker entry.
+        assert_eq!(engine.attempts(&session.id, "ci-failed"), 0);
+        assert!(engine
+            .first_triggered_at(&session.id, "ci-failed")
+            .is_none());
+
+        // First dispatch populates both fields.
+        engine.dispatch(&session, "ci-failed").await.unwrap();
+        assert_eq!(engine.attempts(&session.id, "ci-failed"), 1);
+        let first = engine
+            .first_triggered_at(&session.id, "ci-failed")
+            .expect("first dispatch must populate first_triggered_at");
+
+        // Tiny sleep so a resetting bug would be observable — the
+        // second dispatch's `Instant::now()` is guaranteed later than
+        // `first`.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        // Second dispatch increments attempts; timestamp unchanged.
+        engine.dispatch(&session, "ci-failed").await.unwrap();
+        assert_eq!(engine.attempts(&session.id, "ci-failed"), 2);
+        assert_eq!(
+            engine.first_triggered_at(&session.id, "ci-failed"),
+            Some(first),
+            "first_triggered_at must survive subsequent dispatches"
+        );
+    }
+
+    #[tokio::test]
+    async fn tracker_first_triggered_at_resets_after_clear() {
+        // Clearing the tracker (on status change away from the
+        // triggering status) drops the whole entry, so the next
+        // dispatch gets a fresh `first_triggered_at`. Protects the
+        // "second episode starts a fresh clock" property the doc
+        // comment promises.
+        let mut config = ReactionConfig::new(ReactionAction::Notify);
+        config.message = Some("hi".into());
+        let mut map = HashMap::new();
+        map.insert("ci-failed".into(), config);
+
+        let (engine, _runtime, _rx) = build(map);
+        let session = fake_session("s1");
+
+        engine.dispatch(&session, "ci-failed").await.unwrap();
+        let first = engine
+            .first_triggered_at(&session.id, "ci-failed")
+            .expect("populated");
+
+        // Simulate the lifecycle's "left the triggering status" hook.
+        engine.clear_tracker(&session.id, "ci-failed");
+        assert_eq!(engine.attempts(&session.id, "ci-failed"), 0);
+        assert!(engine
+            .first_triggered_at(&session.id, "ci-failed")
+            .is_none());
+
+        tokio::time::sleep(Duration::from_millis(5)).await;
+
+        engine.dispatch(&session, "ci-failed").await.unwrap();
+        let second = engine
+            .first_triggered_at(&session.id, "ci-failed")
+            .expect("repopulated");
+        assert!(
+            second > first,
+            "second episode must start a fresh first_triggered_at"
+        );
     }
 
     #[tokio::test]
@@ -1338,9 +1669,13 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn escalate_after_duration_is_ignored_in_phase_d() {
-        // Duration form is a no-op in Phase D. This test locks in that
-        // contract so Phase E has a clear "before" baseline.
+    async fn escalate_after_duration_does_not_fire_before_elapsed() {
+        // Phase H contract: duration gate is now honoured, but 5 rapid
+        // back-to-back dispatches with a `10m` threshold are nowhere
+        // near elapsed, so no escalation fires — the retries path is
+        // unset, and the duration gate compares against `first_triggered_at
+        // + 10m`, which is still in the future. Exercises the happy
+        // "gate configured, not yet tripped" path.
         let mut config = ReactionConfig::new(ReactionAction::SendToAgent);
         config.message = Some("fix".into());
         config.escalate_after = Some(EscalateAfter::Duration("10m".into()));
@@ -1350,8 +1685,6 @@ mod tests {
         let (engine, runtime, _rx) = build(map);
         let session = fake_session("s1");
 
-        // Five attempts all still run the configured action — no escalation
-        // because Duration escalate-after is not honoured yet.
         for _ in 0..5 {
             let r = engine
                 .dispatch(&session, "ci-failed")
@@ -1361,6 +1694,137 @@ mod tests {
             assert!(!r.escalated);
         }
         assert_eq!(runtime.sends().len(), 5);
+    }
+
+    #[tokio::test]
+    async fn escalate_after_duration_fires_once_elapsed_exceeds_threshold() {
+        // Phase H: duration-based escalation is real. We rewind
+        // `first_triggered_at` by more than the configured threshold
+        // instead of sleeping — the logic under test is a pure
+        // comparison against `elapsed()`, and rewinding exercises the
+        // same code path far faster than waiting.
+        let mut config = ReactionConfig::new(ReactionAction::Notify);
+        config.message = Some("stuck".into());
+        config.retries = None; // no attempts gate — only duration gate
+        config.escalate_after = Some(EscalateAfter::Duration("1s".into()));
+        let mut map = HashMap::new();
+        map.insert("agent-stuck".into(), config);
+
+        let (engine, _runtime, mut rx) = build(map);
+        let mut session = fake_session("s1");
+        session.status = SessionStatus::Working;
+
+        // First dispatch: tracker created, first_triggered_at = now,
+        // elapsed ≈ 0, duration gate NOT tripped.
+        let first = engine
+            .dispatch(&session, "agent-stuck")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!first.escalated);
+
+        // Rewind so elapsed() > 1s on the next read. We access the
+        // private tracker map directly because this test lives inside
+        // the same module.
+        {
+            let mut trackers = engine.trackers.lock().unwrap();
+            let key = (session.id.clone(), "agent-stuck".to_string());
+            let entry = trackers.get_mut(&key).expect("tracker populated");
+            entry.first_triggered_at = Instant::now()
+                .checked_sub(Duration::from_secs(2))
+                .expect("monotonic clock has been running >2s");
+        }
+
+        // Second dispatch: elapsed ≈ 2s > threshold 1s → escalate.
+        let second = engine
+            .dispatch(&session, "agent-stuck")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(second.escalated, "duration gate should have fired");
+        assert_eq!(second.action, ReactionAction::Notify);
+
+        // Both a ReactionEscalated and a ReactionTriggered(Notify) are
+        // emitted on escalation — matches the attempts-form path.
+        let events = drain(&mut rx);
+        assert!(
+            events
+                .iter()
+                .any(|e| matches!(e, OrchestratorEvent::ReactionEscalated { .. })),
+            "expected ReactionEscalated, got {events:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn escalate_after_duration_with_garbage_string_logs_once_and_retries_gate_still_fires() {
+        // A malformed `escalate_after` string must not panic or flip
+        // `escalate = true`. The retries gate is independent and must
+        // still fire after the configured number of attempts.
+        // `warned_parse_failures` must record the key exactly once.
+        let mut config = ReactionConfig::new(ReactionAction::Notify);
+        config.message = Some("stuck".into());
+        config.retries = Some(2);
+        config.escalate_after = Some(EscalateAfter::Duration("ten minutes".into()));
+        let mut map = HashMap::new();
+        map.insert("agent-stuck".into(), config);
+
+        let (engine, _runtime, _rx) = build(map);
+        let mut session = fake_session("s1");
+        session.status = SessionStatus::Working;
+
+        // 3 dispatches: attempts 1, 2 no escalate; attempt 3 > retries=2 escalates.
+        let r1 = engine
+            .dispatch(&session, "agent-stuck")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!r1.escalated);
+        let r2 = engine
+            .dispatch(&session, "agent-stuck")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(!r2.escalated);
+        let r3 = engine
+            .dispatch(&session, "agent-stuck")
+            .await
+            .unwrap()
+            .unwrap();
+        assert!(
+            r3.escalated,
+            "retries gate must still fire even when escalate_after is garbage"
+        );
+
+        // Warn-once set should contain the key exactly once (three
+        // dispatches, but only the first parse failure emits a warn).
+        let warned = engine.warned_parse_failures.lock().unwrap();
+        assert!(warned.contains("agent-stuck.escalate_after"));
+        assert_eq!(
+            warned.len(),
+            1,
+            "only one warn should be recorded across 3 dispatches"
+        );
+    }
+
+    #[tokio::test]
+    async fn warn_once_parse_failure_is_idempotent_per_key() {
+        // Direct helper test: calling warn_once_parse_failure multiple
+        // times with the same (reaction_key, field) pair inserts once
+        // and is silently idempotent on subsequent calls. Calling with
+        // a different field inserts a second entry — the two warnings
+        // are independent so a reaction with BOTH threshold and
+        // escalate_after broken gets warned about each.
+        let (engine, _runtime, _rx) = build(HashMap::new());
+
+        engine.warn_once_parse_failure("agent-stuck", "threshold", "ten");
+        engine.warn_once_parse_failure("agent-stuck", "threshold", "eleven");
+        engine.warn_once_parse_failure("agent-stuck", "threshold", "twelve");
+        engine.warn_once_parse_failure("agent-stuck", "escalate_after", "frob");
+
+        let warned = engine.warned_parse_failures.lock().unwrap();
+        assert_eq!(warned.len(), 2);
+        assert!(warned.contains("agent-stuck.threshold"));
+        assert!(warned.contains("agent-stuck.escalate_after"));
     }
 
     #[tokio::test]

--- a/crates/ao-core/src/reactions.rs
+++ b/crates/ao-core/src/reactions.rs
@@ -100,8 +100,11 @@ pub enum EscalateAfter {
     /// Retry `send-to-agent` this many times, then escalate to `notify`.
     Attempts(u32),
     /// Wait this long after the first attempt before escalating. String
-    /// form (`"10m"`, `"1h30m"`) — parsed lazily in Phase D where the
-    /// engine interprets it.
+    /// form matching the TS regex `^\d+(s|m|h)$` — e.g. `"30s"`,
+    /// `"10m"`, `"2h"`. Compound or fractional forms (`"1h30m"`,
+    /// `"1.5m"`) are rejected. Parsed lazily by `parse_duration` on
+    /// each dispatch so a misconfigured value only logs once and does
+    /// not poison the engine.
     Duration(String),
 }
 

--- a/docs/ai/deployment/README.md
+++ b/docs/ai/deployment/README.md
@@ -1,0 +1,72 @@
+---
+phase: deployment
+title: Deployment Strategy
+description: Define deployment process, infrastructure, and release procedures
+---
+
+# Deployment Strategy
+
+## Infrastructure
+**Where will the application run?**
+
+- Hosting platform (AWS, GCP, Azure, etc.)
+- Infrastructure components (servers, databases, etc.)
+- Environment separation (dev, staging, production)
+
+## Deployment Pipeline
+**How do we deploy changes?**
+
+### Build Process
+- Build steps and commands
+- Asset compilation/optimization
+- Environment configuration
+
+### CI/CD Pipeline
+- Automated testing gates
+- Build automation
+- Deployment automation
+
+## Environment Configuration
+**What settings differ per environment?**
+
+### Development
+- Configuration details
+- Local setup
+
+### Staging
+- Configuration details
+- Testing environment
+
+### Production
+- Configuration details
+- Monitoring setup
+
+## Deployment Steps
+**What's the release process?**
+
+1. Pre-deployment checklist
+2. Deployment execution steps
+3. Post-deployment validation
+4. Rollback procedure (if needed)
+
+## Database Migrations
+**How do we handle schema changes?**
+
+- Migration strategy
+- Backup procedures
+- Rollback approach
+
+## Secrets Management
+**How do we handle sensitive data?**
+
+- Environment variables
+- Secret storage solution
+- Key rotation strategy
+
+## Rollback Plan
+**What if something goes wrong?**
+
+- Rollback triggers
+- Rollback steps
+- Communication plan
+

--- a/docs/ai/design/README.md
+++ b/docs/ai/design/README.md
@@ -1,0 +1,60 @@
+---
+phase: design
+title: System Design & Architecture
+description: Define the technical architecture, components, and data models
+---
+
+# System Design & Architecture
+
+## Architecture Overview
+**What is the high-level system structure?**
+
+- Include a mermaid diagram that captures the main components and their relationships. Example:
+  ```mermaid
+  graph TD
+    Client -->|HTTPS| API
+    API --> ServiceA
+    API --> ServiceB
+    ServiceA --> Database[(DB)]
+  ```
+- Key components and their responsibilities
+- Technology stack choices and rationale
+
+## Data Models
+**What data do we need to manage?**
+
+- Core entities and their relationships
+- Data schemas/structures
+- Data flow between components
+
+## API Design
+**How do components communicate?**
+
+- External APIs (if applicable)
+- Internal interfaces
+- Request/response formats
+- Authentication/authorization approach
+
+## Component Breakdown
+**What are the major building blocks?**
+
+- Frontend components (if applicable)
+- Backend services/modules
+- Database/storage layer
+- Third-party integrations
+
+## Design Decisions
+**Why did we choose this approach?**
+
+- Key architectural decisions and trade-offs
+- Alternatives considered
+- Patterns and principles applied
+
+## Non-Functional Requirements
+**How should the system perform?**
+
+- Performance targets
+- Scalability considerations
+- Security requirements
+- Reliability/availability needs
+

--- a/docs/ai/design/feature-agent-stuck-detection.md
+++ b/docs/ai/design/feature-agent-stuck-detection.md
@@ -1,0 +1,406 @@
+---
+phase: design
+title: agent-stuck detection — system design
+description: How idle tracking, Stuck transitions, and duration-based escalation plug into the existing lifecycle + reaction engine.
+---
+
+# Design — agent-stuck detection & reaction
+
+## Architecture Overview
+
+```mermaid
+graph TD
+    Tick["LifecycleManager::tick()"] --> PollOne["poll_one(session)"]
+    PollOne --> Alive{runtime alive?}
+    Alive -- no --> Terminate["terminate()"]
+    Alive -- yes --> Activity["detect_activity()"]
+    Activity --> ActivityPersist["persist ActivityChanged"]
+    ActivityPersist --> HappyFlip["Spawning &#8594; Working"]
+    HappyFlip --> SCM["poll_scm() &#91;Phase F&#93;"]
+    SCM --> StuckCheck["stuck_detection_step (new)"]
+
+    subgraph "new stuck step"
+      StuckCheck --> IdleSince["idle_since: HashMap&lt;SessionId, Instant&gt;"]
+      IdleSince --> IdleCheck{activity Idle/Blocked?}
+      IdleCheck -- no --> Clear["drop idle_since entry"]
+      IdleCheck -- yes --> StuckEligible{status stuck-eligible?}
+      StuckEligible -- no --> Noop["no-op"]
+      StuckEligible -- yes --> Threshold{"elapsed &gt; threshold?"}
+      Threshold -- no --> Wait["do nothing, retry next tick"]
+      Threshold -- yes --> Transition["transition(Stuck)"]
+      Transition --> ReactionKey["status_to_reaction_key(Stuck) = agent-stuck"]
+      ReactionKey --> Engine["ReactionEngine::dispatch"]
+    end
+
+    Engine --> Notify["Notify &#8594; ReactionTriggered event"]
+    Engine --> Escalate{"first_triggered_at + Duration escalate_after?"}
+    Escalate -- elapsed --> Escalated["ReactionEscalated event"]
+```
+
+Three concrete changes to existing code:
+
+1. **`LifecycleManager` gains an `idle_since` map.** `Mutex<HashMap<SessionId, Instant>>` — one entry per session currently observed in `Idle`/`Blocked` activity. Populated lazily on first idle observation, removed when activity leaves idle, cleared entirely in `terminate()` (same lifecycle as reaction trackers).
+2. **A new `poll_one` step 6**: stuck detection. Runs after `poll_scm`, only on stuck-eligible statuses, only when the `agent-stuck` reaction is configured with a usable `threshold`.
+3. **`ReactionEngine::TrackerState` gains `first_triggered_at: Instant`**, and `dispatch` actually honours `EscalateAfter::Duration`. This closes the parser TODO that Phase D deferred.
+
+**Ordering guarantee.** `check_stuck` only runs when **no prior step
+in the same tick has already transitioned the session**. Step 4
+(activity-flip) and step 5 (SCM poll) can both mutate
+`session.status`; `poll_one` snapshots the status at the top of the
+transition block and short-circuits step 6 if either of them
+changed it. This matches TS `determineStatus` returning exactly one
+status per call, and it prevents operator-visible double-fires
+like `ci-failed` and `agent-stuck` both firing on the same tick.
+Detail in Design Decision 8 below.
+
+## Data Models
+
+### New type: stuck threshold parsing
+
+No new struct needed — we parse on demand. A free function with the TS-matching regex:
+
+```rust
+// crates/ao-core/src/reaction_engine.rs
+
+/// Parse a duration string matching the TS reference's
+/// `parseDuration`: `^\d+(s|m|h)$`. Returns `None` on any other
+/// shape so callers can no-op.
+pub(crate) fn parse_duration(s: &str) -> Option<Duration> { ... }
+```
+
+- Returns `Option<Duration>`, **not** `Result`. A garbage threshold becomes a no-op, same as TS (`parseDuration` returns 0).
+- Lives in `reaction_engine.rs` as a `pub(crate)` helper — confirmed over a dedicated `duration.rs` module. Both callers (the engine's duration-escalation branch and `LifecycleManager::check_stuck` via a small `reaction_config(key)` accessor) are internal; no external consumers justify a new file yet.
+- **Parsed lazily, once per dispatch call.** Not pre-validated at `AoConfig::load` time — see Design Decision 9.
+
+### Modified type: `TrackerState`
+
+```rust
+// Before (reaction_engine.rs)
+struct TrackerState { attempts: u32 }
+
+// After
+struct TrackerState {
+    attempts: u32,
+    first_triggered_at: Instant,
+}
+```
+
+- Populated in the `or_insert_with(|| TrackerState { attempts: 0, first_triggered_at: Instant::now() })` path.
+- Read in the escalation decision alongside `attempts`.
+- `#[derive(Clone, Copy)]` stays valid — `Instant` is Copy.
+
+### New LifecycleManager field: `idle_since`
+
+```rust
+pub struct LifecycleManager {
+    // ... existing fields ...
+    idle_since: Mutex<HashMap<SessionId, Instant>>,
+}
+```
+
+- `Mutex`, not async — the critical sections are tiny map mutations with no `.await`.
+- Cleared on `terminate()`, same as reaction trackers.
+- Not persisted. Matches the requirements-doc "non-goal: persistent idle-since state".
+
+### Data on disk
+
+**No new on-disk state.** `Session::status` can already be `Stuck` (it was added in Phase B). The yaml file round-trip already works. The only lifecycle change is that `transition(session, SessionStatus::Stuck)` is now reachable from `poll_one`.
+
+## API Design
+
+No new public traits. No new CLI commands. Phase H is an internal wiring change.
+
+### Internal function additions
+
+```rust
+// crates/ao-core/src/reaction_engine.rs
+pub const fn status_to_reaction_key(status: SessionStatus) -> Option<&'static str> {
+    match status {
+        SessionStatus::CiFailed => Some("ci-failed"),
+        SessionStatus::ChangesRequested => Some("changes-requested"),
+        SessionStatus::Mergeable => Some("approved-and-green"),
+        SessionStatus::Stuck => Some("agent-stuck"),   // NEW
+        _ => None,
+    }
+}
+
+// crates/ao-core/src/lifecycle.rs
+impl LifecycleManager {
+    /// Observed-stuck detection. Called from `poll_one` after SCM polling.
+    /// Only transitions the session if:
+    /// 1. Activity is `Idle` or `Blocked`
+    /// 2. Current status is stuck-eligible (see `is_stuck_eligible`)
+    /// 3. The `agent-stuck` reaction has a parseable `threshold`
+    /// 4. The session has been idle for longer than `threshold`
+    async fn check_stuck(&self, session: &mut Session) -> Result<()> { ... }
+
+    /// Update/clear the idle_since entry based on current activity.
+    /// Called unconditionally from `poll_one` after activity persist —
+    /// even when stuck detection will be skipped later. Keeps the map
+    /// honest regardless of config state.
+    fn update_idle_since(&self, session_id: &SessionId, activity: ActivityState) { ... }
+}
+
+/// Does this status qualify for stuck detection? Excludes Spawning
+/// (too early), NeedsInput (already a known-blocked state), Stuck
+/// itself, terminal states, and MergeFailed (the Phase G parking
+/// state — handled by its own retry loop).
+const fn is_stuck_eligible(status: SessionStatus) -> bool { ... }
+```
+
+### Config file surface
+
+No new config keys. Users already write:
+
+```yaml
+reactions:
+  agent-stuck:
+    auto: true
+    action: notify
+    threshold: 10m            # <-- already parsed as String in Phase A
+    priority: warning
+    escalate_after: 30m       # <-- EscalateAfter::Duration, finally honoured
+```
+
+Phase A's `ReactionConfig::threshold: Option<String>` is exactly what we need. Zero schema churn.
+
+## Component Breakdown
+
+| Piece | File | Change type |
+|---|---|---|
+| `status_to_reaction_key(Stuck) = "agent-stuck"` | `crates/ao-core/src/reaction_engine.rs` | Add arm, delete TODO |
+| `parse_duration` helper | `crates/ao-core/src/reaction_engine.rs` (or `duration.rs`) | New |
+| `TrackerState.first_triggered_at` | `crates/ao-core/src/reaction_engine.rs` | Add field |
+| Duration-based escalation | `crates/ao-core/src/reaction_engine.rs::dispatch` | Replace `tracing::trace!` no-op with real check |
+| `LifecycleManager::idle_since` field | `crates/ao-core/src/lifecycle.rs` | Add field + init |
+| `update_idle_since` + `check_stuck` methods | `crates/ao-core/src/lifecycle.rs` | New |
+| `poll_one` step 6 (stuck check) | `crates/ao-core/src/lifecycle.rs::poll_one` | Add step |
+| `terminate()` clears `idle_since` | `crates/ao-core/src/lifecycle.rs::terminate` | Extend |
+| `Stuck → Working` exit transition | `crates/ao-core/src/lifecycle.rs::poll_one` step 4 | Extend existing branch |
+| State-machine doc | `docs/state-machine.md` | Add Phase H section |
+| Reactions doc | `docs/reactions.md` | Add Phase H section, mark `agent-stuck` done |
+| Architecture open-question | `docs/architecture.md` | Move `Duration-based escalate-after` from "Open" to "Answered" |
+
+**Files added:** 0. `parse_duration` lives in `reaction_engine.rs` as `pub(crate)` — confirmed.
+
+**No `ao-cli` changes.** The existing event printer at `crates/ao-cli/src/main.rs:700-750` already renders `status_changed`, `reaction_fired`, and `reaction_escalated` cleanly for any `SessionStatus` / `ReactionAction` variant, including the `Stuck` status and the duration-based escalation path. Phase H ships zero new CLI output shapes.
+
+## Design Decisions
+
+### 1. Track `idle_since` in `LifecycleManager`, not on `Session` or via trait extension
+
+Three alternatives were considered:
+
+| Option | Pros | Cons | Verdict |
+|---|---|---|---|
+| **In-memory map on `LifecycleManager`** | Zero trait churn, zero schema churn, matches reaction-tracker pattern, resets on `ao-rs watch` restart (acceptable per requirements) | Not persistent across restarts | **Chosen** |
+| Extend `Agent::detect_activity` to return `(ActivityState, Option<Instant>)` | Lets the agent plugin supply a more accurate timestamp (TS does this via JSONL) | Invasive trait change, every plugin ripples, JSONL introspection is out of scope | Rejected |
+| Add `Session::idle_since: Option<DateTime>` persisted to yaml | Survives restarts | Churns the on-disk schema, adds a field the user doesn't need to see, couples status to bookkeeping | Rejected |
+
+The in-memory approach matches how `ReactionEngine::trackers` already works. Both reset on `ao-rs watch` restart, and in both cases the reset is acceptable because the next observation will re-establish state on the next tick.
+
+### 2. Use `Instant`, not `SystemTime`
+
+`Instant` is monotonic and immune to wall-clock skew (NTP adjustments, the user's laptop sleeping and waking). `SystemTime` would risk reporting a negative elapsed duration. The only reason to prefer `SystemTime` would be serialization — and we don't serialize `idle_since`.
+
+### 3. `ActivityState::Blocked` counts as "idle-ish" for stuck purposes
+
+Reason: matches TS (`state === "idle" || state === "blocked"` triggers `detectedIdleTimestamp`). Semantically, `Blocked` is "agent hit an error or got stuck" — exactly the condition we want the stuck reaction to fire on. Rejecting `Blocked` would silently exclude the primary case the reaction is for.
+
+### 4. Stuck-eligible status set
+
+```rust
+const fn is_stuck_eligible(status: SessionStatus) -> bool {
+    matches!(
+        status,
+        SessionStatus::Working
+            | SessionStatus::PrOpen
+            | SessionStatus::CiFailed
+            | SessionStatus::ReviewPending
+            | SessionStatus::ChangesRequested
+            | SessionStatus::Approved
+            | SessionStatus::Mergeable
+    )
+}
+```
+
+Excluded and why:
+
+- `Spawning` — the session hasn't even gotten to first activity poll, nothing to measure.
+- `Idle` — dedicated "waiting for work, not stuck" status. Different semantics; wouldn't benefit from the stuck label.
+- `NeedsInput` — already a known-blocked-on-human state, reaction `agent-needs-input` handles it (future phase).
+- `Stuck` — already stuck, no re-entry.
+- `MergeFailed` — Phase G parking state. Has its own retry loop; conflating with stuck would break the retry-budget accounting.
+- Terminal states (`Killed`, `Terminated`, `Done`, `Cleanup`, `Errored`, `Merged`) — filtered earlier by `tick()` / `is_terminal()`.
+
+This list is deliberately wider than "just `Working`". A session parked at `PrOpen` with an idle agent is exactly the scenario the TS post-PR stuck check was added for (see TS `lifecycle-manager.ts:503-509` and `537-543`). Not porting that would leave a visible gap vs. the TS reference.
+
+### 5. Stuck exit: activity flip in `poll_one` step 4
+
+TS handles `stuck → working` transparently by the `determineStatus` falling through to the "if active, return working" default. The Rust equivalent extends the existing happy-path branch:
+
+```rust
+// Before
+if session.status == SessionStatus::Spawning
+    && matches!(activity, ActivityState::Active | ActivityState::Ready)
+{
+    self.transition(&mut session, SessionStatus::Working).await?;
+}
+
+// After
+if matches!(session.status, SessionStatus::Spawning | SessionStatus::Stuck)
+    && matches!(activity, ActivityState::Active | ActivityState::Ready)
+{
+    self.transition(&mut session, SessionStatus::Working).await?;
+}
+```
+
+- Clears the `idle_since` entry via `update_idle_since` running earlier in the same tick.
+- `clear_tracker_on_transition` on the `Stuck → Working` edge clears the `agent-stuck` reaction tracker via the existing `status_to_reaction_key(Stuck)` path — so a session that gets stuck, recovers, then gets stuck again starts from a fresh retry budget. Same semantic as `ci-failed` cycles.
+
+### 6. Duration-based `escalate_after`: check wall-clock elapsed before attempt count
+
+```rust
+let should_escalate = {
+    // attempt-count gate
+    let mut escalate = cfg.retries.is_some_and(|n| attempts > n);
+    match cfg.escalate_after {
+        Some(EscalateAfter::Attempts(n)) if attempts > n => escalate = true,
+        Some(EscalateAfter::Duration(ref s)) => {
+            if let Some(d) = parse_duration(s) {
+                if tracker_state.first_triggered_at.elapsed() > d {
+                    escalate = true;
+                }
+            }
+        }
+        _ => {}
+    }
+    escalate
+};
+```
+
+Two independent gates (`retries` and `escalate_after`) that both flip `should_escalate` to true. Either can trigger — matches TS, matches Phase D behaviour for the attempts form.
+
+Note: `first_triggered_at` is populated on the **first** dispatch for this (session, reaction) pair. A cleared-then-recurring tracker starts fresh. This is essential — a session that was stuck for 10 minutes, recovered, and is stuck again shouldn't escalate on the first attempt of the second episode just because wall-clock time has marched on.
+
+### 7. No `Notifier` plugin in this phase
+
+`Notify` already degrades gracefully: `dispatch_notify` emits `ReactionTriggered { action: Notify }` on the broadcast channel and returns success. `ao-rs watch` subscribers already print that. No new code path needed for delivery; the reaction is "visible" exactly the same way `approved-and-green` is.
+
+The requirements doc lists this as a non-goal. Slice 3 picks it up.
+
+### 8. `check_stuck` yields when a prior step already transitioned this tick
+
+Two earlier steps in `poll_one` can mutate `session.status`:
+
+- **Step 4 (activity flip):** `Spawning/Stuck → Working` on `Active`/`Ready` activity.
+- **Step 5 (SCM poll):** PR-driven transitions like `PrOpen → CiFailed`, `ChangesRequested → Approved`, etc.
+
+If either of those already set a new status this tick, **`check_stuck` is a no-op for the current tick** and runs again on the next tick. Implementation is a single local snapshot:
+
+```rust
+// poll_one, around steps 4–6
+let pre_transition_status = session.status;
+
+// step 4 — happy-path activity flip (Spawning/Stuck → Working)
+// step 5 — poll_scm
+// ...
+
+// step 6 — stuck detection
+if session.status == pre_transition_status {
+    self.check_stuck(&mut session).await?;
+}
+```
+
+Rationale:
+
+- Matches TS `determineStatus`: one status per call. A PR that both fails CI *and* has been idle fires `ci-failed` on the current tick; on the next tick `CiFailed` is still stuck-eligible and `agent-stuck` follows if the threshold keeps elapsing. No double-reaction on a single tick.
+- No public API change. `poll_scm` stays `async fn(&self, &mut Session) -> Result<()>`. The snapshot lives inside `poll_one`, which is the only caller that needs the ordering.
+- Recovery (`Stuck → Working`) uses step 4, and by design step 4 *is* allowed to override `Stuck` — so the snapshot-and-skip rule only applies to step 6, not backward. The extended activity-flip branch in step 4 handles the recovery path.
+- Clean interaction with `update_idle_since`: that runs *before* the snapshot (right after activity persist) so the map stays honest even on a skipped tick — if the SCM poll transitioned us, we still track that the session is idle and will fire stuck on the next clean tick.
+
+Rejected alternative: add a `bool` return value to `poll_scm`. Works, but churns the function signature for a concern that's entirely local to `poll_one`. Snapshot is cheaper.
+
+### 9. Parse `threshold` lazily at dispatch time, not eagerly at config load
+
+`ReactionConfig::threshold` stays `Option<String>`. `parse_duration` is called on every dispatch attempt that needs it (duration-escalation gate in `reaction_engine.rs::dispatch`, and stuck-threshold check in `LifecycleManager::check_stuck`).
+
+Rejected alternative: change `ReactionConfig` to carry `Option<Duration>` post-load and fail `AoConfig::load` on garbage. Pros: fail-fast UX, single parse site. Cons:
+
+- Churns `AoConfig::load` to return validation errors for what is currently a simple yaml deserialize.
+- Requires a second schema type (`ReactionConfigRaw` → `ReactionConfig`) if we want to keep the on-disk shape as `String` for forward-compat.
+- Breaks "non-goal: no schema churn" from the requirements doc.
+- Only two parse sites — the duplication is trivial.
+
+Trade-off accepted: misconfigured thresholds (e.g., `"ten minutes"`) silently no-op until the first dispatch tries to use them, at which point we log a one-shot warning and continue. See "Warn-once observability" below.
+
+### 10. Status transitions are decoupled from the reaction's `auto` flag
+
+`check_stuck` calls `self.transition(session, SessionStatus::Stuck)` unconditionally once threshold is exceeded, regardless of whether the `agent-stuck` reaction has `auto: true` or `auto: false`. The status flip is lifecycle bookkeeping; the reaction engine gates the *action* (`dispatch_notify`, `dispatch_send_to_agent`, `dispatch_auto_merge`) on `auto` in its existing dispatch path.
+
+Rationale:
+
+- Matches how `ci-failed`, `changes-requested`, and `mergeable` already work: `derive_scm_status` flips the status regardless of reaction config; the engine separately decides whether to fire an action.
+- An operator with `auto: false` still sees `working → stuck` in `ao-rs watch`, which is useful observability. Hiding the status flip behind `auto` would create a silent "I know you're stuck but I won't tell you" mode.
+- "No config → no-op" (requirements acceptance criterion) is still honoured: if the `agent-stuck` reaction entry is entirely absent, `check_stuck` early-returns before calling `transition`. `auto: false` is different — the reaction exists, the threshold is configured, the operator has opted in to tracking but not to action.
+- Consequence: `auto: false` means "flip the status + emit `status_changed` event + let me manually react". `auto: true` adds "+ fire `Notify` / `SendToAgent` / `AutoMerge`". This is the same semantic gap as elsewhere.
+
+## State Machine Deltas
+
+### New `SessionStatus` transitions
+
+```
+Working         → Stuck    (idle > threshold)
+PrOpen          → Stuck    (idle > threshold)
+CiFailed        → Stuck    (idle > threshold)
+ReviewPending   → Stuck    (idle > threshold)
+ChangesRequested → Stuck   (idle > threshold)
+Approved        → Stuck    (idle > threshold)
+Mergeable       → Stuck    (idle > threshold)
+
+Stuck           → Working  (activity becomes Active/Ready)
+```
+
+`Stuck → Working` is the **only** exit. A stuck session that re-discovers a PR goes via `Working` on one tick and then `derive_scm_status` promotes it on the next tick. Simpler than adding `Stuck` as a starting state in `derive_scm_status`'s priority ladder.
+
+### Tracker preservation rules
+
+New entries for `clear_tracker_on_transition`:
+
+| From | To | Tracker to clear |
+|---|---|---|
+| `Stuck` | `Working` (exit) | `agent-stuck` |
+| `Working`/PR-track | `Stuck` | — (nothing; the engine is *entering* the reaction, not leaving it) |
+
+The existing generic rule (`status_to_reaction_key(from) → clear that key`) covers the `Stuck → Working` exit for free once `status_to_reaction_key(Stuck) = Some("agent-stuck")` is in place. No explicit branch needed.
+
+## Non-Functional Requirements
+
+- **Performance.** Per-tick overhead is one `HashMap` lookup + optional insert per session. Dominated by existing I/O (`SessionManager::list`, plus `gh` shell-outs in `poll_scm`). Negligible.
+- **Correctness at N=1.** The test suite drives a single session through all transitions. Phase D/F/G all land single-session tests and the pattern carries over.
+- **Thread safety.** `idle_since` is a `Mutex`, accessed only from inside `tick()` which is single-threaded per `LifecycleManager`. The lock is technically unnecessary but kept for the same "defence in depth" reason the tracker map uses `Mutex`.
+- **No new panics.** `parse_duration` returns `Option`, `Mutex::lock().expect(...)` matches the reaction engine's existing poisoning contract, `first_triggered_at` defaults via `Instant::now()` (infallible).
+- **Observability.** `tracing::debug!` on every stuck transition. Warn-once for unparseable duration strings: the reaction engine gains a process-local `warned_parse_failures: Mutex<HashSet<String>>` (keyed by reaction key). First time `parse_duration` returns `None` for that reaction's `threshold` or `escalate_after`, the engine emits a single `tracing::warn!` and inserts the key; subsequent failures are silent. Resets on `ao-rs watch` restart, which is consistent with how `idle_since` and reaction trackers behave. Cheaper than per-(session, reaction) dedup and avoids a hot-path unbounded-growth footgun — the set size is bounded by the number of distinct reaction keys in the user's config (≤ 10 in practice).
+
+## Intentional Divergences from TS Reference
+
+| TS | Rust | Why |
+|---|---|---|
+| Idle timestamp comes from the agent's JSONL session file | Idle timestamp is "first tick I saw Idle/Blocked" | JSONL introspection is out of scope for the learning port. Rust's approximation is one tick later than TS's — acceptable at the 5 s default poll interval. |
+| Stuck check runs inside `determineStatus` at multiple call sites (steps 2, 4b, 5) | Stuck check is one new step in `poll_one`, after SCM polling | Rust separates SCM polling into its own function. One caller is cleaner than three. |
+| `parseDuration` returns `0` on invalid input | `parse_duration` returns `None` | Rustic. Same short-circuit semantics (no-op on garbage). |
+| `agent-stuck` can be overridden per project | Global-only | Slice 2 has no per-project reaction overrides yet. |
+
+## Questions & Answers (from requirements)
+
+- **Blocked counts as idle?** Yes — matches TS.
+- **Stuck-eligible status set?** See section 4 above.
+- **Clock source?** `Instant`, not `SystemTime`.
+
+## Test Strategy preview (full detail in testing doc)
+
+1. Unit: `parse_duration` — happy path + rejects.
+2. Unit: `is_stuck_eligible` — exhaustive over `SessionStatus`.
+3. Unit: `TrackerState.first_triggered_at` preserved across attempts; `Duration` escalation fires after wall-clock elapses.
+4. Integration (`lifecycle.rs::tests`): idle-under-threshold → Working; idle-over-threshold → Stuck + `ReactionTriggered`; Active after Stuck → Working; config without `agent-stuck` → no-op; PrOpen idle → Stuck.
+5. Integration (`reaction_engine.rs::tests`): duration-based escalation end-to-end with a scripted MockRuntime.

--- a/docs/ai/implementation/README.md
+++ b/docs/ai/implementation/README.md
@@ -1,0 +1,65 @@
+---
+phase: implementation
+title: Implementation Guide
+description: Technical implementation notes, patterns, and code guidelines
+---
+
+# Implementation Guide
+
+## Development Setup
+**How do we get started?**
+
+- Prerequisites and dependencies
+- Environment setup steps
+- Configuration needed
+
+## Code Structure
+**How is the code organized?**
+
+- Directory structure
+- Module organization
+- Naming conventions
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Core Features
+- Feature 1: Implementation approach
+- Feature 2: Implementation approach
+- Feature 3: Implementation approach
+
+### Patterns & Best Practices
+- Design patterns being used
+- Code style guidelines
+- Common utilities/helpers
+
+## Integration Points
+**How do pieces connect?**
+
+- API integration details
+- Database connections
+- Third-party service setup
+
+## Error Handling
+**How do we handle failures?**
+
+- Error handling strategy
+- Logging approach
+- Retry/fallback mechanisms
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- Optimization strategies
+- Caching approach
+- Query optimization
+- Resource management
+
+## Security Notes
+**What security measures are in place?**
+
+- Authentication/authorization
+- Input validation
+- Data encryption
+- Secrets management
+

--- a/docs/ai/implementation/feature-agent-stuck-detection.md
+++ b/docs/ai/implementation/feature-agent-stuck-detection.md
@@ -1,0 +1,67 @@
+---
+phase: implementation
+title: agent-stuck detection — implementation notes
+description: Filled during Phase 4 (Execute Plan). Capture files touched, surprises, and deviations from the design doc.
+---
+
+# Implementation Guide — agent-stuck detection
+
+*Empty scaffold. Populate as tasks are executed from the planning doc. Keep this file as the one-stop index of "what did we actually change and why" once code lands.*
+
+## Development Setup
+**How do we get started?**
+
+- Prerequisites and dependencies
+- Environment setup steps
+- Configuration needed
+
+## Code Structure
+**How is the code organized?**
+
+- Directory structure
+- Module organization
+- Naming conventions
+
+## Implementation Notes
+**Key technical details to remember:**
+
+### Core Features
+- Feature 1: Implementation approach
+- Feature 2: Implementation approach
+- Feature 3: Implementation approach
+
+### Patterns & Best Practices
+- Design patterns being used
+- Code style guidelines
+- Common utilities/helpers
+
+## Integration Points
+**How do pieces connect?**
+
+- API integration details
+- Database connections
+- Third-party service setup
+
+## Error Handling
+**How do we handle failures?**
+
+- Error handling strategy
+- Logging approach
+- Retry/fallback mechanisms
+
+## Performance Considerations
+**How do we keep it fast?**
+
+- Optimization strategies
+- Caching approach
+- Query optimization
+- Resource management
+
+## Security Notes
+**What security measures are in place?**
+
+- Authentication/authorization
+- Input validation
+- Data encryption
+- Secrets management
+

--- a/docs/ai/monitoring/README.md
+++ b/docs/ai/monitoring/README.md
@@ -1,0 +1,80 @@
+---
+phase: monitoring
+title: Monitoring & Observability
+description: Define monitoring strategy, metrics, alerts, and incident response
+---
+
+# Monitoring & Observability
+
+## Key Metrics
+**What do we need to track?**
+
+### Performance Metrics
+- Response time/latency
+- Throughput/requests per second
+- Resource utilization (CPU, memory, disk)
+
+### Business Metrics
+- User engagement metrics
+- Conversion/success rates
+- Feature usage
+
+### Error Metrics
+- Error rates by type
+- Failed requests
+- Exception tracking
+
+## Monitoring Tools
+**What tools are we using?**
+
+- Application monitoring (APM)
+- Infrastructure monitoring
+- Log aggregation
+- User analytics
+
+## Logging Strategy
+**What do we log and how?**
+
+- Log levels and categories
+- Structured logging format
+- Log retention policy
+- Sensitive data handling
+
+## Alerts & Notifications
+**When and how do we get notified?**
+
+### Critical Alerts
+- Alert 1: [Condition] → [Action]
+- Alert 2: [Condition] → [Action]
+
+### Warning Alerts
+- Alert 1: [Condition] → [Action]
+- Alert 2: [Condition] → [Action]
+
+## Dashboards
+**What do we visualize?**
+
+- System health dashboard
+- Business metrics dashboard
+- Custom views per team/role
+
+## Incident Response
+**How do we handle issues?**
+
+### On-Call Rotation
+- Schedule and contacts
+- Escalation path
+
+### Incident Process
+1. Detection and triage
+2. Investigation and diagnosis
+3. Resolution and mitigation
+4. Post-mortem and learning
+
+## Health Checks
+**How do we verify system health?**
+
+- Endpoint health checks
+- Dependency checks
+- Automated smoke tests
+

--- a/docs/ai/planning/README.md
+++ b/docs/ai/planning/README.md
@@ -1,0 +1,60 @@
+---
+phase: planning
+title: Project Planning & Task Breakdown
+description: Break down work into actionable tasks and estimate timeline
+---
+
+# Project Planning & Task Breakdown
+
+## Milestones
+**What are the major checkpoints?**
+
+- [ ] Milestone 1: [Description]
+- [ ] Milestone 2: [Description]
+- [ ] Milestone 3: [Description]
+
+## Task Breakdown
+**What specific work needs to be done?**
+
+### Phase 1: Foundation
+- [ ] Task 1.1: [Description]
+- [ ] Task 1.2: [Description]
+
+### Phase 2: Core Features
+- [ ] Task 2.1: [Description]
+- [ ] Task 2.2: [Description]
+
+### Phase 3: Integration & Polish
+- [ ] Task 3.1: [Description]
+- [ ] Task 3.2: [Description]
+
+## Dependencies
+**What needs to happen in what order?**
+
+- Task dependencies and blockers
+- External dependencies (APIs, services, etc.)
+- Team/resource dependencies
+
+## Timeline & Estimates
+**When will things be done?**
+
+- Estimated effort per task/phase
+- Target dates for milestones
+- Buffer for unknowns
+
+## Risks & Mitigation
+**What could go wrong?**
+
+- Technical risks
+- Resource risks
+- Dependency risks
+- Mitigation strategies
+
+## Resources Needed
+**What do we need to succeed?**
+
+- Team members and roles
+- Tools and services
+- Infrastructure
+- Documentation/knowledge
+

--- a/docs/ai/planning/feature-agent-stuck-detection.md
+++ b/docs/ai/planning/feature-agent-stuck-detection.md
@@ -1,0 +1,185 @@
+---
+phase: planning
+title: agent-stuck detection — project plan
+description: Task breakdown, execution order, and risks for Slice 2 Phase H.
+---
+
+# Planning — agent-stuck detection & reaction
+
+## Milestones
+
+- [ ] **M1: parser + tracker shape.** `parse_duration` + `TrackerState.first_triggered_at` landed and unit-tested.
+- [ ] **M2: duration-based escalation live.** The reaction engine honours `EscalateAfter::Duration` end-to-end. Proven by a dedicated test in `reaction_engine.rs::tests`.
+- [ ] **M3: stuck detection wired.** `LifecycleManager` tracks idle_since, runs stuck detection in `poll_one`, and flips sessions to `Stuck`. `status_to_reaction_key(Stuck)` returns `"agent-stuck"`.
+- [ ] **M4: stuck exit + tracker hygiene.** `Stuck → Working` recovers cleanly, tracker clears, `idle_since` clears on terminate.
+- [ ] **M5: docs + review gate.** `docs/state-machine.md`, `docs/reactions.md`, `docs/architecture.md` updated. `rust-reviewer` agent clean. `cargo fmt --check` + `cargo clippy -- -D warnings` clean. Commit and push.
+
+## Task Breakdown
+
+### Phase 1: Foundation (M1)
+
+- [ ] **Task 1.1 — `parse_duration` helper**
+      Add to `crates/ao-core/src/reaction_engine.rs` as a `pub(crate) fn` (location locked in Phase 3 review — not a new `duration.rs`). Match TS regex `^\d+(s|m|h)$`, return `Option<Duration>`. Unit tests: `"10s"`, `"10m"`, `"10h"`, `"0s"` (Some(ZERO)), `"10"` (None), `""` (None), `"fast"` (None), `"10m10s"` (None — TS doesn't accept compound).
+      Ref: TS `lifecycle-manager.ts:45-59`.
+
+- [ ] **Task 1.2 — Extend `TrackerState`**
+      Add `first_triggered_at: Instant`. Populate in the `entry().or_insert_with(...)` site so every tracker carries a creation timestamp. Unit test: `ReactionEngine::attempts` still returns 0 for a never-triggered key; first dispatch populates `first_triggered_at`; second dispatch does **not** reset it.
+      Ref: `crates/ao-core/src/reaction_engine.rs:70-77, 200-209`.
+
+### Phase 2: Core features (M2 + M3 + M4)
+
+- [ ] **Task 2.1 — Duration-based escalation in `dispatch` + warn-once set**
+      Replace the `tracing::trace!` no-op branch at `reaction_engine.rs:224-232` with a real check: `if let Some(d) = parse_duration(s) { if tracker.first_triggered_at.elapsed() > d { escalate = true; } } else { warn_once(key) }`. Preserve the existing attempts-form path unchanged.
+      Add `warned_parse_failures: Mutex<HashSet<String>>` field to `ReactionEngine` and a small `warn_once(&self, reaction_key: &str, field: &str)` helper that inserts the key and emits `tracing::warn!` on first insertion only. Used here for `escalate_after` and by `check_stuck` (via `reaction_config` accessor) for `threshold`.
+      Unit tests: (a) configure `escalate_after: "1s"` + `retries: None`, dispatch twice with a `sleep(1100ms)` between — the second dispatch escalates. (b) configure `escalate_after: "garbage"` + retries: 3, dispatch 5 times — only retries gate fires, no panic, warn emits once.
+      Critical: `retries: None` alone without escalate_after still means "retry forever" — don't regress Phase D semantics.
+
+- [ ] **Task 2.2 — `status_to_reaction_key(Stuck) = Some("agent-stuck")`**
+      Delete the `TODO(PhaseE)` at `reaction_engine.rs:93-97`, add the match arm. Update the doc-comment on `status_to_reaction_key` to mention it. Unit test extending the existing exhaustive-match test.
+
+- [ ] **Task 2.3 — `LifecycleManager::idle_since` field + update helper**
+      Add `idle_since: Mutex<HashMap<SessionId, Instant>>`. Initialize in `new`. Add private helper `update_idle_since(session_id, activity)`:
+      - `Idle`/`Blocked` → `or_insert(Instant::now())` (preserve an older timestamp if one exists!)
+      - Any other activity → `remove`.
+      Call unconditionally from `poll_one` right after the "persist activity transition" block.
+
+- [ ] **Task 2.4 — `check_stuck` helper + `poll_one` step 6 + prior-transition snapshot**
+      New private `async fn check_stuck(&self, session: &mut Session)`:
+      1. Early-return if `!is_stuck_eligible(session.status)`.
+      2. Early-return if no `idle_since` entry (not idle).
+      3. Look up `agent-stuck` reaction in the engine's config (need a new `reaction_config(key)` accessor on `ReactionEngine` — **decision: add `fn reaction_config(&self, key: &str) -> Option<&ReactionConfig>` as `pub(crate)`**).
+      4. Parse `threshold`; `None` → no-op (warn-once handled in reaction engine, see Task 2.1).
+      5. Compare `idle_since.elapsed()` vs parsed threshold.
+      6. If over → `self.transition(session, SessionStatus::Stuck).await?`.
+      Wire into `poll_one` as step 6, after `poll_scm`. **Gate step 6 on a pre-transition snapshot** (Design Decision 8): capture `let pre_transition_status = session.status;` before step 4, then only call `check_stuck` if `session.status == pre_transition_status`. Guard on `self.reaction_engine.is_some()` so the Phase C/D tests without a reaction engine don't crash.
+
+- [ ] **Task 2.5 — `is_stuck_eligible` const fn**
+      Exhaustive match on `SessionStatus`. Unit test: every variant has an explicit answer, no wildcard `_ =>`. This makes the next new `SessionStatus` variant fail the build until stuck eligibility is decided for it — same pattern as `derive_scm_status`'s exhaustiveness test.
+
+- [ ] **Task 2.6 — Stuck → Working exit**
+      Extend the existing `Spawning → Working` branch in `poll_one` step 4:
+      ```rust
+      if matches!(session.status, SessionStatus::Spawning | SessionStatus::Stuck)
+          && matches!(activity, ActivityState::Active | ActivityState::Ready)
+      { transition(Working) }
+      ```
+      `clear_tracker_on_transition` handles the `agent-stuck` tracker clear automatically via `status_to_reaction_key(Stuck)`.
+
+- [ ] **Task 2.7 — Clear `idle_since` in `terminate`**
+      Alongside the existing `engine.clear_all_for_session` call. Prevents memory leaks on long-running watch loops.
+
+### Phase 3: Integration & polish (M5)
+
+- [ ] **Task 3.1 — Integration tests (lifecycle)**
+      Add to `crates/ao-core/src/lifecycle.rs::tests`:
+      - `stuck_detection_fires_on_working_after_threshold`
+      - `stuck_detection_fires_on_pr_open_after_threshold`
+      - `stuck_recovers_to_working_on_active_activity`
+      - `stuck_not_triggered_without_agent_stuck_config`
+      - `stuck_not_triggered_before_threshold_elapses`
+      - `stuck_eligibility_excludes_needs_input`
+      Use a `MockAgent` that returns `Idle` and a `threshold: "100ms"` config. `tokio::time::sleep(150ms)` between ticks.
+
+- [ ] **Task 3.2 — Integration test (reaction engine duration escalation)**
+      `crates/ao-core/src/reaction_engine.rs::tests::duration_escalate_after_fires_on_elapsed`. No `LifecycleManager` needed — direct `engine.dispatch` calls with a sleep between.
+
+- [ ] **Task 3.3 — Update `docs/state-machine.md`**
+      New "Stuck detection (Phase H)" section. Document: the idle_since map, stuck-eligible status set, the `Stuck → Working` exit, and which trackers clear where.
+
+- [ ] **Task 3.4 — Update `docs/reactions.md`**
+      Move `agent-stuck` from the "Proposed" column to "Implemented through Phase H". Add a subsection on duration-based escalation with a yaml example.
+
+- [ ] **Task 3.5 — Update `docs/architecture.md`**
+      Move the "Duration-based `escalate-after`" bullet from "Open architecture questions" to "Answered / no longer open". One-liner pointing at Phase H.
+
+- [ ] **Task 3.6 — Run `cargo fmt` + `cargo clippy -- -D warnings`**
+      Workspace-wide. Fix any clippy lints introduced.
+
+- [ ] **Task 3.7 — Invoke `rust-reviewer` agent**
+      Per the porting-workflow feedback memory. Address blockers, re-run if they land meaningful changes.
+
+- [ ] **Task 3.8 — Focused commit + push**
+      One commit: `feat(core): Slice 2 Phase H — agent-stuck detection + duration-based escalate_after`. Push to origin, mark Phase H done in memory.
+
+## Dependencies
+
+```
+Task 1.1 (parse_duration) ─┬─> Task 2.1 (duration escalation)
+Task 1.2 (TrackerState)    ─┘
+Task 2.2 (reaction key)    ─> Task 2.4 (check_stuck)
+Task 2.3 (idle_since)      ─> Task 2.4 (check_stuck)
+Task 2.5 (is_stuck_eligible)─> Task 2.4 (check_stuck)
+Task 2.4 (check_stuck)     ─> Task 3.1 (integration tests)
+Task 2.6 (stuck exit)      ─> Task 3.1
+Task 2.1                   ─> Task 3.2
+All code + tests           ─> Task 3.3-3.8 (docs + review + commit)
+```
+
+Concrete execution order (serial):
+
+1. Task 1.1 (parser)
+2. Task 1.2 (tracker field)
+3. Task 2.1 (escalation) — finishes M2
+4. Task 2.2 (reaction key)
+5. Task 2.5 (stuck_eligible)
+6. Task 2.3 (idle_since + update)
+7. Task 2.4 (check_stuck + step 6)
+8. Task 2.6 (stuck exit)
+9. Task 2.7 (terminate cleanup) — finishes M3+M4
+10. Task 3.1, 3.2 (tests) — verify M2/M3/M4 with real fixtures
+11. Task 3.3, 3.4, 3.5 (docs) — M5 docs
+12. Task 3.6 (fmt/clippy), 3.7 (review), 3.8 (commit) — M5 close
+
+## Timeline & Estimates
+
+Per the porting-workflow memory, each task is a focused "one clear change + its tests" unit. Rough order-of-magnitude:
+
+| Task | Effort |
+|---|---|
+| 1.1 parse_duration | ~15 min |
+| 1.2 TrackerState field | ~15 min |
+| 2.1 duration escalation | ~30 min (includes test) |
+| 2.2 reaction key | ~5 min |
+| 2.3 idle_since | ~20 min |
+| 2.4 check_stuck | ~45 min (includes new `reaction_config` accessor) |
+| 2.5 is_stuck_eligible | ~20 min |
+| 2.6 stuck exit | ~10 min |
+| 2.7 terminate cleanup | ~5 min |
+| 3.1 lifecycle integration tests | ~1 hour |
+| 3.2 reaction engine duration test | ~20 min |
+| 3.3–3.5 docs | ~45 min |
+| 3.6 fmt/clippy | ~10 min |
+| 3.7 rust-reviewer | ~20 min (cycle time, not wall-clock) |
+| 3.8 commit + push | ~5 min |
+
+Total: roughly a half-day of focused work, in line with Phase D/F/G.
+
+## Risks & Mitigation
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **Test flakiness from `tokio::time::sleep`** | Intermittent CI failures on integration tests | Use `tokio::time::pause()` + `tokio::time::advance()` where possible. Where a real sleep is required (to let `Instant::elapsed` advance), use short durations (100ms) and generous margins (50% buffer). |
+| **`Instant::elapsed` in tests vs. mock clocks** | Can't inject a test clock without overhauling the engine | Accept real-wall-clock in integration tests. Keep individual test durations ≤200 ms so the suite stays fast. |
+| **`Stuck → Working` recovery missed if activity flips back *during* the same tick** | Session gets stuck on one tick and recovers the next before anyone notices | Acceptable — the reaction still fires once, the transition event is visible in `ao-rs watch`, and a one-tick false positive is better than silent non-detection. |
+| **Duration escalation conflicts with attempts escalation when both configured** | User sees `escalate_after: 10m` but retries run out after 3 attempts first | Documented behaviour: the first gate to trigger wins. Either can fire. Add a test covering both configured — the earlier-firing gate escalates, the later is a no-op because `should_escalate` is already true. |
+| **Config churn if Task 2.4 needs a new accessor** | Shape of `ReactionEngine` public API changes | `reaction_config(key) -> Option<&ReactionConfig>` is purely additive; no existing callers break. Low-risk extension. |
+| **`parse_duration` silently no-oping on malformed threshold** | User misconfigures `threshold: "ten minutes"` and nothing happens | Log a one-shot `tracing::warn!` on first use per (session, reaction) pair. Follows the same pattern the engine uses for "`send-to-agent` without a message". |
+| **Regression of Phase G retry loop** | Accidentally parking `MergeFailed` sessions via the stuck path | `is_stuck_eligible` explicitly excludes `MergeFailed`. Add a test that ensures a `MergeFailed` session with idle activity does NOT transition to `Stuck`. |
+
+## Resources Needed
+
+- **TS reference.** `~/study/agent-orchestrator/packages/core/src/lifecycle-manager.ts` lines 45-59 (parseDuration), 340-351 (isIdleBeyondThreshold), 370-560 (determineStatus with stuck checks at 4b and 5).
+- **Existing Rust code to study.** `reaction_engine.rs` tracker accounting path (lines 200-270), `lifecycle.rs::poll_one` (215-297), `lifecycle.rs::terminate` (392-404), `clear_tracker_on_transition` for the cross-transition rules.
+- **rust-reviewer agent.** Per porting workflow — gates every phase commit.
+- **Tools.** `cargo fmt`, `cargo clippy`, `cargo test -p ao-core` (single-crate fast iteration), full `cargo test` before commit.
+
+## Exit Criteria
+
+Phase H is done when:
+
+1. All tasks in the breakdown are checked.
+2. `cargo test` passes on the worktree.
+3. `cargo fmt --check` + `cargo clippy -- -D warnings` clean.
+4. `rust-reviewer` agent returns no blockers.
+5. One focused commit exists on `feature-agent-stuck-detection`.
+6. The `ao-rs port state` memory entry is updated to reflect Phase H done + Phase I plan stub (or "port is paused" — decide at commit time).

--- a/docs/ai/requirements/README.md
+++ b/docs/ai/requirements/README.md
@@ -1,0 +1,51 @@
+---
+phase: requirements
+title: Requirements & Problem Understanding
+description: Clarify the problem space, gather requirements, and define success criteria
+---
+
+# Requirements & Problem Understanding
+
+## Problem Statement
+**What problem are we solving?**
+
+- Describe the core problem or pain point
+- Who is affected by this problem?
+- What is the current situation/workaround?
+
+## Goals & Objectives
+**What do we want to achieve?**
+
+- Primary goals
+- Secondary goals
+- Non-goals (what's explicitly out of scope)
+
+## User Stories & Use Cases
+**How will users interact with the solution?**
+
+- As a [user type], I want to [action] so that [benefit]
+- Key workflows and scenarios
+- Edge cases to consider
+
+## Success Criteria
+**How will we know when we're done?**
+
+- Measurable outcomes
+- Acceptance criteria
+- Performance benchmarks (if applicable)
+
+## Constraints & Assumptions
+**What limitations do we need to work within?**
+
+- Technical constraints
+- Business constraints
+- Time/budget constraints
+- Assumptions we're making
+
+## Questions & Open Items
+**What do we still need to clarify?**
+
+- Unresolved questions
+- Items requiring stakeholder input
+- Research needed
+

--- a/docs/ai/requirements/feature-agent-stuck-detection.md
+++ b/docs/ai/requirements/feature-agent-stuck-detection.md
@@ -1,0 +1,247 @@
+---
+phase: requirements
+title: agent-stuck detection & reaction (Slice 2 Phase H)
+description: Detect idle-beyond-threshold sessions, flip them to `Stuck`, and fire the `agent-stuck` reaction.
+---
+
+# Requirements — agent-stuck detection & reaction
+
+## Problem Statement
+
+The Rust port's reaction engine can already fire `ci-failed`,
+`changes-requested`, and `approved-and-green` reactions. What it
+**cannot** do is notice a session that has stopped making progress on
+its own.
+
+Symptoms a human sees today without stuck detection:
+
+- An agent writes code, hits an unexpected edge case, emits a
+  "hmm, I'm not sure what to do here" message, and goes `Idle`. The
+  lifecycle loop observes `ActivityChanged(active → idle)` and
+  persists it. That's the end of the story — the session sits in
+  `Working` / `Idle` forever. No notification fires, no `stuck`
+  status, no escalation.
+- Same thing with a `PrOpen` session: agent pushed a PR, CI is
+  queued, reviewer hasn't looked, and the agent has gone home. The
+  session looks fine-ish in `ao-rs status`, but no human is told
+  that the PR has been sitting for hours with no forward motion.
+
+Concretely, the TODO at `crates/ao-core/src/reaction_engine.rs:93`
+has been flagging this gap since Phase D:
+
+```rust
+// TODO(PhaseE): add Stuck → "agent-stuck" and Errored → "agent-errored".
+// agent-stuck needs auxiliary state (time entered Idle) that the
+// engine doesn't track today — the pure status-to-key mapping will
+// work, but the engine side needs a `status_entered_at` tracker.
+```
+
+Phase H closes that gap.
+
+**Who is affected?** The single operator running `ao-rs watch` on
+their laptop (learning-port scope). No "mass" users.
+
+**Current workaround?** Manually `tmux attach` and eyeball each
+session. Doesn't scale past 2-3 sessions, which is exactly the
+count this project is designed for.
+
+## Goals & Objectives
+
+### Primary goals
+
+1. Detect that a session has been "idle-ish" continuously for longer
+   than a configurable threshold (default: the `agent-stuck`
+   reaction's `threshold` field, e.g. `"10m"`).
+2. When detected, transition the session's `SessionStatus` to
+   `Stuck` and fire the `agent-stuck` reaction through the existing
+   `ReactionEngine::dispatch` path.
+3. Allow a stuck session to recover: when the agent starts acting
+   again, flip `Stuck` back to `Working` (matching the TS
+   reference). Stuck is not terminal.
+4. Wire **duration-based `escalate_after`** (`escalate_after: 10m`)
+   into the reaction engine — `agent-stuck` is the first reaction
+   that actually needs wall-clock escalation, and the parser was
+   deliberately deferred until this phase (see
+   `docs/architecture.md#open-architecture-questions`).
+
+### Secondary goals
+
+- Document the new transition in `docs/state-machine.md` and the
+  new reaction wiring in `docs/reactions.md`.
+- Keep the reaction delivery as `tracing::warn!` + emit
+  `ReactionTriggered` on the broadcast channel. No new `Notifier`
+  trait — that's Slice 3.
+
+### Non-goals
+
+- **Real `Notifier` plugin.** Slack / desktop / email delivery
+  stays out of scope. `Notify` fires on the broadcast channel and
+  `ao-rs watch` prints it to stdout — same contract as every other
+  reaction today.
+- **JSONL introspection.** The TS reference reads the agent's own
+  session files to get a precise "idle since" timestamp. The Rust
+  port will instead use "first tick we observed Idle/Blocked
+  activity" as an approximation. Intentional divergence — see
+  design doc.
+- **Persistent idle-since state.** The `idle_since` map lives in
+  memory inside `LifecycleManager`. A `ao-rs watch` restart resets
+  it. TS does the same (the tracker is rebuilt from disk on boot,
+  but the per-session idle clock is in-process).
+- **Per-project stuck thresholds.** Slice 2 has no project-level
+  reaction overrides yet (the global `reactions:` map is the only
+  source). This phase uses whatever the global `agent-stuck`
+  threshold is; per-project merge lands later if ever.
+- **`agent-errored` reaction.** The TODO mentioned both. This
+  phase only does `agent-stuck`.
+
+## User Stories & Use Cases
+
+1. **Idle background coder.** *As the operator*, I want a session
+   that has gone idle for 10 minutes with no PR opened to flip to
+   `stuck` and print a warning row in `ao-rs watch`, so I can
+   attach and unblock it.
+2. **PR that lost its reviewer.** *As the operator*, I want a
+   session sitting at `pr_open` with idle activity for 30 minutes
+   to also flip to `stuck`, so I don't have to spot-check every
+   open PR.
+3. **Recovery.** *As the operator*, when I attach and the agent
+   starts working again, the session flips back to `working` on
+   the next tick without me having to `ao-rs session restore`.
+4. **Escalation.** *As the operator*, if I don't respond to a
+   `Notify` for the configured `escalate_after: 10m`, the engine
+   re-fires with escalation marker so I see it twice (still via
+   `tracing::warn!` / broadcast event, but marked `escalated`).
+5. **No-config means no check.** *As the operator*, if I haven't
+   put `agent-stuck` in my `~/.ao-rs/config.yaml`, the feature is a
+   no-op. No accidental status flips from a default threshold.
+
+### What the operator sees in `ao-rs watch`
+
+When a session goes stuck, the existing event printer (see
+`crates/ao-cli/src/main.rs:700-750`) emits two rows in order, no
+CLI changes needed:
+
+```
+3a4b5c6d   status_changed       working → stuck
+3a4b5c6d   reaction_fired       agent-stuck → notify
+```
+
+On recovery:
+
+```
+3a4b5c6d   activity_changed     idle → active
+3a4b5c6d   status_changed       stuck → working
+```
+
+If duration-based `escalate_after` trips (reaction was `notify`,
+not responded to, wall-clock elapsed), a third row appears:
+
+```
+3a4b5c6d   reaction_escalated   agent-stuck (2 attempts)
+3a4b5c6d   reaction_fired       agent-stuck → notify
+```
+
+Phase H ships zero new row shapes — the existing `reaction_fired`
+and `reaction_escalated` variants already print cleanly.
+
+## Success Criteria
+
+Acceptance:
+
+- [ ] `status_to_reaction_key(Stuck)` returns `Some("agent-stuck")`
+      — the TODO at `reaction_engine.rs:93` is gone.
+- [ ] A `LifecycleManager` integration test with a `MockAgent` that
+      reports `Idle` and a 1-second `agent-stuck` threshold flips
+      the session to `Stuck` on the tick after threshold expiry and
+      emits `ReactionTriggered { key: "agent-stuck", action: notify }`.
+- [ ] Same test but activity returns to `Active` — session flips
+      back to `Working` on the next tick.
+- [ ] Stuck detection fires for both non-PR sessions (`Working`)
+      and PR-track sessions (`PrOpen`, `CiFailed`, etc.). A table
+      test enumerates which statuses are "stuck-eligible".
+- [ ] Duration-based `escalate_after: "1s"` triggers escalation in
+      a unit test (wall-clock elapsed > parsed duration on the
+      second attempt).
+- [ ] Threshold parser accepts `Ns` / `Nm` / `Nh` for any
+      non-negative `N` (including `0s` — see "Constraints" below).
+      Garbage input (`"fast"`, `"10"`, empty, `"1m30s"` compound)
+      becomes a no-op with a one-shot `tracing::warn!` on first
+      use per reaction — matching how TS's `parseDuration` returns
+      0 and short-circuits.
+- [ ] No `agent-stuck` config → no behaviour change vs. Phase G.
+      Covered by keeping all Phase G tests green.
+- [ ] `cargo fmt --check` clean, `cargo clippy -- -D warnings`
+      clean in the whole workspace.
+- [ ] `rust-reviewer` gate passes.
+
+Performance:
+
+- No measurable overhead on ticks when no session is stuck.
+  Insert/lookup on `HashMap<SessionId, Instant>` is O(1) and the
+  per-tick cost is bounded by session count (dozens, not
+  thousands). Matches the existing tracker map cost profile.
+
+## Constraints & Assumptions
+
+- **Disk is the source of truth** (architecture principle #2).
+  Stuck is derived from runtime state; the transition is persisted
+  via `SessionManager::save` like every other status change.
+- **Trait objects at plugin boundaries** (#3). The `Agent` trait
+  is not touched — we do not add a "return idle timestamp" method.
+  `LifecycleManager` tracks idle entry in its own state.
+- **Shell-out over libraries** (#1). Irrelevant here — no new
+  subprocess calls.
+- The TS reference uses a trivial regex for duration parsing
+  (`^\d+(s|m|h)$`). Rust matches it — no need for `humantime` as
+  a dep just to parse `"10m"`.
+- `Stuck` is a non-terminal, non-PR-track status. `tick()` will
+  still poll it. Exit is via the activity path in `poll_one`, not
+  `derive_scm_status`.
+- **`ActivityState::Blocked` counts as idle for stuck detection,
+  not only `Idle`.** Semantically `Blocked` means "agent hit an
+  error or got stuck" — exactly the condition the reaction is
+  for. Matches TS (`state === "idle" || state === "blocked"`
+  triggers `detectedIdleTimestamp` in
+  `lifecycle-manager.ts:414`). Listed here rather than in the
+  design doc because it affects which sessions fire user-visible
+  reactions — not a hidden implementation detail.
+- **Minimum `threshold` is whatever the parser accepts — no
+  clamping, no floor.** `threshold: "0s"` will fire on the first
+  idle-activity tick the session observes. `threshold: "1s"` with
+  the default 5-second poll interval effectively fires on the
+  next tick after entering idle. We do **not** clamp to poll
+  interval because (a) the parser is the honest contract, and
+  (b) users configuring sub-poll-interval thresholds will see
+  surprising behaviour either way — clamping hides it, rejection
+  helps catch typos but also catches legitimate test fixtures.
+- **`ao-rs watch` restart resets the idle clock.** This is the
+  user-observable consequence of the non-goal "persistent
+  idle-since state". A session that was idle for 9 minutes under
+  a `threshold: 10m` reaction, when the operator stops and
+  restarts `ao-rs watch`, will take another full 10 minutes of
+  continuous idle activity after restart before stuck fires.
+  Accepted trade-off — matches TS (which rebuilds its tracker
+  from disk on boot, but the idle timestamp itself is
+  in-process). Documented here so the operator isn't surprised.
+
+## Questions & Open Items
+
+All originally-open questions have been resolved. Summary here so a
+reader who only looks at this file knows what was decided:
+
+- **`ActivityState::Blocked` counts as idle.** → Constraint
+  section above.
+- **Minimum stuck-eligible status set.** → Design doc. Excludes
+  `Spawning`, `NeedsInput`, `Stuck` itself, `MergeFailed`, and
+  all terminal states.
+- **Clock source.** → Design doc. `std::time::Instant`
+  (monotonic, immune to wall-clock skew).
+- **Minimum `threshold` value / parser strictness.** →
+  Constraint section. No clamping, no floor; the parser is the
+  contract.
+- **Restart behaviour.** → Constraint section. Idle clock
+  resets; documented as known limitation.
+
+Phase 2 review added three constraint items, one CLI-observability
+user-story subsection, and sharpened the parser acceptance
+criterion. No re-scope.

--- a/docs/ai/testing/README.md
+++ b/docs/ai/testing/README.md
@@ -1,0 +1,81 @@
+---
+phase: testing
+title: Testing Strategy
+description: Define testing approach, test cases, and quality assurance
+---
+
+# Testing Strategy
+
+## Test Coverage Goals
+**What level of testing do we aim for?**
+
+- Unit test coverage target (default: 100% of new/changed code)
+- Integration test scope (critical paths + error handling)
+- End-to-end test scenarios (key user journeys)
+- Alignment with requirements/design acceptance criteria
+
+## Unit Tests
+**What individual components need testing?**
+
+### Component/Module 1
+- [ ] Test case 1: [Description] (covers scenario / branch)
+- [ ] Test case 2: [Description] (covers edge case / error handling)
+- [ ] Additional coverage: [Description]
+
+### Component/Module 2
+- [ ] Test case 1: [Description]
+- [ ] Test case 2: [Description]
+- [ ] Additional coverage: [Description]
+
+## Integration Tests
+**How do we test component interactions?**
+
+- [ ] Integration scenario 1
+- [ ] Integration scenario 2
+- [ ] API endpoint tests
+- [ ] Integration scenario 3 (failure mode / rollback)
+
+## End-to-End Tests
+**What user flows need validation?**
+
+- [ ] User flow 1: [Description]
+- [ ] User flow 2: [Description]
+- [ ] Critical path testing
+- [ ] Regression of adjacent features
+
+## Test Data
+**What data do we use for testing?**
+
+- Test fixtures and mocks
+- Seed data requirements
+- Test database setup
+
+## Test Reporting & Coverage
+**How do we verify and communicate test results?**
+
+- Coverage commands and thresholds (`npm run test -- --coverage`)
+- Coverage gaps (files/functions below 100% and rationale)
+- Links to test reports or dashboards
+- Manual testing outcomes and sign-off
+
+## Manual Testing
+**What requires human validation?**
+
+- UI/UX testing checklist (include accessibility)
+- Browser/device compatibility
+- Smoke tests after deployment
+
+## Performance Testing
+**How do we validate performance?**
+
+- Load testing scenarios
+- Stress testing approach
+- Performance benchmarks
+
+## Bug Tracking
+**How do we manage issues?**
+
+- Issue tracking process
+- Bug severity levels
+- Regression testing strategy
+

--- a/docs/ai/testing/feature-agent-stuck-detection.md
+++ b/docs/ai/testing/feature-agent-stuck-detection.md
@@ -1,0 +1,83 @@
+---
+phase: testing
+title: agent-stuck detection — test plan
+description: Filled during Phase 4 (as tests are written) and Phase 7 (coverage validation). Seed cases come from the design doc's "Test Strategy preview" section.
+---
+
+# Testing Strategy — agent-stuck detection
+
+*Seed the concrete test list from `docs/ai/design/feature-agent-stuck-detection.md` "Test Strategy preview". Expand with results, coverage gaps, and manual verification notes as tests land in Phase 4 and get reviewed in Phase 7.*
+
+## Test Coverage Goals
+**What level of testing do we aim for?**
+
+- Unit test coverage target (default: 100% of new/changed code)
+- Integration test scope (critical paths + error handling)
+- End-to-end test scenarios (key user journeys)
+- Alignment with requirements/design acceptance criteria
+
+## Unit Tests
+**What individual components need testing?**
+
+### Component/Module 1
+- [ ] Test case 1: [Description] (covers scenario / branch)
+- [ ] Test case 2: [Description] (covers edge case / error handling)
+- [ ] Additional coverage: [Description]
+
+### Component/Module 2
+- [ ] Test case 1: [Description]
+- [ ] Test case 2: [Description]
+- [ ] Additional coverage: [Description]
+
+## Integration Tests
+**How do we test component interactions?**
+
+- [ ] Integration scenario 1
+- [ ] Integration scenario 2
+- [ ] API endpoint tests
+- [ ] Integration scenario 3 (failure mode / rollback)
+
+## End-to-End Tests
+**What user flows need validation?**
+
+- [ ] User flow 1: [Description]
+- [ ] User flow 2: [Description]
+- [ ] Critical path testing
+- [ ] Regression of adjacent features
+
+## Test Data
+**What data do we use for testing?**
+
+- Test fixtures and mocks
+- Seed data requirements
+- Test database setup
+
+## Test Reporting & Coverage
+**How do we verify and communicate test results?**
+
+- Coverage commands and thresholds (`npm run test -- --coverage`)
+- Coverage gaps (files/functions below 100% and rationale)
+- Links to test reports or dashboards
+- Manual testing outcomes and sign-off
+
+## Manual Testing
+**What requires human validation?**
+
+- UI/UX testing checklist (include accessibility)
+- Browser/device compatibility
+- Smoke tests after deployment
+
+## Performance Testing
+**How do we validate performance?**
+
+- Load testing scenarios
+- Stress testing approach
+- Performance benchmarks
+
+## Bug Tracking
+**How do we manage issues?**
+
+- Issue tracking process
+- Bug severity levels
+- Regression testing strategy
+

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -148,21 +148,6 @@ These are parked until a slice forces us to decide:
   the worktree is gone. A future Phase could add it.
 - **Subprocess-plugin API?** TS's marketplace model eventually wants
   JSON-RPC / LSP-style subprocess plugins. Out of scope for the port.
-- **SCM-driven status transitions.** Slice 2 Phase D wired the reaction
-  engine into `LifecycleManager::transition`, but status transitions
-  themselves are still only driven by runtime liveness + agent activity.
-  A follow-up phase wires `Arc<dyn Scm>` into the polling loop so
-  `Working → PrOpen/CiFailed/ChangesRequested/Mergeable` fires from real
-  PR state. Until that phase lands, users exercise reactions by scripting
-  transitions (or waiting for a future `ao-rs transition` debug command).
-- **AutoMerge wiring.** The `approved-and-green` reaction currently emits
-  a `ReactionTriggered` event with `action=auto-merge` but doesn't call
-  `Scm::merge`. Same follow-up phase as SCM polling — once the loop holds
-  an `Arc<dyn Scm>`, the engine can dispatch through it.
-- **Duration-based `escalate-after`.** Phase D parses `Duration("10m")`
-  but the engine ignores it (`tracing::trace!` + fall through to attempt
-  counting). The parser lands next to the first reaction that actually
-  needs wall-clock escalation (`agent-stuck`).
 
 Answered / no longer open:
 
@@ -172,3 +157,19 @@ Answered / no longer open:
 - ~~**Config file?**~~ Yes, `~/.ao-rs/config.yaml`, loaded by
   `AoConfig::load_default()`. Only the `reactions:` subtree is read.
   Missing file is treated as "no reactions configured".
+- ~~**SCM-driven status transitions.**~~ Landed in Slice 2 Phase F.
+  `LifecycleManager::poll_scm` holds an `Arc<dyn Scm>` and fans out to
+  `detect_pr` + four parallel probes per tick; the results flow through
+  `scm_transitions::derive_scm_status` for PR-driven transitions.
+- ~~**AutoMerge wiring.**~~ Landed in Slice 2 Phase F / Phase G.
+  `ReactionEngine::dispatch_auto_merge` re-probes mergeability and calls
+  `Scm::merge`; Phase G's `merge_failed` parking loop handles the retry
+  story when `Scm::merge` errors mid-tick.
+- ~~**Duration-based `escalate-after`.**~~ Landed in Slice 2 Phase H.
+  `reaction_engine::parse_duration` (`^\d+(s|m|h)$`) is parsed lazily
+  at each `dispatch` call and compared against the new
+  `TrackerState.first_triggered_at`. Unparseable strings log a
+  one-shot `tracing::warn!` via `warn_once_parse_failure` and fall
+  through silently so a typo in the config can't wedge the engine.
+  The same parser powers the `agent-stuck.threshold` lookup in
+  `LifecycleManager::check_stuck`.

--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -1,6 +1,6 @@
 # Reaction engine — Slice 2
 
-Slice 2 is implemented through **Phase G**. The "plan" sections below
+Slice 2 is implemented through **Phase H**. The "plan" sections below
 document the original target shape; the "Implemented" section below
 documents the actual landed surface — defer to the code (and the tests)
 as the source of truth when they diverge.
@@ -8,7 +8,7 @@ as the source of truth when they diverge.
 Read this alongside `packages/core/src/lifecycle-manager.ts` lines 130–1180
 and `packages/core/src/types.ts` lines 960–1170 in the TS reference.
 
-## Implemented through Phase G
+## Implemented through Phase H
 
 | Piece | Where | Status |
 | --- | --- | --- |
@@ -20,6 +20,8 @@ and `packages/core/src/types.ts` lines 960–1170 in the TS reference.
 | `approved-and-green` → real `gh pr merge` | `ReactionEngine::dispatch_auto_merge` | ✅ |
 | `ci-failed` / `changes-requested` reactions | `ReactionEngine::dispatch` | ✅ |
 | `merge_failed` parking loop (Phase G / M1) | `lifecycle::park_in_merge_failed` + `scm_transitions` | ✅ |
+| `agent-stuck` detection + reaction (Phase H) | `lifecycle::check_stuck` + `ReactionEngine::dispatch` | ✅ |
+| Duration-based `escalate_after: "10m"` | `ReactionEngine::dispatch` (parses via `parse_duration`) | ✅ |
 | `Tracker` trait / GitHub impl | `ao_core::traits::Tracker`, `ao-plugin-tracker-github` | ✅ |
 | `Notifier` trait | — | ⏳ Slice 3 |
 | Multi-notifier routing | — | ⏳ Slice 3 |
@@ -102,6 +104,77 @@ concerns:
 
 See `docs/state-machine.md#the-merge_failed-parking-loop-phase-g` for
 the transition table and the rationale for why the state had to exist.
+
+### Phase H wiring (`agent-stuck` detection + duration escalation)
+
+Phase H closes two gaps the engine carried from Phase D:
+
+1. `agent-stuck` was listed as a valid reaction key but nothing ever
+   fired it. `status_to_reaction_key(SessionStatus::Stuck)` returned
+   `None`, and there was no machinery to flip a session *into* `Stuck`
+   in the first place.
+2. `escalate_after: "10m"` (the TS-compatible duration form) was
+   accepted at parse time but silently ignored at dispatch — only
+   `escalate_after: 3` (the attempts form) actually gated escalation.
+
+The Phase H changes are scoped to `lifecycle.rs` + `reaction_engine.rs`
+and do not touch plugin contracts:
+
+- **Lifecycle owns detection.** `LifecycleManager::check_stuck` runs as
+  the final transitioning step in `poll_one`, gated on both a
+  reaction engine being attached AND a pre-step-4 status snapshot
+  (so two transitions can never fire on the same tick — see
+  [Stuck detection (Phase H)](../state-machine.md#stuck-detection-phase-h)).
+  When every guard passes, `check_stuck` calls
+  `transition(session, Stuck)`, which in turn dispatches the
+  `agent-stuck` reaction through the normal
+  `status_to_reaction_key(Stuck) = Some("agent-stuck")` path.
+- **Engine owns duration parsing.** `reaction_engine::parse_duration`
+  accepts the TS regex `^\d+(s|m|h)$` (e.g. `"10s"`, `"5m"`, `"2h"`).
+  `dispatch` parses the duration form of `escalate_after` lazily on
+  each call and compares against `TrackerState.first_triggered_at`
+  (also new in Phase H). The attempts form (`Attempts(u32)`) still
+  works unchanged — if both are configured, whichever gate trips
+  first wins.
+- **Warn-once on malformed strings.** Both `threshold` and duration
+  `escalate_after` values that fail `parse_duration` trigger a single
+  `tracing::warn!` per `"{reaction_key}.{field}"` key, deduplicated via
+  a process-local `Mutex<HashSet<String>>` on the engine. Operators
+  see the typo once in logs and then stop getting spammed every tick.
+  The function silently no-ops afterwards — a broken threshold does
+  not cause dispatch errors.
+- **Status flip is decoupled from `auto`.** `check_stuck` transitions
+  to `Stuck` whenever a `threshold` is configured, regardless of
+  `auto: true|false`. The `auto` flag only gates the *action*
+  (`Notify`, `SendToAgent`, `AutoMerge`) inside `ReactionEngine::dispatch`.
+  This matches how `ci-failed`, `changes-requested`, and
+  `approved-and-green` already behave — status flip is lifecycle
+  bookkeeping, action dispatch is reaction bookkeeping.
+
+A typical `agent-stuck` config:
+
+```yaml
+reactions:
+  agent-stuck:
+    auto: true
+    action: notify
+    priority: warning
+    threshold: 10m          # Phase H: parsed lazily per tick
+  ci-failed:
+    auto: true
+    action: send-to-agent
+    message: "CI failed. Fix it and push."
+    retries: 3
+    escalate_after: 5m      # Phase H: duration form now honoured
+```
+
+With that config, a session that goes idle in `Working` for more than
+10 minutes flips to `Stuck` on the next tick and fires the `Notify`
+action. The moment the agent produces any `Active`/`Ready` activity
+again, step 4 of `poll_one` flips `Stuck → Working`,
+`clear_tracker_on_transition` wipes the `agent-stuck` tracker via
+`status_to_reaction_key(Stuck)`, and the `idle_since` entry gets
+removed — the next idle streak starts from a fresh clock.
 
 ## What is a "reaction"?
 

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -75,7 +75,7 @@ active ↔ ready ↔ idle      waiting_input     blocked     exited (terminal)
 | `blocked` | Hit an error or is stuck |
 | `exited` | Process is gone — terminal |
 
-## Transitions currently implemented (through Phase F)
+## Transitions currently implemented (through Phase H)
 
 `lifecycle.rs::poll_one` handles these transitions per tick:
 
@@ -84,8 +84,15 @@ active ↔ ready ↔ idle      waiting_input     blocked     exited (terminal)
 3. **Activity probe.** `Agent::detect_activity(session)`.
    - If `Exited`, `terminate(AgentExited)`.
    - Else persist and emit `ActivityChanged` if it differs from the last-seen value.
-4. **Happy-path status flip.** If `status == Spawning` **and**
-   `activity ∈ {Active, Ready}`, transition to `Working`.
+   - Then update the `idle_since` bookkeeping: `Idle`/`Blocked` insert
+     (or preserve) a per-session `Instant`, anything else removes the
+     entry so the next idle streak restarts the clock.
+4. **Happy-path status flip.** If `status ∈ {Spawning, Stuck}` **and**
+   `activity ∈ {Active, Ready}`, transition to `Working`. The `Stuck`
+   arm is the Phase H recovery edge — an agent that just started
+   producing activity again exits the stuck parking state immediately.
+   `clear_tracker_on_transition` takes care of clearing the
+   `agent-stuck` tracker via `status_to_reaction_key(Stuck)`.
 5. **SCM probe** *(Phase F, only when an `Scm` plugin is attached via
    `LifecycleManager::with_scm`)*. `poll_scm` calls `detect_pr` and, on
    hit, fans out in parallel (`tokio::join!`) to `pr_state`,
@@ -94,6 +101,11 @@ active ↔ ready ↔ idle      waiting_input     blocked     exited (terminal)
    refuse to transition on a partial observation. On success the
    four-tuple is folded into `ScmObservation` and handed to the pure
    `derive_scm_status` decision function.
+6. **Agent-stuck detection** *(Phase H, only when a reaction engine is
+   attached via `LifecycleManager::with_reaction_engine`)*. `check_stuck`
+   runs only if steps 4 and 5 left `session.status` untouched this tick
+   — see [Stuck detection (Phase H)](#stuck-detection-phase-h) for the
+   full gating and the "one transition per tick" invariant.
 
 Terminal sessions are skipped on the same tick they're observed.
 
@@ -223,6 +235,121 @@ Rust port we added the filter to stop `StatusChanged` spam, which had
 the side effect of trapping failed auto-merges in `mergeable` with no
 way to re-fire the reaction. `merge_failed` restores the retry
 behavior without removing the filter.
+
+## Stuck detection (Phase H)
+
+A session is "stuck" when the agent has produced no progress for
+longer than the operator-configured `agent-stuck.threshold`. The
+lifecycle owns the detection and the `ReactionEngine` owns the
+response.
+
+### Idle-since bookkeeping
+
+`LifecycleManager::idle_since: Mutex<HashMap<SessionId, Instant>>`
+records the wall-clock moment each session first entered an idle
+activity state. The `update_idle_since(session_id, activity)` helper
+runs unconditionally after step 3 ("persist ActivityChanged") on every
+tick:
+
+| Activity this tick | Effect on `idle_since` |
+| --- | --- |
+| `Idle`, `Blocked` | `or_insert(Instant::now())` — preserves an older entry if one exists so `elapsed()` grows monotonically across a streak. |
+| `Active`, `Ready`, `WaitingInput` | `remove` — the next idle streak restarts from zero. |
+| `Exited` | N/A — `poll_one` short-circuits to `terminate` before reaching this helper. |
+
+`terminate()` also removes the entry unconditionally (regardless of
+activity) so long-running `ao-rs watch` loops don't accumulate entries
+for every terminated session.
+
+### Stuck-eligible statuses
+
+Not every `SessionStatus` is eligible for a stuck flip. The
+`is_stuck_eligible` `const fn` in `lifecycle.rs` uses an **exhaustive
+match** (no `_ =>` wildcard) so adding a new `SessionStatus` variant
+fails the build until a stuck answer is committed for it — same
+pattern as `derive_scm_status`'s exhaustiveness test.
+
+| Stuck-eligible | Reason |
+| --- | --- |
+| `working` | canonical case — agent went silent mid-task |
+| `pr_open` | PR opened, no feedback loop |
+| `ci_failed` | agent is expected to iterate on the failure |
+| `review_pending` | agent waits for CI; if CI stalls too, that's stuck |
+| `changes_requested` | agent is expected to address feedback |
+| `approved` | waiting for CI/readiness but agent should still be active |
+| `mergeable` | awaiting auto-merge retry; idle here implies runtime trouble |
+
+| NOT stuck-eligible | Reason |
+| --- | --- |
+| `spawning` | not yet started; covered by spawn timeout, not stuck |
+| `idle` | status is already the idle marker |
+| `needs_input` | deliberately blocked on a human; separate reaction will cover it |
+| `stuck` | already stuck — avoid re-dispatch loops |
+| `merge_failed` | parked for the Phase G retry loop, not stuck on the agent |
+| `killed`, `terminated`, `done`, `cleanup`, `errored`, `merged` | terminal/post-terminal |
+
+### `check_stuck` five-guard decision
+
+`LifecycleManager::check_stuck(session)` runs as poll_one step 6 and
+early-returns silently in each of these cases:
+
+1. `!is_stuck_eligible(session.status)` — see the table above.
+2. No `idle_since` entry — the session isn't idle at all.
+3. No reaction engine attached, or no `agent-stuck` reaction
+   configured — stuck detection is disabled for this deployment.
+4. `threshold` missing or unparseable. Malformed strings log a
+   one-shot `tracing::warn!` via `ReactionEngine::warn_once_parse_failure`
+   keyed by `"agent-stuck.threshold"`.
+5. `idle_started.elapsed() <= threshold` — the clock hasn't run long
+   enough yet.
+
+Only when all five guards pass does `check_stuck` call
+`transition(session, Stuck)`, which in turn dispatches the
+`agent-stuck` reaction and emits `StatusChanged(prev → Stuck)` on
+the event bus.
+
+### One-transition-per-tick invariant
+
+Step 6 is gated on a pre-step-4 snapshot:
+
+```rust
+let pre_transition_status = session.status;
+// step 4 — Spawning/Stuck → Working
+// step 5 — poll_scm (may set CiFailed / ChangesRequested / …)
+if self.reaction_engine.is_some() && session.status == pre_transition_status {
+    self.check_stuck(&mut session).await?;
+}
+```
+
+This preserves the TS reference's `determineStatus` semantics: one
+status transition per poll cycle, max. A session whose PR just went
+red AND has been idle for two hours fires `ci-failed` this tick; next
+tick sees `CiFailed` (still stuck-eligible) and fires `agent-stuck`
+once the threshold keeps elapsing. Operators never see a
+`StatusChanged(Working → CiFailed)` immediately followed by
+`StatusChanged(CiFailed → Stuck)` on the same tick.
+
+### Stuck → Working recovery
+
+Step 4's first condition is `status ∈ {Spawning, Stuck}`. Recovery is
+instant: the moment `Agent::detect_activity` returns `Active` or
+`Ready`, the next tick flips the session back to `Working`,
+`clear_tracker_on_transition` clears the `agent-stuck` tracker (via
+`status_to_reaction_key(Stuck) = Some("agent-stuck")`), and
+`update_idle_since` removes the timestamp. The following tick is
+indistinguishable from a session that was never stuck.
+
+### Status flip is decoupled from reaction `auto`
+
+`check_stuck` calls `transition(Stuck)` whenever the threshold is
+configured, regardless of whether the reaction's `auto` flag is set.
+The `auto` flag only gates the *action* dispatch inside
+`ReactionEngine::dispatch` (`Notify`, `SendToAgent`, `AutoMerge`). This
+matches how `ci-failed`, `changes-requested`, and `approved-and-green`
+already work — status flip is lifecycle bookkeeping, action dispatch
+is reaction bookkeeping. Hiding the flip behind `auto` would create a
+silent "I know you're stuck but I won't tell you" mode that's worse
+than the current symmetry.
 
 ## Events the loop emits
 


### PR DESCRIPTION
## Summary
- **Agent-stuck detection.** `LifecycleManager::check_stuck` runs as the final step of `poll_one`, gated on a pre-transition status snapshot and a reaction engine being attached. Five-guard decision (stuck-eligible status → `idle_since` entry → `agent-stuck` config → parseable threshold → elapsed strictly exceeds threshold). `Stuck → Working` recovery extends the existing `Spawning → Working` activity branch; `idle_since` cleared in `terminate` to bound memory.
- **Duration-form `escalate_after`.** `reaction_engine::parse_duration` accepts TS regex `^\d+(s|m|h)$` (rejects compound/fractional). Parsed lazily per `dispatch` call against a new `TrackerState.first_triggered_at`. Malformed strings trigger a one-shot `tracing::warn!` via `warn_once_parse_failure` (deduped with `Mutex<HashSet<String>>`) and silently fall through so a typo can't wedge the engine.
- **Two cross-phase invariants enforced:** one-transition-per-tick (via `pre_transition_status` snapshot gate) and status flips decoupled from reaction `auto` flag.

## Test plan
- [x] `cargo test -p ao-core` — 157 passing (was 127 at Phase G)
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Rewind-`Instant` test pattern instead of real sleeps — deterministic and fast
- [x] `rust-reviewer` gate passed (three nits addressed: doc for rejected compound forms, `strictly exceeded` wording, `WaitingInput`/`Ready` coverage)

Docs updated: `state-machine.md` (new Stuck detection section), `reactions.md` (Phase H wiring), `architecture.md` (duration-escalate moved from open to answered).

🤖 Generated with [Claude Code](https://claude.com/claude-code)