### PR TITLE
feat(api): add hello endpoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -12,6 +12,7 @@ members = [
     "crates/plugins/notifier-ntfy",
     "crates/plugins/notifier-desktop",
     "crates/plugins/notifier-discord",
+    "crates/ao-api",
 ]
 
 [workspace.package]
@@ -22,6 +23,7 @@ rust-version = "1.80"
 
 [workspace.dependencies]
 ao-core = { path = "crates/ao-core" }
+ao-api = { path = "crates/ao-api" }
 
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }

--- a/crates/ao-api/Cargo.toml
+++ b/crates/ao-api/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "ao-api"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+axum = "0.7"
+tokio = { workspace = true }
+
+[dev-dependencies]
+tower = "0.5"

--- a/crates/ao-api/src/lib.rs
+++ b/crates/ao-api/src/lib.rs
@@ -1,0 +1,42 @@
+use axum::{routing::get, Router};
+use std::net::SocketAddr;
+
+async fn hello() -> &'static str {
+    "Hello, ao-rs!"
+}
+
+pub fn router() -> Router {
+    Router::new().route("/hello", get(hello))
+}
+
+pub async fn serve(addr: SocketAddr) -> Result<(), std::io::Error> {
+    let listener = tokio::net::TcpListener::bind(addr).await?;
+    axum::serve(listener, router()).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use axum::body::Body;
+    use axum::http::{Request, StatusCode};
+    use tower::ServiceExt;
+
+    #[tokio::test]
+    async fn hello_endpoint_returns_greeting() {
+        let app = router();
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/hello")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        assert_eq!(&body[..], b"Hello, ao-rs!");
+    }
+}

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -11,6 +11,7 @@ path = "src/main.rs"
 
 [dependencies]
 ao-core = { workspace = true }
+ao-api = { workspace = true }
 ao-plugin-workspace-worktree = { path = "../plugins/workspace-worktree" }
 ao-plugin-runtime-tmux = { path = "../plugins/runtime-tmux" }
 ao-plugin-agent-claude-code = { path = "../plugins/agent-claude-code" }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -121,6 +121,13 @@ enum Command {
         #[command(subcommand)]
         action: SessionAction,
     },
+
+    /// Start the HTTP API server.
+    Serve {
+        /// Address to bind (e.g. 0.0.0.0:3000).
+        #[arg(long, default_value = "127.0.0.1:3000")]
+        addr: String,
+    },
 }
 
 #[derive(Subcommand)]
@@ -164,6 +171,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Session { action } => match action {
             SessionAction::Restore { session } => restore(session).await,
         },
+        Command::Serve { addr } => {
+            let addr: std::net::SocketAddr = addr.parse()?;
+            println!("Listening on http://{addr}");
+            ao_api::serve(addr).await?;
+            Ok(())
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- Adds new `ao-api` crate with a `/hello` GET endpoint using axum
- Wires it into the CLI as `ao-rs serve --addr 127.0.0.1:3000`
- Includes unit test verifying the endpoint returns `Hello, ao-rs!`

Closes #6

## Test plan
- [x] `cargo test -p ao-api` passes
- [x] `cargo clippy` clean
- [x] `cargo fmt --check` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)