### PR TITLE
feat: Slice 4 — desktop + Discord notifiers, e2e integration test

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -73,6 +73,8 @@ version = "0.0.1"
 dependencies = [
  "ao-core",
  "ao-plugin-agent-claude-code",
+ "ao-plugin-notifier-desktop",
+ "ao-plugin-notifier-discord",
  "ao-plugin-notifier-ntfy",
  "ao-plugin-notifier-stdout",
  "ao-plugin-runtime-tmux",
@@ -105,6 +107,30 @@ version = "0.0.1"
 dependencies = [
  "ao-core",
  "async-trait",
+]
+
+[[package]]
+name = "ao-plugin-notifier-desktop"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "notify-rust",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "ao-plugin-notifier-discord"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "reqwest",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]
@@ -174,6 +200,126 @@ dependencies = [
 ]
 
 [[package]]
+name = "async-broadcast"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-channel"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
+dependencies = [
+ "concurrent-queue",
+ "event-listener-strategy",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-executor"
+version = "1.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
+dependencies = [
+ "async-task",
+ "concurrent-queue",
+ "fastrand",
+ "futures-lite",
+ "pin-project-lite",
+ "slab",
+]
+
+[[package]]
+name = "async-io"
+version = "2.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
+dependencies = [
+ "autocfg",
+ "cfg-if",
+ "concurrent-queue",
+ "futures-io",
+ "futures-lite",
+ "parking",
+ "polling",
+ "rustix",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-lock"
+version = "3.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+dependencies = [
+ "event-listener",
+ "event-listener-strategy",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-process"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
+dependencies = [
+ "async-channel",
+ "async-io",
+ "async-lock",
+ "async-signal",
+ "async-task",
+ "blocking",
+ "cfg-if",
+ "event-listener",
+ "futures-lite",
+ "rustix",
+]
+
+[[package]]
+name = "async-recursion"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "async-signal"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
+dependencies = [
+ "async-io",
+ "async-lock",
+ "atomic-waker",
+ "cfg-if",
+ "futures-core",
+ "futures-io",
+ "rustix",
+ "signal-hook-registry",
+ "slab",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "async-task"
+version = "4.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
+
+[[package]]
 name = "async-trait"
 version = "0.1.89"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -191,6 +337,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
 
 [[package]]
+name = "autocfg"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+
+[[package]]
 name = "base64"
 version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -201,6 +353,28 @@ name = "bitflags"
 version = "2.11.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "843867be96c8daad0d758b57df9392b6d8d271134fce549de6ce169ff98a92af"
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
+]
+
+[[package]]
+name = "blocking"
+version = "1.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
+dependencies = [
+ "async-channel",
+ "async-task",
+ "futures-io",
+ "futures-lite",
+ "piper",
+]
 
 [[package]]
 name = "bumpalo"
@@ -283,10 +457,71 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1d07550c9036bf2ae0c684c4297d503f838287c83c53686d05370d0e139ae570"
 
 [[package]]
+name = "concurrent-queue"
+version = "2.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-utils"
+version = "0.8.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
+
+[[package]]
+name = "deranged"
+version = "0.5.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7cd812cc2bc1d69d4764bd80df88b4317eaef9e773c75226407d9bc0876b211c"
+dependencies = [
+ "powerfmt",
+]
+
+[[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "endi"
+version = "1.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
+
+[[package]]
+name = "enumflags2"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
+dependencies = [
+ "enumflags2_derive",
+ "serde",
+]
+
+[[package]]
+name = "enumflags2_derive"
+version = "0.7.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -308,6 +543,33 @@ dependencies = [
  "libc",
  "windows-sys 0.61.2",
 ]
+
+[[package]]
+name = "event-listener"
+version = "5.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+dependencies = [
+ "concurrent-queue",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "event-listener-strategy"
+version = "0.5.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+dependencies = [
+ "event-listener",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "fastrand"
+version = "2.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
 name = "find-msvc-tools"
@@ -344,6 +606,25 @@ name = "futures-core"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7e3450815272ef58cec6d564423f6e755e25379b217b0bc688e295ba24df6b1d"
+
+[[package]]
+name = "futures-io"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
+
+[[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
 
 [[package]]
 name = "futures-macro"
@@ -441,6 +722,18 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "hermit-abi"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+
+[[package]]
+name = "hex"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "http"
@@ -721,6 +1014,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "linux-raw-sys"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32a66949e030da00e8c7d4434b251670a91556f4144941d37452769c25d58a53"
+
+[[package]]
 name = "litemap"
 version = "0.8.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -748,6 +1047,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
+name = "mac-notification-sys"
+version = "0.6.12"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29a16783dd1a47849b8c8133c9cd3eb2112cfbc6901670af3dba47c8bbfb07d3"
+dependencies = [
+ "cc",
+ "objc2",
+ "objc2-foundation",
+ "time",
+]
+
+[[package]]
 name = "matchers"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -763,6 +1074,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
+name = "memoffset"
+version = "0.9.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "mio"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -774,12 +1094,71 @@ dependencies = [
 ]
 
 [[package]]
+name = "notify-rust"
+version = "4.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b2c9bc1689653cfbc04400b8719f2562638ff9c545bbd48cc58c657a14526df"
+dependencies = [
+ "futures-lite",
+ "log",
+ "mac-notification-sys",
+ "serde",
+ "tauri-winrt-notification",
+ "zbus",
+]
+
+[[package]]
 name = "nu-ansi-term"
 version = "0.50.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
 dependencies = [
  "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "num-conv"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6673768db2d862beb9b39a78fdcb1a69439615d5794a1be50caa9bc92c81967"
+
+[[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
+name = "objc2-core-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
+dependencies = [
+ "bitflags",
+ "dispatch2",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -793,6 +1172,22 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "ordered-stream"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
+dependencies = [
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "parking"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -814,7 +1209,7 @@ dependencies = [
  "libc",
  "redox_syscall",
  "smallvec",
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -830,6 +1225,31 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
+name = "piper"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
+dependencies = [
+ "atomic-waker",
+ "fastrand",
+ "futures-io",
+]
+
+[[package]]
+name = "polling"
+version = "3.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
+dependencies = [
+ "cfg-if",
+ "concurrent-queue",
+ "hermit-abi",
+ "pin-project-lite",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "potential_utf"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -837,6 +1257,12 @@ checksum = "0103b1cef7ec0cf76490e969665504990193874ea05c85ff9bab8b911d0a0564"
 dependencies = [
  "zerovec",
 ]
+
+[[package]]
+name = "powerfmt"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
@@ -858,12 +1284,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.106"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
 dependencies = [
  "unicode-ident",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.37.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "331e97a1af0bf59823e6eadffe373d7b27f485be8748f71471c662c1f269b7fb"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -1056,6 +1500,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "94300abf3f1ae2e2b8ffb7b58043de3d399c73fa6f4b73826402a5c457614dbe"
 
 [[package]]
+name = "rustix"
+version = "1.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6fe4565b9518b83ef4f91bb47ce29620ca828bd32cb7e408f0062e9930ba190"
+dependencies = [
+ "bitflags",
+ "errno",
+ "libc",
+ "linux-raw-sys",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "rustls"
 version = "0.23.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1155,6 +1612,17 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_repr"
+version = "0.1.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "175ee3e80ae9982737ca543e96133087cbd9a485eecc3bc4de9c1a37b47ea59c"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
 ]
 
 [[package]]
@@ -1279,6 +1747,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "tauri-winrt-notification"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b1e66e07de489fe43a46678dd0b8df65e0c973909df1b60ba33874e297ba9b9"
+dependencies = [
+ "quick-xml",
+ "thiserror 2.0.18",
+ "windows",
+ "windows-version",
+]
+
+[[package]]
+name = "tempfile"
+version = "3.27.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
+dependencies = [
+ "fastrand",
+ "getrandom 0.4.2",
+ "once_cell",
+ "rustix",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "thiserror"
 version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1326,6 +1819,25 @@ checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
 dependencies = [
  "cfg-if",
 ]
+
+[[package]]
+name = "time"
+version = "0.3.47"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+dependencies = [
+ "deranged",
+ "num-conv",
+ "powerfmt",
+ "serde_core",
+ "time-core",
+]
+
+[[package]]
+name = "time-core"
+version = "0.1.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "tinystr"
@@ -1402,6 +1914,36 @@ dependencies = [
  "futures-util",
  "pin-project-lite",
  "tokio",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.11+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b59c4d22ed448339746c59b905d24568fcbb3ab65a500494f7b8c3e97739f2b"
+dependencies = [
+ "indexmap",
+ "toml_datetime",
+ "toml_parser",
+ "winnow 1.0.1",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.2+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2abe9b86193656635d2411dc43050282ca48aa31c2451210f4202550afb7526"
+dependencies = [
+ "winnow 1.0.1",
 ]
 
 [[package]]
@@ -1515,6 +2057,17 @@ name = "try-lock"
 version = "0.2.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
+
+[[package]]
+name = "uds_windows"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
+dependencies = [
+ "memoffset",
+ "tempfile",
+ "windows-sys 0.61.2",
+]
 
 [[package]]
 name = "unicode-ident"
@@ -1734,10 +2287,112 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows"
+version = "0.61.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9babd3a767a4c1aef6900409f85f5d53ce2544ccdfaa86dad48c91782c6d6893"
+dependencies = [
+ "windows-collections",
+ "windows-core",
+ "windows-future",
+ "windows-link 0.1.3",
+ "windows-numerics",
+]
+
+[[package]]
+name = "windows-collections"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3beeceb5e5cfd9eb1d76b381630e82c4241ccd0d27f1a39ed41b2760b255c5e8"
+dependencies = [
+ "windows-core",
+]
+
+[[package]]
+name = "windows-core"
+version = "0.61.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0fdd3ddb90610c7638aa2b3a3ab2904fb9e5cdbecc643ddb3647212781c4ae3"
+dependencies = [
+ "windows-implement",
+ "windows-interface",
+ "windows-link 0.1.3",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
+name = "windows-future"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc6a41e98427b19fe4b73c550f060b59fa592d7d686537eebf9385621bfbad8e"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+ "windows-threading",
+]
+
+[[package]]
+name = "windows-implement"
+version = "0.60.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-interface"
+version = "0.59.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "windows-link"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+
+[[package]]
 name = "windows-link"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0805222e57f7521d6a62e36fa9163bc891acd422f971defe97d64e70d0a4fe5"
+
+[[package]]
+name = "windows-numerics"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9150af68066c4c5c07ddc0ce30421554771e528bde427614c61038bc2c92c2b1"
+dependencies = [
+ "windows-core",
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-result"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-strings"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56e6c93f3a0c3b36176cb1327a4958a0353d5d166c2a35cb268ace15e91d3b57"
+dependencies = [
+ "windows-link 0.1.3",
+]
 
 [[package]]
 name = "windows-sys"
@@ -1763,7 +2418,7 @@ version = "0.61.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1788,7 +2443,7 @@ version = "0.53.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
- "windows-link",
+ "windows-link 0.2.1",
  "windows_aarch64_gnullvm 0.53.1",
  "windows_aarch64_msvc 0.53.1",
  "windows_i686_gnu 0.53.1",
@@ -1797,6 +2452,24 @@ dependencies = [
  "windows_x86_64_gnu 0.53.1",
  "windows_x86_64_gnullvm 0.53.1",
  "windows_x86_64_msvc 0.53.1",
+]
+
+[[package]]
+name = "windows-threading"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b66463ad2e0ea3bbf808b7f1d371311c80e115c0b71d60efc142cafbcfb057a6"
+dependencies = [
+ "windows-link 0.1.3",
+]
+
+[[package]]
+name = "windows-version"
+version = "0.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4060a1da109b9d0326b7262c8e12c84df67cc0dbc9e33cf49e01ccc2eb63631"
+dependencies = [
+ "windows-link 0.2.1",
 ]
 
 [[package]]
@@ -1894,6 +2567,24 @@ name = "windows_x86_64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09dac053f1cd375980747450bfc7250c264eaae0583872e845c0c7cd578872b5"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "wit-bindgen"
@@ -2013,6 +2704,67 @@ dependencies = [
 ]
 
 [[package]]
+name = "zbus"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
+dependencies = [
+ "async-broadcast",
+ "async-executor",
+ "async-io",
+ "async-lock",
+ "async-process",
+ "async-recursion",
+ "async-task",
+ "async-trait",
+ "blocking",
+ "enumflags2",
+ "event-listener",
+ "futures-core",
+ "futures-lite",
+ "hex",
+ "libc",
+ "ordered-stream",
+ "rustix",
+ "serde",
+ "serde_repr",
+ "tracing",
+ "uds_windows",
+ "uuid",
+ "windows-sys 0.61.2",
+ "winnow 0.7.15",
+ "zbus_macros",
+ "zbus_names",
+ "zvariant",
+]
+
+[[package]]
+name = "zbus_macros"
+version = "5.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zbus_names",
+ "zvariant",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zbus_names"
+version = "4.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
+dependencies = [
+ "serde",
+ "winnow 0.7.15",
+ "zvariant",
+]
+
+[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2097,3 +2849,43 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zvariant"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
+dependencies = [
+ "endi",
+ "enumflags2",
+ "serde",
+ "winnow 0.7.15",
+ "zvariant_derive",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_derive"
+version = "5.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "zvariant_utils",
+]
+
+[[package]]
+name = "zvariant_utils"
+version = "3.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde",
+ "syn",
+ "winnow 0.7.15",
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,8 @@ members = [
     "crates/ao-plugin-tracker-github",
     "crates/ao-plugin-notifier-stdout",
     "crates/ao-plugin-notifier-ntfy",
+    "crates/ao-plugin-notifier-desktop",
+    "crates/ao-plugin-notifier-discord",
 ]
 
 [workspace.package]

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -17,6 +17,8 @@ ao-plugin-agent-claude-code = { path = "../ao-plugin-agent-claude-code" }
 ao-plugin-scm-github = { path = "../ao-plugin-scm-github" }
 ao-plugin-notifier-stdout = { path = "../ao-plugin-notifier-stdout" }
 ao-plugin-notifier-ntfy = { path = "../ao-plugin-notifier-ntfy" }
+ao-plugin-notifier-desktop = { path = "../ao-plugin-notifier-desktop" }
+ao-plugin-notifier-discord = { path = "../ao-plugin-notifier-discord" }
 
 tokio = { workspace = true }
 clap = { version = "4", features = ["derive"] }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -18,6 +18,8 @@ use ao_core::{
     SessionStatus, Workspace, WorkspaceCreateConfig,
 };
 use ao_plugin_agent_claude_code::ClaudeCodeAgent;
+use ao_plugin_notifier_desktop::DesktopNotifier;
+use ao_plugin_notifier_discord::DiscordNotifier;
 use ao_plugin_notifier_ntfy::NtfyNotifier;
 use ao_plugin_notifier_stdout::StdoutNotifier;
 use ao_plugin_runtime_tmux::TmuxRuntime;
@@ -641,6 +643,14 @@ async fn watch(interval: Duration) -> Result<(), Box<dyn std::error::Error>> {
     if let Ok(topic) = std::env::var("AO_NTFY_TOPIC") {
         let base = std::env::var("AO_NTFY_URL").unwrap_or_else(|_| "https://ntfy.sh".to_string());
         notifier_registry.register("ntfy", Arc::new(NtfyNotifier::with_base_url(topic, base)));
+    }
+
+    // Slice 4: register desktop notifier (always available).
+    notifier_registry.register("desktop", Arc::new(DesktopNotifier::new()));
+
+    // Slice 4: register discord if the AO_DISCORD_WEBHOOK_URL env var is set.
+    if let Ok(webhook_url) = std::env::var("AO_DISCORD_WEBHOOK_URL") {
+        notifier_registry.register("discord", Arc::new(DiscordNotifier::new(webhook_url)));
     }
 
     // Phase F wires SCM into both engines. `LifecycleManager` uses it to

--- a/crates/ao-core/tests/notification_flow.rs
+++ b/crates/ao-core/tests/notification_flow.rs
@@ -1,0 +1,479 @@
+//! End-to-end integration test: lifecycle → reaction engine → notifier.
+//!
+//! Exercises the full notification pipeline using mock plugins and a
+//! recording notifier. Proves that a status transition dispatches the
+//! right reaction and the notifier registry delivers to the right
+//! plugins.
+
+use ao_core::{
+    error::Result,
+    events::OrchestratorEvent,
+    lifecycle::LifecycleManager,
+    notifier::{
+        NotificationPayload, NotificationRouting, Notifier, NotifierError, NotifierRegistry,
+    },
+    reaction_engine::ReactionEngine,
+    reactions::{EventPriority, ReactionAction, ReactionConfig},
+    scm::{CiStatus, MergeReadiness, PrState, PullRequest, ReviewDecision},
+    session_manager::SessionManager,
+    traits::{Agent, Runtime, Scm},
+    types::{ActivityState, Session, SessionId, SessionStatus},
+};
+use async_trait::async_trait;
+use std::collections::{HashMap, HashSet};
+use std::path::PathBuf;
+use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
+use std::sync::{Arc, Mutex};
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+static DIR_COUNTER: AtomicUsize = AtomicUsize::new(0);
+
+fn unique_temp_dir(label: &str) -> PathBuf {
+    let n = DIR_COUNTER.fetch_add(1, Ordering::Relaxed);
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    std::env::temp_dir().join(format!("ao-e2e-{label}-{nanos}-{n}"))
+}
+
+fn fake_session(short: &str, project: &str) -> Session {
+    Session {
+        id: SessionId(format!("{short}-0000-0000-0000-000000000000")),
+        project_id: project.to_string(),
+        status: SessionStatus::Working,
+        branch: format!("ao-{short}"),
+        task: "test task".to_string(),
+        workspace_path: Some(PathBuf::from("/tmp/fake-ws")),
+        runtime_handle: Some(format!("tmux-{short}")),
+        activity: Some(ActivityState::Ready),
+        created_at: ao_core::now_ms(),
+    }
+}
+
+fn fake_pr() -> PullRequest {
+    PullRequest {
+        number: 42,
+        title: "fix tests".to_string(),
+        branch: "ao-test".to_string(),
+        base_branch: "main".to_string(),
+        url: "https://github.com/test/test/pull/42".to_string(),
+        owner: "test".to_string(),
+        repo: "test".to_string(),
+        is_draft: false,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Mock plugins
+// ---------------------------------------------------------------------------
+
+struct MockRuntime {
+    alive: AtomicBool,
+}
+
+impl MockRuntime {
+    fn new() -> Self {
+        Self {
+            alive: AtomicBool::new(true),
+        }
+    }
+}
+
+#[async_trait]
+impl Runtime for MockRuntime {
+    async fn create(
+        &self,
+        _id: &str,
+        _cwd: &std::path::Path,
+        _cmd: &str,
+        _env: &[(String, String)],
+    ) -> Result<String> {
+        Ok("mock-handle".into())
+    }
+    async fn send_message(&self, _handle: &str, _msg: &str) -> Result<()> {
+        Ok(())
+    }
+    async fn is_alive(&self, _handle: &str) -> Result<bool> {
+        Ok(self.alive.load(Ordering::SeqCst))
+    }
+    async fn destroy(&self, _handle: &str) -> Result<()> {
+        Ok(())
+    }
+}
+
+struct MockAgent;
+
+#[async_trait]
+impl Agent for MockAgent {
+    fn launch_command(&self, _s: &Session) -> String {
+        "echo mock".into()
+    }
+    fn environment(&self, _s: &Session) -> Vec<(String, String)> {
+        vec![]
+    }
+    fn initial_prompt(&self, _s: &Session) -> String {
+        "mock prompt".into()
+    }
+    async fn detect_activity(&self, _s: &Session) -> Result<ActivityState> {
+        Ok(ActivityState::Ready)
+    }
+}
+
+struct MockScm {
+    pr: Mutex<Option<PullRequest>>,
+    ci: Mutex<CiStatus>,
+}
+
+impl MockScm {
+    fn new() -> Self {
+        Self {
+            pr: Mutex::new(None),
+            ci: Mutex::new(CiStatus::Passing),
+        }
+    }
+
+    fn set_pr(&self, pr: Option<PullRequest>) {
+        *self.pr.lock().unwrap() = pr;
+    }
+
+    fn set_ci(&self, ci: CiStatus) {
+        *self.ci.lock().unwrap() = ci;
+    }
+}
+
+#[async_trait]
+impl Scm for MockScm {
+    fn name(&self) -> &str {
+        "mock-scm"
+    }
+    async fn detect_pr(&self, _s: &Session) -> Result<Option<PullRequest>> {
+        Ok(self.pr.lock().unwrap().clone())
+    }
+    async fn pr_state(&self, _pr: &PullRequest) -> Result<PrState> {
+        Ok(PrState::Open)
+    }
+    async fn ci_checks(&self, _pr: &PullRequest) -> Result<Vec<ao_core::scm::CheckRun>> {
+        Ok(vec![])
+    }
+    async fn ci_status(&self, _pr: &PullRequest) -> Result<CiStatus> {
+        Ok(*self.ci.lock().unwrap())
+    }
+    async fn reviews(&self, _pr: &PullRequest) -> Result<Vec<ao_core::scm::Review>> {
+        Ok(vec![])
+    }
+    async fn review_decision(&self, _pr: &PullRequest) -> Result<ReviewDecision> {
+        Ok(ReviewDecision::None)
+    }
+    async fn pending_comments(
+        &self,
+        _pr: &PullRequest,
+    ) -> Result<Vec<ao_core::scm::ReviewComment>> {
+        Ok(vec![])
+    }
+    async fn mergeability(&self, _pr: &PullRequest) -> Result<MergeReadiness> {
+        Ok(MergeReadiness {
+            mergeable: false,
+            ci_passing: false,
+            approved: false,
+            no_conflicts: true,
+            blockers: vec!["test".into()],
+        })
+    }
+    async fn merge(
+        &self,
+        _pr: &PullRequest,
+        _method: Option<ao_core::scm::MergeMethod>,
+    ) -> Result<()> {
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Recording + failing notifiers
+// ---------------------------------------------------------------------------
+
+struct RecordingNotifier {
+    payloads: Mutex<Vec<NotificationPayload>>,
+}
+
+impl RecordingNotifier {
+    fn new() -> Self {
+        Self {
+            payloads: Mutex::new(Vec::new()),
+        }
+    }
+
+    fn recorded(&self) -> Vec<NotificationPayload> {
+        self.payloads.lock().unwrap().clone()
+    }
+}
+
+#[async_trait]
+impl Notifier for RecordingNotifier {
+    fn name(&self) -> &str {
+        "recorder"
+    }
+    async fn send(&self, payload: &NotificationPayload) -> std::result::Result<(), NotifierError> {
+        self.payloads.lock().unwrap().push(payload.clone());
+        Ok(())
+    }
+}
+
+struct FailingNotifier;
+
+#[async_trait]
+impl Notifier for FailingNotifier {
+    fn name(&self) -> &str {
+        "fail"
+    }
+    async fn send(&self, _payload: &NotificationPayload) -> std::result::Result<(), NotifierError> {
+        Err(NotifierError::Io("intentional test failure".into()))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Setup helper
+// ---------------------------------------------------------------------------
+
+struct TestHarness {
+    lifecycle: LifecycleManager,
+    sessions: Arc<SessionManager>,
+    scm: Arc<MockScm>,
+    recorder: Arc<RecordingNotifier>,
+    _base: PathBuf,
+}
+
+async fn setup(
+    label: &str,
+    reaction_config: HashMap<String, ReactionConfig>,
+    routing: HashMap<EventPriority, Vec<String>>,
+    extra_notifiers: Vec<(String, Arc<dyn Notifier>)>,
+) -> TestHarness {
+    let base = unique_temp_dir(label);
+    std::fs::create_dir_all(base.join("sessions/test")).unwrap();
+
+    let sessions = Arc::new(SessionManager::new(base.clone()));
+    let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new());
+    let agent: Arc<dyn Agent> = Arc::new(MockAgent);
+    let scm: Arc<MockScm> = Arc::new(MockScm::new());
+
+    let lifecycle = LifecycleManager::new(sessions.clone(), runtime.clone(), agent);
+
+    // Build notifier registry with routing and recorder.
+    let mut registry = NotifierRegistry::new(NotificationRouting::from_map(routing));
+    let recorder = Arc::new(RecordingNotifier::new());
+    registry.register("recorder", recorder.clone());
+    for (name, notifier) in extra_notifiers {
+        registry.register(&name, notifier);
+    }
+
+    let engine = Arc::new(
+        ReactionEngine::new(reaction_config, runtime, lifecycle.events_sender())
+            .with_scm(scm.clone() as Arc<dyn Scm>)
+            .with_notifier_registry(registry),
+    );
+
+    let lifecycle = lifecycle
+        .with_reaction_engine(engine)
+        .with_scm(scm.clone() as Arc<dyn Scm>);
+
+    TestHarness {
+        lifecycle,
+        sessions,
+        scm,
+        recorder,
+        _base: base,
+    }
+}
+
+fn drain_events(
+    rx: &mut tokio::sync::broadcast::Receiver<OrchestratorEvent>,
+) -> Vec<OrchestratorEvent> {
+    let mut events = Vec::new();
+    while let Ok(e) = rx.try_recv() {
+        events.push(e);
+    }
+    events
+}
+
+// ---------------------------------------------------------------------------
+// Tests
+// ---------------------------------------------------------------------------
+
+/// Full chain: lifecycle tick → SCM detects CI failure → reaction engine
+/// dispatches ci-failed → notifier registry resolves → recorder receives.
+#[tokio::test]
+async fn lifecycle_tick_triggers_notify_through_to_plugin() {
+    let mut reactions = HashMap::new();
+    reactions.insert(
+        "ci-failed".to_string(),
+        ReactionConfig {
+            auto: true,
+            action: ReactionAction::Notify,
+            message: Some("CI broke, please fix".into()),
+            priority: Some(EventPriority::Action),
+            retries: None,
+            escalate_after: None,
+            threshold: None,
+            include_summary: false,
+        },
+    );
+
+    let mut routing = HashMap::new();
+    routing.insert(EventPriority::Action, vec!["recorder".to_string()]);
+
+    let h = setup("notify-e2e", reactions, routing, vec![]).await;
+
+    // Save a Working session, then set SCM to return a PR with failing CI.
+    let session = fake_session("e2e1", "test");
+    h.sessions.save(&session).await.unwrap();
+    h.scm.set_pr(Some(fake_pr()));
+    h.scm.set_ci(CiStatus::Failing);
+
+    // Tick the lifecycle — should transition Working → CiFailed.
+    let mut rx = h.lifecycle.subscribe();
+    let mut seen = HashSet::new();
+    h.lifecycle.tick(&mut seen).await.unwrap();
+
+    // Verify the recorder received the notification.
+    let recorded = h.recorder.recorded();
+    assert_eq!(recorded.len(), 1, "expected exactly one notification");
+    let p = &recorded[0];
+    assert_eq!(p.reaction_key, "ci-failed");
+    assert_eq!(p.priority, EventPriority::Action);
+    assert_eq!(p.body, "CI broke, please fix");
+    assert!(!p.escalated);
+    assert_eq!(p.action, ReactionAction::Notify);
+
+    // Verify events include StatusChanged and ReactionTriggered.
+    let events = drain_events(&mut rx);
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            OrchestratorEvent::StatusChanged {
+                from: SessionStatus::Working,
+                to: SessionStatus::CiFailed,
+                ..
+            }
+        )),
+        "expected StatusChanged Working→CiFailed"
+    );
+    assert!(
+        events.iter().any(|e| matches!(
+            e,
+            OrchestratorEvent::ReactionTriggered {
+                action: ReactionAction::Notify,
+                ..
+            }
+        )),
+        "expected ReactionTriggered with Notify"
+    );
+}
+
+/// Escalation path: send-to-agent with retries=0 immediately escalates
+/// on first attempt, falling through to dispatch_notify with escalated=true.
+#[tokio::test]
+async fn escalation_reaches_notifier_with_escalated_flag() {
+    let mut reactions = HashMap::new();
+    reactions.insert(
+        "ci-failed".to_string(),
+        ReactionConfig {
+            auto: true,
+            action: ReactionAction::SendToAgent,
+            message: Some("fix CI".into()),
+            priority: Some(EventPriority::Action),
+            retries: Some(0),
+            escalate_after: Some(ao_core::reactions::EscalateAfter::Attempts(0)),
+            threshold: None,
+            include_summary: false,
+        },
+    );
+
+    let mut routing = HashMap::new();
+    routing.insert(EventPriority::Action, vec!["recorder".to_string()]);
+
+    let h = setup("escalation-e2e", reactions, routing, vec![]).await;
+
+    let session = fake_session("esc1", "test");
+    h.sessions.save(&session).await.unwrap();
+    h.scm.set_pr(Some(fake_pr()));
+    h.scm.set_ci(CiStatus::Failing);
+
+    let mut rx = h.lifecycle.subscribe();
+    let mut seen = HashSet::new();
+    h.lifecycle.tick(&mut seen).await.unwrap();
+
+    // Verify the recorder received an escalated notification.
+    let recorded = h.recorder.recorded();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "expected exactly one escalated notification"
+    );
+    let p = &recorded[0];
+    assert!(p.escalated, "expected escalated=true");
+    assert_eq!(p.reaction_key, "ci-failed");
+
+    // Verify ReactionEscalated event was emitted.
+    let events = drain_events(&mut rx);
+    assert!(
+        events
+            .iter()
+            .any(|e| matches!(e, OrchestratorEvent::ReactionEscalated { .. })),
+        "expected ReactionEscalated event"
+    );
+}
+
+/// Partial failure: one notifier fails, the other still receives the payload.
+/// The lifecycle tick completes normally (no crash from the failing plugin).
+#[tokio::test]
+async fn partial_failure_one_plugin_fails_others_succeed() {
+    let mut reactions = HashMap::new();
+    reactions.insert(
+        "ci-failed".to_string(),
+        ReactionConfig {
+            auto: true,
+            action: ReactionAction::Notify,
+            message: Some("CI broke".into()),
+            priority: Some(EventPriority::Action),
+            retries: None,
+            escalate_after: None,
+            threshold: None,
+            include_summary: false,
+        },
+    );
+
+    // Route to both recorder and fail.
+    let mut routing = HashMap::new();
+    routing.insert(
+        EventPriority::Action,
+        vec!["recorder".to_string(), "fail".to_string()],
+    );
+
+    let extra: Vec<(String, Arc<dyn Notifier>)> =
+        vec![("fail".to_string(), Arc::new(FailingNotifier))];
+
+    let h = setup("partial-e2e", reactions, routing, extra).await;
+
+    let session = fake_session("pf1", "test");
+    h.sessions.save(&session).await.unwrap();
+    h.scm.set_pr(Some(fake_pr()));
+    h.scm.set_ci(CiStatus::Failing);
+
+    let mut seen = HashSet::new();
+    // Tick should complete without panicking, even though FailingNotifier errors.
+    h.lifecycle.tick(&mut seen).await.unwrap();
+
+    // Recorder still received the notification despite the failing sibling.
+    let recorded = h.recorder.recorded();
+    assert_eq!(
+        recorded.len(),
+        1,
+        "recorder should still receive notification"
+    );
+    assert_eq!(recorded[0].reaction_key, "ci-failed");
+}

--- a/crates/ao-plugin-notifier-desktop/Cargo.toml
+++ b/crates/ao-plugin-notifier-desktop/Cargo.toml
@@ -1,0 +1,15 @@
+[package]
+name = "ao-plugin-notifier-desktop"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+notify-rust = { version = "4.14", features = ["async"] }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/ao-plugin-notifier-desktop/src/lib.rs
+++ b/crates/ao-plugin-notifier-desktop/src/lib.rs
@@ -1,0 +1,168 @@
+//! Desktop notification plugin — Slice 4 Phase A.
+//!
+//! Delivers notifications via the OS notification daemon using the
+//! [`notify-rust`](https://docs.rs/notify-rust) crate. Works on macOS
+//! (Notification Center), Linux (libnotify / D-Bus), and Windows
+//! (toast notifications).
+//!
+//! ## Urgency (Linux/Windows only)
+//!
+//! On Linux and Windows, `notify-rust` supports urgency levels:
+//!
+//! | ao-rs | notify-rust | Escalated |
+//! |-------|-------------|-----------|
+//! | Urgent | Critical | Critical |
+//! | Action | Critical | Critical |
+//! | Warning | Normal | Critical |
+//! | Info | Low | Critical |
+//!
+//! macOS does not support urgency — notifications are displayed with
+//! the OS default styling. Escalated notifications still get the
+//! `[ESCALATED]` title prefix on all platforms.
+//!
+//! ## Error handling
+//!
+//! All `notify_rust::error::Error` variants map to
+//! `NotifierError::Unavailable` — desktop notification failures are
+//! almost always the notification daemon being unreachable (headless
+//! server, SSH session, daemon crashed).
+
+use ao_core::{
+    notifier::{NotificationPayload, Notifier, NotifierError},
+    reactions::EventPriority,
+};
+use async_trait::async_trait;
+use notify_rust::Notification;
+
+/// Notifier that shows OS-native desktop notifications.
+pub struct DesktopNotifier;
+
+impl DesktopNotifier {
+    pub fn new() -> Self {
+        Self
+    }
+}
+
+impl Default for DesktopNotifier {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Map `EventPriority` to a `notify_rust::Urgency` value.
+///
+/// Only used on Linux and Windows — macOS does not support urgency.
+#[cfg(not(target_os = "macos"))]
+fn urgency(priority: EventPriority, escalated: bool) -> notify_rust::Urgency {
+    use notify_rust::Urgency;
+    if escalated {
+        return Urgency::Critical;
+    }
+    match priority {
+        EventPriority::Urgent | EventPriority::Action => Urgency::Critical,
+        EventPriority::Warning => Urgency::Normal,
+        EventPriority::Info => Urgency::Low,
+    }
+}
+
+/// Build the notification with platform-appropriate settings.
+fn build_notification(
+    title: &str,
+    body: &str,
+    priority: EventPriority,
+    escalated: bool,
+) -> Notification {
+    let mut n = Notification::new();
+    n.summary(title).body(body);
+
+    // Urgency is only available on Linux and Windows.
+    #[cfg(not(target_os = "macos"))]
+    {
+        n.urgency(urgency(priority, escalated));
+    }
+
+    // Suppress unused-variable warning on macOS.
+    #[cfg(target_os = "macos")]
+    {
+        let _ = (priority, escalated);
+    }
+
+    n
+}
+
+#[async_trait]
+impl Notifier for DesktopNotifier {
+    fn name(&self) -> &str {
+        "desktop"
+    }
+
+    async fn send(&self, payload: &NotificationPayload) -> Result<(), NotifierError> {
+        let title = if payload.escalated {
+            format!("[ESCALATED] {}", payload.title)
+        } else {
+            payload.title.clone()
+        };
+
+        let notification =
+            build_notification(&title, &payload.body, payload.priority, payload.escalated);
+
+        // On Linux/Windows, use show_async() to avoid blocking the tokio runtime
+        // during D-Bus IPC. On macOS, show() is a fast native API call.
+        #[cfg(not(target_os = "macos"))]
+        notification
+            .show_async()
+            .await
+            .map_err(|e| NotifierError::Unavailable(format!("desktop notification failed: {e}")))?;
+
+        #[cfg(target_os = "macos")]
+        notification
+            .show()
+            .map_err(|e| NotifierError::Unavailable(format!("desktop notification failed: {e}")))?;
+
+        tracing::debug!("desktop notification sent");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_desktop() {
+        assert_eq!(DesktopNotifier::new().name(), "desktop");
+    }
+
+    #[test]
+    fn default_impl_works() {
+        let n: DesktopNotifier = Default::default();
+        assert_eq!(n.name(), "desktop");
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn urgency_mapping_covers_all_variants() {
+        use notify_rust::Urgency;
+        assert_eq!(urgency(EventPriority::Urgent, false), Urgency::Critical);
+        assert_eq!(urgency(EventPriority::Action, false), Urgency::Critical);
+        assert_eq!(urgency(EventPriority::Warning, false), Urgency::Normal);
+        assert_eq!(urgency(EventPriority::Info, false), Urgency::Low);
+    }
+
+    #[cfg(not(target_os = "macos"))]
+    #[test]
+    fn escalated_always_critical() {
+        use notify_rust::Urgency;
+        assert_eq!(urgency(EventPriority::Urgent, true), Urgency::Critical);
+        assert_eq!(urgency(EventPriority::Action, true), Urgency::Critical);
+        assert_eq!(urgency(EventPriority::Warning, true), Urgency::Critical);
+        assert_eq!(urgency(EventPriority::Info, true), Urgency::Critical);
+    }
+
+    #[test]
+    fn build_notification_sets_title_and_body() {
+        let n = build_notification("Test Title", "Test Body", EventPriority::Info, false);
+        assert_eq!(n.summary, "Test Title");
+        assert_eq!(n.body, "Test Body");
+    }
+}

--- a/crates/ao-plugin-notifier-discord/Cargo.toml
+++ b/crates/ao-plugin-notifier-discord/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "ao-plugin-notifier-discord"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }

--- a/crates/ao-plugin-notifier-discord/src/lib.rs
+++ b/crates/ao-plugin-notifier-discord/src/lib.rs
@@ -1,0 +1,236 @@
+//! Discord webhook notifier plugin — Slice 4 Phase B.
+//!
+//! Delivers notifications via HTTP POST to a Discord webhook URL.
+//! Uses rich embeds with color-coded priority levels so notifications
+//! are visually scannable in a Discord channel.
+//!
+//! ## Configuration
+//!
+//! Construction takes a webhook URL (required), set once at startup
+//! via `ao-cli` from the `AO_DISCORD_WEBHOOK_URL` environment variable.
+//!
+//! ## Color mapping
+//!
+//! | ao-rs | Color | Hex |
+//! |-------|-------|-----|
+//! | Urgent | Red | #FF0000 |
+//! | Action | Orange | #FF8C00 |
+//! | Warning | Yellow | #FFD700 |
+//! | Info | Green | #00C853 |
+//!
+//! Escalated notifications always use red regardless of priority.
+//!
+//! ## Error handling
+//!
+//! Same pattern as the ntfy plugin:
+//! - Timeout → `NotifierError::Timeout`
+//! - Connection/DNS → `NotifierError::Unavailable`
+//! - Non-2xx → `NotifierError::Service { status, body }`
+//!
+//! ## Rate limiting
+//!
+//! Discord webhooks allow ~30 requests per minute. At the default 5s
+//! poll interval with a small session fleet, this is not a concern.
+//! The plugin does not implement its own rate limiting.
+
+use ao_core::{
+    notifier::{NotificationPayload, Notifier, NotifierError},
+    reactions::EventPriority,
+};
+use async_trait::async_trait;
+use serde::Serialize;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 5;
+
+/// Discord embed color constants (decimal RGB).
+const COLOR_RED: u32 = 0xFF0000;
+const COLOR_ORANGE: u32 = 0xFF8C00;
+const COLOR_YELLOW: u32 = 0xFFD700;
+const COLOR_GREEN: u32 = 0x00C853;
+
+/// Notifier that POSTs to a Discord webhook.
+pub struct DiscordNotifier {
+    webhook_url: String,
+    client: reqwest::Client,
+}
+
+impl DiscordNotifier {
+    /// Create a notifier for the given Discord webhook URL.
+    pub fn new(webhook_url: impl Into<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .expect("failed to build reqwest client");
+        Self {
+            webhook_url: webhook_url.into(),
+            client,
+        }
+    }
+
+    /// Exposed for testing.
+    pub fn webhook_url(&self) -> &str {
+        &self.webhook_url
+    }
+}
+
+/// Map `EventPriority` to a Discord embed color.
+pub(crate) fn embed_color(priority: EventPriority, escalated: bool) -> u32 {
+    if escalated {
+        return COLOR_RED;
+    }
+    match priority {
+        EventPriority::Urgent => COLOR_RED,
+        EventPriority::Action => COLOR_ORANGE,
+        EventPriority::Warning => COLOR_YELLOW,
+        EventPriority::Info => COLOR_GREEN,
+    }
+}
+
+// --- Discord webhook JSON types (private) ---
+
+#[derive(Serialize)]
+struct WebhookPayload {
+    #[serde(skip_serializing_if = "Option::is_none")]
+    content: Option<String>,
+    embeds: Vec<Embed>,
+}
+
+#[derive(Serialize)]
+struct Embed {
+    title: String,
+    description: String,
+    color: u32,
+    footer: Footer,
+}
+
+#[derive(Serialize)]
+struct Footer {
+    text: String,
+}
+
+#[async_trait]
+impl Notifier for DiscordNotifier {
+    fn name(&self) -> &str {
+        "discord"
+    }
+
+    async fn send(&self, payload: &NotificationPayload) -> Result<(), NotifierError> {
+        let title = if payload.escalated {
+            format!("[ESCALATED] {}", payload.title)
+        } else {
+            payload.title.clone()
+        };
+
+        let content = if payload.escalated {
+            Some("Escalated notification — retries exhausted".to_string())
+        } else {
+            None
+        };
+
+        let body = WebhookPayload {
+            content,
+            embeds: vec![Embed {
+                title,
+                description: payload.body.clone(),
+                color: embed_color(payload.priority, payload.escalated),
+                footer: Footer {
+                    text: format!(
+                        "ao-rs | {} | {}",
+                        payload.reaction_key,
+                        payload.priority.as_str()
+                    ),
+                },
+            }],
+        };
+
+        let response = self
+            .client
+            .post(&self.webhook_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    NotifierError::Timeout {
+                        elapsed_ms: DEFAULT_TIMEOUT_SECS * 1000,
+                    }
+                } else if e.is_connect() {
+                    NotifierError::Unavailable(format!("discord connection failed: {e}"))
+                } else {
+                    NotifierError::Io(format!("discord request failed: {e}"))
+                }
+            })?;
+
+        let status = response.status().as_u16();
+        if !response.status().is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".into());
+            return Err(NotifierError::Service {
+                status,
+                message: body,
+            });
+        }
+
+        tracing::debug!("discord notification sent");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn name_is_discord() {
+        let n = DiscordNotifier::new("https://discord.com/api/webhooks/test");
+        assert_eq!(n.name(), "discord");
+    }
+
+    #[test]
+    fn webhook_url_is_preserved() {
+        let url = "https://discord.com/api/webhooks/123/abc";
+        let n = DiscordNotifier::new(url);
+        assert_eq!(n.webhook_url(), url);
+    }
+
+    #[test]
+    fn color_mapping_covers_all_variants() {
+        assert_eq!(embed_color(EventPriority::Urgent, false), COLOR_RED);
+        assert_eq!(embed_color(EventPriority::Action, false), COLOR_ORANGE);
+        assert_eq!(embed_color(EventPriority::Warning, false), COLOR_YELLOW);
+        assert_eq!(embed_color(EventPriority::Info, false), COLOR_GREEN);
+    }
+
+    #[test]
+    fn escalated_color_is_always_red() {
+        assert_eq!(embed_color(EventPriority::Urgent, true), COLOR_RED);
+        assert_eq!(embed_color(EventPriority::Action, true), COLOR_RED);
+        assert_eq!(embed_color(EventPriority::Warning, true), COLOR_RED);
+        assert_eq!(embed_color(EventPriority::Info, true), COLOR_RED);
+    }
+
+    #[test]
+    fn embed_structure_serializes_correctly() {
+        let body = WebhookPayload {
+            content: None,
+            embeds: vec![Embed {
+                title: "CI failed".into(),
+                description: "Tests broke".into(),
+                color: COLOR_RED,
+                footer: Footer {
+                    text: "ao-rs | ci-failed | urgent".into(),
+                },
+            }],
+        };
+        let json = serde_json::to_value(&body).unwrap();
+        assert!(json["content"].is_null());
+        assert_eq!(json["embeds"][0]["title"], "CI failed");
+        assert_eq!(json["embeds"][0]["color"], COLOR_RED);
+        assert_eq!(
+            json["embeds"][0]["footer"]["text"],
+            "ao-rs | ci-failed | urgent"
+        );
+    }
+}


### PR DESCRIPTION
## Summary
- **Desktop notifier** (`notify-rust`): OS-native notifications with urgency mapping on Linux/Windows, `show_async()` to avoid blocking tokio, cfg-gated macOS support
- **Discord webhook notifier**: color-coded embeds by priority, env-var gated (`AO_DISCORD_WEBHOOK_URL`), same error-handling pattern as ntfy
- **E2E integration test**: exercises full lifecycle → reaction engine → notifier registry pipeline with mock plugins, covers escalation and partial-failure paths

## Test plan
- [x] 279 tests pass (`cargo test --workspace`)
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Rust reviewer gate passed (fixed 3 clippy findings + blocking I/O concern)

🤖 Generated with [Claude Code](https://claude.com/claude-code)