### PR TITLE
feat: slices 7-12 + agent-cursor plugin

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,7 @@
 .DS_Store
 
 .claude
+CLAUDE.md
 .worktrees
 
 docs/ai

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -74,6 +74,7 @@ dependencies = [
  "ao-core",
  "ao-dashboard",
  "ao-plugin-agent-claude-code",
+ "ao-plugin-agent-cursor",
  "ao-plugin-notifier-desktop",
  "ao-plugin-notifier-discord",
  "ao-plugin-notifier-ntfy",
@@ -127,6 +128,16 @@ dependencies = [
  "async-trait",
  "filetime",
  "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "ao-plugin-agent-cursor"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
  "tokio",
  "tracing",
 ]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -125,6 +125,7 @@ version = "0.0.1"
 dependencies = [
  "ao-core",
  "async-trait",
+ "filetime",
  "serde_json",
  "tokio",
  "tracing",
@@ -645,6 +646,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f1f227452a390804cdb637b74a86990f2a7d7ba4b7d5693aac9b4dd6defd8d6"
 
 [[package]]
+name = "filetime"
+version = "0.2.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f98844151eee8917efc50bd9e8318cb963ae8b297431495d3f758616ea5c57db"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "libredox",
+]
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1094,6 +1106,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48f5d2a454e16a5ea0f4ced81bd44e4cfc7bd3a507b61887c99fd3538b28e4af"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "bitflags",
+ "libc",
+ "plain",
+ "redox_syscall 0.7.4",
+]
+
+[[package]]
 name = "linux-raw-sys"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1299,7 +1323,7 @@ checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
 dependencies = [
  "cfg-if",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.5.18",
  "smallvec",
  "windows-link 0.2.1",
 ]
@@ -1326,6 +1350,12 @@ dependencies = [
  "fastrand",
  "futures-io",
 ]
+
+[[package]]
+name = "plain"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
 name = "polling"
@@ -1512,6 +1542,15 @@ name = "redox_syscall"
 version = "0.5.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+dependencies = [
+ "bitflags",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f450ad9c3b1da563fb6948a8e0fb0fb9269711c9c73d9ea1de5058c79c8d643a"
 dependencies = [
  "bitflags",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/plugins/workspace-worktree",
     "crates/plugins/runtime-tmux",
     "crates/plugins/agent-claude-code",
+    "crates/plugins/agent-cursor",
     "crates/plugins/scm-github",
     "crates/plugins/tracker-github",
     "crates/plugins/notifier-stdout",

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -14,6 +14,7 @@ ao-core = { workspace = true }
 ao-plugin-workspace-worktree = { path = "../plugins/workspace-worktree" }
 ao-plugin-runtime-tmux = { path = "../plugins/runtime-tmux" }
 ao-plugin-agent-claude-code = { path = "../plugins/agent-claude-code" }
+ao-plugin-agent-cursor = { path = "../plugins/agent-cursor" }
 ao-plugin-scm-github = { path = "../plugins/scm-github" }
 ao-plugin-tracker-github = { path = "../plugins/tracker-github" }
 ao-plugin-notifier-stdout = { path = "../plugins/notifier-stdout" }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -7,6 +7,8 @@
 //!   - `watch`           — run the LifecycleManager and stream events to stdout
 //!   - `send`            — forward a message to a running session's agent
 //!   - `pr`              — inspect GitHub PR state + CI + review for a session
+//!   - `doctor`          — check environment: required tools, auth, config
+//!   - `review-check`    — scan PRs for new comments and forward to agents
 //!   - `session restore` — respawn a terminated session in-place
 //!
 //! `watch` is guarded by a pidfile at `~/.ao-rs/lifecycle.pid` so running
@@ -245,6 +247,29 @@ enum Command {
         dry_run: bool,
     },
 
+    /// Check that required tools and environment are healthy.
+    ///
+    /// Verifies: `git`, `gh`, `tmux`, `claude` on PATH; `gh auth status`;
+    /// config file loads; sessions directory exists. Reports PASS / WARN /
+    /// FAIL per check.
+    Doctor,
+
+    /// Scan active sessions' PRs for new review comments.
+    ///
+    /// For each non-terminal session that has a PR, fetches pending comments
+    /// via the SCM plugin. If new comments are found (compared to the last
+    /// check), sends a fix prompt to the agent. Use `--dry-run` to preview
+    /// without sending.
+    ReviewCheck {
+        /// Filter to a single project.
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Show what would be sent without actually messaging agents.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Session management subcommands.
     Session {
         #[command(subcommand)]
@@ -315,6 +340,8 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Pr { session } => pr(session).await,
         Command::Kill { session } => kill(session).await,
         Command::Cleanup { project, dry_run } => cleanup(project, dry_run).await,
+        Command::Doctor => doctor().await,
+        Command::ReviewCheck { project, dry_run } => review_check(project, dry_run).await,
         Command::Session { action } => match action {
             SessionAction::Restore { session } => restore(session).await,
             SessionAction::Attach { session } => attach(session).await,
@@ -1386,6 +1413,292 @@ async fn attach(session_id_or_prefix: String) -> Result<(), Box<dyn std::error::
         .args(["attach-session", "-t", handle])
         .exec();
     Err(format!("failed to exec tmux: {err}").into())
+}
+
+// ---- doctor ----------------------------------------------------------------
+
+/// `ao-rs doctor` — verify environment health.
+///
+/// Runs a series of checks and prints PASS / WARN / FAIL per check.
+/// Exit code 0 if all checks pass or warn, 1 if any check fails.
+async fn doctor() -> Result<(), Box<dyn std::error::Error>> {
+    println!("ao-rs doctor");
+    println!("────────────────────────────────────────");
+
+    let mut failures = 0u32;
+
+    // 1. Required CLI tools on PATH.
+    for tool in ["git", "gh", "tmux", "claude"] {
+        let status = which(tool).await;
+        match status {
+            ToolStatus::Found(path) => println!("  PASS  {tool:<10} {path}"),
+            ToolStatus::NotFound => {
+                println!("  FAIL  {tool:<10} not found on PATH");
+                failures += 1;
+            }
+        }
+    }
+
+    // 2. gh auth status — verify GitHub authentication.
+    let gh_auth = tokio::process::Command::new("gh")
+        .args(["auth", "status"])
+        .stdout(std::process::Stdio::null())
+        .stderr(std::process::Stdio::null())
+        .status()
+        .await;
+    match gh_auth {
+        Ok(s) if s.success() => println!("  PASS  {:<10} authenticated", "gh auth"),
+        Ok(_) => {
+            println!(
+                "  FAIL  {:<10} not authenticated (run `gh auth login`)",
+                "gh auth"
+            );
+            failures += 1;
+        }
+        Err(_) => {
+            println!("  WARN  {:<10} could not run `gh auth status`", "gh auth");
+        }
+    }
+
+    // 3. Config file loads without error.
+    let config_path = AoConfig::local_path();
+    match AoConfig::load_from_or_default(&config_path) {
+        Ok(cfg) => {
+            let projects = cfg.projects.len();
+            let reactions = cfg.reactions.len();
+            if config_path.exists() {
+                println!(
+                    "  PASS  {:<10} {} ({projects} project(s), {reactions} reaction(s))",
+                    "config",
+                    config_path.display()
+                );
+            } else {
+                println!(
+                    "  WARN  {:<10} no config file (run `ao-rs start`)",
+                    "config"
+                );
+            }
+        }
+        Err(e) => {
+            println!("  FAIL  {:<10} {} — {e}", "config", config_path.display());
+            failures += 1;
+        }
+    }
+
+    // 4. Sessions directory exists.
+    let sessions_dir = paths::default_sessions_dir();
+    if sessions_dir.is_dir() {
+        let count = SessionManager::with_default()
+            .list()
+            .await
+            .map(|s| s.len())
+            .unwrap_or(0);
+        println!(
+            "  PASS  {:<10} {} ({count} session(s))",
+            "sessions",
+            sessions_dir.display()
+        );
+    } else {
+        println!(
+            "  WARN  {:<10} {} does not exist yet",
+            "sessions",
+            sessions_dir.display()
+        );
+    }
+
+    println!("────────────────────────────────────────");
+    if failures > 0 {
+        println!("  {failures} check(s) FAILED");
+        std::process::exit(1);
+    } else {
+        println!("  all checks passed");
+    }
+
+    Ok(())
+}
+
+/// Check if a tool is on PATH.
+enum ToolStatus {
+    Found(String),
+    NotFound,
+}
+
+async fn which(tool: &str) -> ToolStatus {
+    let output = tokio::process::Command::new("which")
+        .arg(tool)
+        .output()
+        .await;
+    match output {
+        Ok(o) if o.status.success() => {
+            let path = String::from_utf8_lossy(&o.stdout).trim().to_string();
+            ToolStatus::Found(path)
+        }
+        _ => ToolStatus::NotFound,
+    }
+}
+
+// ---- review-check ----------------------------------------------------------
+
+/// `ao-rs review-check` — scan active sessions' PRs for new comments.
+///
+/// For each non-terminal session with a PR, fetches unresolved review
+/// comments via `Scm::pending_comments`. If any comments are found,
+/// sends a message to the agent prompting it to address them.
+///
+/// Comment fingerprinting: to avoid re-sending the same comments on
+/// every run, we hash the comment IDs and compare to a stored fingerprint
+/// in `~/.ao-rs/review-fingerprints/<session-id>`. Only sends when the
+/// fingerprint changes.
+async fn review_check(
+    project_filter: Option<String>,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let manager = SessionManager::with_default();
+    let all = manager.list().await?;
+
+    // Filter to non-terminal sessions, optionally by project.
+    let candidates: Vec<&Session> = all
+        .iter()
+        .filter(|s| !s.is_terminal())
+        .filter(|s| project_filter.as_ref().map_or(true, |p| s.project_id == *p))
+        .collect();
+
+    if candidates.is_empty() {
+        println!("no active sessions to check");
+        return Ok(());
+    }
+
+    use std::fmt::Write as _;
+
+    let scm = GitHubScm::new();
+    let runtime = TmuxRuntime::new();
+    let fingerprint_dir = paths::data_dir().join("review-fingerprints");
+
+    // Create fingerprint directory once, outside the loop.
+    if !dry_run {
+        tokio::fs::create_dir_all(&fingerprint_dir).await?;
+    }
+
+    let mut checked = 0u32;
+    let mut no_pr = 0u32;
+    let mut sent = 0u32;
+    let mut skipped = 0u32;
+    let mut errors = 0u32;
+
+    for session in &candidates {
+        let short = short_id(&session.id);
+
+        // Detect PR — skip sessions that haven't opened one yet.
+        let pr = match scm.detect_pr(session).await {
+            Ok(Some(pr)) => pr,
+            Ok(None) => {
+                no_pr += 1;
+                continue;
+            }
+            Err(e) => {
+                eprintln!("  {short}  error detecting PR: {e}");
+                errors += 1;
+                continue;
+            }
+        };
+        checked += 1;
+
+        // Fetch pending (unresolved) comments.
+        let comments = match scm.pending_comments(&pr).await {
+            Ok(c) => c,
+            Err(e) => {
+                eprintln!("  {short}  error fetching comments: {e}");
+                errors += 1;
+                continue;
+            }
+        };
+
+        if comments.is_empty() {
+            continue;
+        }
+
+        // Compute fingerprint from sorted comment IDs.
+        let mut ids: Vec<&str> = comments.iter().map(|c| c.id.as_str()).collect();
+        ids.sort();
+        let fingerprint = ids.join(",");
+
+        // Check if fingerprint changed since last run.
+        let fp_path = fingerprint_dir.join(format!("{}.txt", session.id.0));
+        let old_fp = tokio::fs::read_to_string(&fp_path)
+            .await
+            .unwrap_or_default();
+        if old_fp.trim() == fingerprint {
+            // Already sent for this set of comments.
+            skipped += 1;
+            continue;
+        }
+
+        // Format the review message using write! to avoid per-comment allocations.
+        let mut msg = format!(
+            "There are {} new review comment(s) on PR #{} that need your attention:\n\n",
+            comments.len(),
+            pr.number
+        );
+        for c in &comments {
+            let _ = write!(msg, "- @{}", c.author);
+            if let Some(ref path) = c.path {
+                let _ = write!(msg, " on `{path}`");
+                if let Some(line) = c.line {
+                    let _ = write!(msg, ":{line}");
+                }
+            }
+            let _ = writeln!(msg, ": {}", c.body.lines().next().unwrap_or(""));
+        }
+        msg.push_str(
+            "\nAddress each comment, push your changes, and mark conversations as resolved.",
+        );
+
+        if dry_run {
+            println!(
+                "  {short}  PR #{} — {} comment(s) (dry-run, not sending)",
+                pr.number,
+                comments.len()
+            );
+            println!("    would send: {}", msg.lines().next().unwrap_or(""));
+        } else {
+            // Send to agent via runtime.
+            if let Some(ref handle) = session.runtime_handle {
+                match runtime.send_message(handle, &msg).await {
+                    Ok(()) => {
+                        println!(
+                            "  {short}  PR #{} — sent {} comment(s) to agent",
+                            pr.number,
+                            comments.len()
+                        );
+                        sent += 1;
+                        // Persist fingerprint — failure is per-session, not fatal.
+                        if let Err(e) = tokio::fs::write(&fp_path, &fingerprint).await {
+                            eprintln!("  {short}  warning: failed to persist fingerprint: {e}");
+                        }
+                    }
+                    Err(e) => {
+                        eprintln!("  {short}  error sending message: {e}");
+                        errors += 1;
+                    }
+                }
+            } else {
+                eprintln!("  {short}  no runtime handle — skipping");
+                skipped += 1;
+            }
+        }
+    }
+
+    println!();
+    let mut summary = format!(
+        "review-check: {checked} PR(s) checked, {sent} sent, {skipped} skipped, {errors} error(s)"
+    );
+    if no_pr > 0 {
+        use std::fmt::Write as _;
+        let _ = write!(summary, ", {no_pr} without PR");
+    }
+    println!("{summary}");
+
+    Ok(())
 }
 
 /// `ao-rs session restore <session>` — respawn a terminated session in place.

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -32,6 +32,26 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
+/// Typed error for duplicate issue detection so `batch_spawn` can distinguish
+/// "skipped duplicate" from "real failure" without string matching.
+#[derive(Debug)]
+struct DuplicateIssue {
+    issue_id: String,
+    session_short: String,
+}
+
+impl std::fmt::Display for DuplicateIssue {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(
+            f,
+            "active session {} is already working on issue #{}. use --force to spawn anyway",
+            self.session_short, self.issue_id
+        )
+    }
+}
+
+impl std::error::Error for DuplicateIssue {}
+
 #[derive(Parser)]
 #[command(
     name = "ao-rs",
@@ -92,6 +112,43 @@ enum Command {
         /// Skip sending the initial prompt (useful when `claude` isn't installed).
         #[arg(long)]
         no_prompt: bool,
+
+        /// Spawn even if another active session is already working on the
+        /// same issue. Without this flag, `--issue` rejects duplicates.
+        #[arg(long)]
+        force: bool,
+    },
+
+    /// Spawn multiple sessions from a list of GitHub issue numbers.
+    ///
+    /// Sequentially spawns one session per issue, skipping any that already
+    /// have an active session (unless `--force` is set). Prints a summary
+    /// when done.
+    BatchSpawn {
+        /// One or more issue numbers (e.g. `42 43 44`).
+        #[arg(required = true)]
+        issues: Vec<String>,
+
+        /// Path to the git repo. Defaults to the current directory.
+        #[arg(long)]
+        repo: Option<PathBuf>,
+
+        /// Default branch of the repo, used as the worktree base.
+        #[arg(long, default_value = "main")]
+        default_branch: String,
+
+        /// Project id; namespaces worktrees under `~/.worktrees/<project>/`.
+        #[arg(long, default_value = "demo")]
+        project: String,
+
+        /// Skip sending the initial prompt (useful when `claude` isn't installed).
+        #[arg(long)]
+        no_prompt: bool,
+
+        /// Spawn even if another active session is already working on the
+        /// same issue.
+        #[arg(long)]
+        force: bool,
     },
 
     /// List all known sessions, newest first.
@@ -239,7 +296,16 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             default_branch,
             project,
             no_prompt,
-        } => spawn(task, issue, repo, default_branch, project, no_prompt).await,
+            force,
+        } => spawn(task, issue, repo, default_branch, project, no_prompt, force).await,
+        Command::BatchSpawn {
+            issues,
+            repo,
+            default_branch,
+            project,
+            no_prompt,
+            force,
+        } => batch_spawn(issues, repo, default_branch, project, no_prompt, force).await,
         Command::Status { project, pr, cost } => status(project, pr, cost).await,
         Command::Watch { interval } => watch(Duration::from_secs(interval)).await,
         Command::Dashboard { port, interval } => {
@@ -345,6 +411,7 @@ async fn spawn(
     default_branch: String,
     project: String,
     no_prompt: bool,
+    force: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ---- 1. Resolve repo path ----
     let repo_path = match repo {
@@ -359,6 +426,23 @@ async fn spawn(
     // Either --issue <n> (fetch from GitHub) or --task "..." (free-form).
     let (resolved_task, branch_prefix, resolved_issue_id, resolved_issue_url) =
         if let Some(ref id) = issue {
+            // Normalize: strip leading `#` so `#42` and `42` match the stored
+            // `issue_id` (which is always a bare number from `gh issue view`).
+            let normalized = id.strip_prefix('#').unwrap_or(id);
+
+            // Duplicate detection: reject if another active session is on this issue.
+            if !force {
+                let manager = SessionManager::with_default();
+                let dupes = manager.find_by_issue_id(normalized).await?;
+                if !dupes.is_empty() {
+                    let short = short_id(&dupes[0].id);
+                    return Err(DuplicateIssue {
+                        issue_id: normalized.to_string(),
+                        session_short: short,
+                    }
+                    .into());
+                }
+            }
             println!("→ fetching issue {}...", id);
             let tracker = GitHubTracker::from_repo(&repo_path).await?;
             let fetched = tracker.get_issue(id).await?;
@@ -498,6 +582,75 @@ async fn spawn(
     println!("───────────────────────────────────────────────");
 
     Ok(())
+}
+
+/// `ao-rs batch-spawn <issues...>` — spawn one session per issue.
+///
+/// Iterates the issue list sequentially, running the same spawn logic per
+/// issue. Skips duplicates (another active session on the same issue) unless
+/// `--force` is set. Prints a summary at the end.
+async fn batch_spawn(
+    issues: Vec<String>,
+    repo: Option<PathBuf>,
+    default_branch: String,
+    project: String,
+    no_prompt: bool,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let total = issues.len();
+    let mut created = 0u32;
+    let mut skipped = 0u32;
+    let mut failed = 0u32;
+
+    println!("→ batch-spawn: {} issue(s)", total);
+    println!();
+
+    for (i, issue_id) in issues.iter().enumerate() {
+        println!("── [{}/{}] issue #{issue_id} ──", i + 1, total);
+
+        match spawn(
+            None,
+            Some(issue_id.clone()),
+            repo.clone(),
+            default_branch.clone(),
+            project.clone(),
+            no_prompt,
+            force,
+        )
+        .await
+        {
+            Ok(()) => {
+                created += 1;
+            }
+            Err(e) => {
+                if e.downcast_ref::<DuplicateIssue>().is_some() {
+                    println!("  ⊘ skipped: {e}");
+                    skipped += 1;
+                } else {
+                    eprintln!("  ✗ failed: {e}");
+                    failed += 1;
+                }
+            }
+        }
+        println!();
+    }
+
+    println!("───────────────────────────────────────────────");
+    println!("  batch-spawn summary:");
+    println!("    created: {created}");
+    if skipped > 0 {
+        println!("    skipped: {skipped} (duplicate)");
+    }
+    if failed > 0 {
+        println!("    failed:  {failed}");
+    }
+    println!("───────────────────────────────────────────────");
+
+    if failed > 0 {
+        Err(format!("{failed} spawn(s) failed").into())
+    } else {
+        Ok(())
+    }
 }
 
 async fn status(

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -15,12 +15,14 @@
 //! it twice concurrently fails fast instead of racing two polling loops.
 
 use ao_core::{
-    build_prompt, generate_config, install_skills, now_ms, paths, restore_session, Agent, AoConfig,
-    CiStatus, LifecycleManager, LockError, MergeReadiness, NotificationRouting, NotifierRegistry,
-    OrchestratorEvent, PidFile, PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm,
-    Session, SessionId, SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
+    build_prompt, generate_config, install_skills, now_ms, paths, restore_session, Agent,
+    AgentConfig, AoConfig, CiStatus, LifecycleManager, LockError, MergeReadiness,
+    NotificationRouting, NotifierRegistry, OrchestratorEvent, PidFile, PrState, PullRequest,
+    ReactionEngine, ReviewDecision, Runtime, Scm, Session, SessionId, SessionManager,
+    SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
 use ao_plugin_agent_claude_code::ClaudeCodeAgent;
+use ao_plugin_agent_cursor::CursorAgent;
 use ao_plugin_notifier_desktop::DesktopNotifier;
 use ao_plugin_notifier_discord::DiscordNotifier;
 use ao_plugin_notifier_ntfy::NtfyNotifier;
@@ -53,6 +55,30 @@ impl std::fmt::Display for DuplicateIssue {
 }
 
 impl std::error::Error for DuplicateIssue {}
+
+/// Select an agent plugin by name, optionally reading rules from config.
+///
+/// Warns (but does not error) if the name is unknown — falls back to
+/// `claude-code` so that older configs still work.
+fn select_agent(name: &str, agent_config: Option<&AgentConfig>) -> Box<dyn Agent> {
+    match name {
+        "cursor" => match agent_config {
+            Some(cfg) => Box::new(CursorAgent::from_config(cfg)),
+            None => Box::new(CursorAgent::new()),
+        },
+        "claude-code" => match agent_config {
+            Some(cfg) => Box::new(ClaudeCodeAgent::from_config(cfg)),
+            None => Box::new(ClaudeCodeAgent::with_default_rules()),
+        },
+        _ => {
+            eprintln!("warning: unknown agent '{name}', falling back to claude-code");
+            match agent_config {
+                Some(cfg) => Box::new(ClaudeCodeAgent::from_config(cfg)),
+                None => Box::new(ClaudeCodeAgent::with_default_rules()),
+            }
+        }
+    }
+}
 
 #[derive(Parser)]
 #[command(
@@ -119,6 +145,11 @@ enum Command {
         /// same issue. Without this flag, `--issue` rejects duplicates.
         #[arg(long)]
         force: bool,
+
+        /// Agent plugin to use. Defaults to `claude-code`.
+        /// Supported: `claude-code`, `cursor`.
+        #[arg(long, default_value = "claude-code")]
+        agent: String,
     },
 
     /// Spawn multiple sessions from a list of GitHub issue numbers.
@@ -151,6 +182,11 @@ enum Command {
         /// same issue.
         #[arg(long)]
         force: bool,
+
+        /// Agent plugin to use. Defaults to `claude-code`.
+        /// Supported: `claude-code`, `cursor`.
+        #[arg(long, default_value = "claude-code")]
+        agent: String,
     },
 
     /// List all known sessions, newest first.
@@ -322,7 +358,20 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             project,
             no_prompt,
             force,
-        } => spawn(task, issue, repo, default_branch, project, no_prompt, force).await,
+            agent,
+        } => {
+            spawn(
+                task,
+                issue,
+                repo,
+                default_branch,
+                project,
+                no_prompt,
+                force,
+                agent,
+            )
+            .await
+        }
         Command::BatchSpawn {
             issues,
             repo,
@@ -330,7 +379,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             project,
             no_prompt,
             force,
-        } => batch_spawn(issues, repo, default_branch, project, no_prompt, force).await,
+            agent,
+        } => {
+            batch_spawn(
+                issues,
+                repo,
+                default_branch,
+                project,
+                no_prompt,
+                force,
+                agent,
+            )
+            .await
+        }
         Command::Status { project, pr, cost } => status(project, pr, cost).await,
         Command::Watch { interval } => watch(Duration::from_secs(interval)).await,
         Command::Dashboard { port, interval } => {
@@ -431,6 +492,7 @@ async fn start(repo: Option<PathBuf>) -> Result<(), Box<dyn std::error::Error>> 
     Ok(())
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn spawn(
     task: Option<String>,
     issue: Option<String>,
@@ -439,6 +501,7 @@ async fn spawn(
     project: String,
     no_prompt: bool,
     force: bool,
+    agent_name: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ---- 1. Resolve repo path ----
     let repo_path = match repo {
@@ -558,7 +621,8 @@ async fn spawn(
         manager.save(&session).await?;
 
         // ---- 4. Agent: get launch command + env ----
-        let agent = ClaudeCodeAgent::with_default_rules();
+        let agent_config = project_config.and_then(|p| p.agent_config.as_ref());
+        let agent: Box<dyn Agent> = select_agent(&agent_name, agent_config);
         let launch_command = agent.launch_command(&session);
         let env = agent.environment(&session);
         let initial_prompt = build_prompt(&session, project_config, issue_context.as_deref());
@@ -633,6 +697,7 @@ async fn batch_spawn(
     project: String,
     no_prompt: bool,
     force: bool,
+    agent_name: String,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let total = issues.len();
     let mut created = 0u32;
@@ -653,6 +718,7 @@ async fn batch_spawn(
             project.clone(),
             no_prompt,
             force,
+            agent_name.clone(),
         )
         .await
         {
@@ -1024,6 +1090,9 @@ async fn watch(interval: Duration) -> Result<(), Box<dyn std::error::Error>> {
 
     let sessions = Arc::new(SessionManager::with_default());
     let runtime: Arc<dyn Runtime> = Arc::new(TmuxRuntime::new());
+    // TODO: Hardcoded to ClaudeCodeAgent — sessions spawned with `--agent cursor`
+    // will get incorrect activity detection. Need to persist agent name in Session
+    // and reconstruct the right plugin here.
     let agent: Arc<dyn Agent> = Arc::new(ClaudeCodeAgent::with_default_rules());
     // Phase F: SCM plugin is compile-time GitHubScm. Zero-sized, so the
     // Arc here is just for trait-object uniformity with Runtime/Agent.
@@ -1167,6 +1236,8 @@ async fn dashboard(port: u16, interval: Duration) -> Result<(), Box<dyn std::err
 
     let sessions = Arc::new(SessionManager::with_default());
     let runtime: Arc<dyn Runtime> = Arc::new(TmuxRuntime::new());
+    // TODO: Hardcoded to ClaudeCodeAgent — same limitation as `watch`.
+    // Need agent name persisted in Session to reconstruct the right plugin.
     let agent: Arc<dyn Agent> = Arc::new(ClaudeCodeAgent::with_default_rules());
     let scm: Arc<dyn Scm> = Arc::new(GitHubScm::new());
 

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -163,6 +163,31 @@ enum Command {
         interval: u64,
     },
 
+    /// Kill a running session: stop the runtime, remove the worktree,
+    /// and archive the session file.
+    ///
+    /// Safe to run on already-terminal sessions — they get archived without
+    /// touching the (already gone) runtime.
+    Kill {
+        /// Session uuid or unambiguous prefix (e.g. an 8-char short id).
+        session: String,
+    },
+
+    /// Clean up terminal sessions: remove worktrees and archive YAML files.
+    ///
+    /// Scans all terminal sessions (killed, terminated, errored, merged, etc.)
+    /// and for each one removes the git worktree (if it still exists) and
+    /// moves the session YAML into `.archive/`. Use `--dry-run` to preview.
+    Cleanup {
+        /// Filter to a single project id.
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Show what would be cleaned up without actually doing it.
+        #[arg(long)]
+        dry_run: bool,
+    },
+
     /// Session management subcommands.
     Session {
         #[command(subcommand)]
@@ -179,6 +204,15 @@ enum SessionAction {
     /// identifier can be the full uuid or any unambiguous prefix.
     Restore {
         /// Full session uuid or a unique prefix (e.g. the 8-char short id).
+        session: String,
+    },
+
+    /// Attach to a session's tmux terminal.
+    ///
+    /// Resolves the session and execs `tmux attach-session -t <handle>`,
+    /// replacing the current process. Detach with `Ctrl-b d` as usual.
+    Attach {
+        /// Session uuid or unambiguous prefix.
         session: String,
     },
 }
@@ -213,8 +247,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         }
         Command::Send { session, message } => send(session, message).await,
         Command::Pr { session } => pr(session).await,
+        Command::Kill { session } => kill(session).await,
+        Command::Cleanup { project, dry_run } => cleanup(project, dry_run).await,
         Command::Session { action } => match action {
             SessionAction::Restore { session } => restore(session).await,
+            SessionAction::Attach { session } => attach(session).await,
         },
     }
 }
@@ -1017,6 +1054,175 @@ async fn dashboard(port: u16, interval: Duration) -> Result<(), Box<dyn std::err
     lifecycle_handle.stop().await;
     println!("→ stopped.");
     Ok(())
+}
+
+/// `ao-rs kill <session>` — stop the runtime, remove the worktree, archive.
+///
+/// Safe to run on already-terminal sessions: the runtime and worktree steps
+/// are best-effort (a missing tmux session or already-removed worktree just
+/// logs a warning), and the archive always runs.
+async fn kill(session_id_or_prefix: String) -> Result<(), Box<dyn std::error::Error>> {
+    let sessions = SessionManager::with_default();
+    let mut session = match sessions.find_by_prefix(&session_id_or_prefix).await {
+        Ok(s) => s,
+        Err(ao_core::AoError::SessionNotFound(_)) => {
+            // Check if already archived — give a clearer message than "not found".
+            let all_projects = sessions.list().await.unwrap_or_default();
+            // Collect unique project IDs to search archives.
+            let project_ids: std::collections::HashSet<_> =
+                all_projects.iter().map(|s| s.project_id.as_str()).collect();
+            for pid in project_ids {
+                let archived = sessions.list_archived(pid).await.unwrap_or_default();
+                if archived
+                    .iter()
+                    .any(|s| s.id.0.starts_with(&session_id_or_prefix))
+                {
+                    return Err(format!(
+                        "session {session_id_or_prefix} is already killed and archived"
+                    )
+                    .into());
+                }
+            }
+            return Err(ao_core::AoError::SessionNotFound(session_id_or_prefix.clone()).into());
+        }
+        Err(e) => return Err(e.into()),
+    };
+    let short = short_id(&session.id);
+
+    // 1. Kill runtime (best-effort — may already be gone).
+    if let Some(ref handle) = session.runtime_handle {
+        let runtime = TmuxRuntime::new();
+        match runtime.destroy(handle).await {
+            Ok(()) => println!("→ killed runtime {handle}"),
+            Err(e) => eprintln!("  warning: runtime destroy failed (may already be gone): {e}"),
+        }
+    }
+
+    // 2. Remove worktree (best-effort — destroy already handles missing dirs).
+    if let Some(ref ws) = session.workspace_path {
+        let workspace = WorktreeWorkspace::new();
+        match workspace.destroy(ws).await {
+            Ok(()) => println!("→ removed worktree {}", ws.display()),
+            Err(e) => eprintln!("  warning: worktree cleanup failed: {e}"),
+        }
+    }
+
+    // 3. Transition to Killed (unless already terminal).
+    if !session.status.is_terminal() {
+        session.status = SessionStatus::Killed;
+        sessions.save(&session).await?;
+    }
+
+    // 4. Archive — moves YAML from active dir to .archive/.
+    sessions.archive(&session).await?;
+
+    println!("→ session {short} killed and archived");
+    Ok(())
+}
+
+/// `ao-rs cleanup` — remove worktrees and archive terminal sessions.
+///
+/// Iterates every terminal session (optionally filtered by `--project`),
+/// removes the git worktree if it still exists on disk, and moves the
+/// session YAML into `.archive/`. `--dry-run` previews without acting.
+async fn cleanup(
+    project_filter: Option<String>,
+    dry_run: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let sessions = SessionManager::with_default();
+    let all = match &project_filter {
+        Some(p) => sessions.list_for_project(p).await?,
+        None => sessions.list().await?,
+    };
+
+    let terminal: Vec<_> = all.into_iter().filter(|s| s.is_terminal()).collect();
+
+    if terminal.is_empty() {
+        println!("no terminal sessions to clean up");
+        return Ok(());
+    }
+
+    let mut cleaned = 0u32;
+    let mut errors = 0u32;
+
+    for session in &terminal {
+        let short = short_id(&session.id);
+
+        if dry_run {
+            let ws_note = session
+                .workspace_path
+                .as_ref()
+                .filter(|p| p.exists())
+                .map(|p| format!(" (worktree: {})", p.display()))
+                .unwrap_or_default();
+            println!(
+                "  would clean: {short} ({}, {}){ws_note}",
+                session.project_id,
+                session.status.as_str(),
+            );
+            cleaned += 1;
+            continue;
+        }
+
+        // Remove worktree if still on disk.
+        if let Some(ref ws) = session.workspace_path {
+            if ws.exists() {
+                let workspace = WorktreeWorkspace::new();
+                match workspace.destroy(ws).await {
+                    Ok(()) => println!("  → removed worktree: {}", ws.display()),
+                    Err(e) => {
+                        eprintln!("  warning: worktree cleanup for {short}: {e}");
+                        errors += 1;
+                    }
+                }
+            }
+        }
+
+        // Archive session YAML.
+        match sessions.archive(session).await {
+            Ok(()) => {
+                println!("  → archived: {short}");
+                cleaned += 1;
+            }
+            Err(e) => {
+                eprintln!("  error archiving {short}: {e}");
+                errors += 1;
+            }
+        }
+    }
+
+    println!();
+    if dry_run {
+        println!("dry run: {cleaned} session(s) would be cleaned");
+    } else {
+        println!("cleaned: {cleaned}, errors: {errors}");
+    }
+    Ok(())
+}
+
+/// `ao-rs session attach <session>` — exec into a tmux session.
+///
+/// Replaces the current process with `tmux attach-session -t <handle>`.
+/// Detach with the usual `Ctrl-b d`.
+async fn attach(session_id_or_prefix: String) -> Result<(), Box<dyn std::error::Error>> {
+    let sessions = SessionManager::with_default();
+    let session = sessions.find_by_prefix(&session_id_or_prefix).await?;
+
+    let handle = session.runtime_handle.as_deref().ok_or_else(|| {
+        format!(
+            "session {} has no runtime handle (status={})",
+            short_id(&session.id),
+            session.status.as_str()
+        )
+    })?;
+
+    // exec() replaces the current process image — user is dropped straight
+    // into tmux. If it returns at all, the exec failed.
+    use std::os::unix::process::CommandExt;
+    let err = std::process::Command::new("tmux")
+        .args(["attach-session", "-t", handle])
+        .exec();
+    Err(format!("failed to exec tmux: {err}").into())
 }
 
 /// `ao-rs session restore <session>` — respawn a terminated session in place.

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -13,8 +13,8 @@
 //! it twice concurrently fails fast instead of racing two polling loops.
 
 use ao_core::{
-    generate_config, install_skills, now_ms, paths, restore_session, Agent, AoConfig, CiStatus,
-    LifecycleManager, LockError, MergeReadiness, NotificationRouting, NotifierRegistry,
+    build_prompt, generate_config, install_skills, now_ms, paths, restore_session, Agent, AoConfig,
+    CiStatus, LifecycleManager, LockError, MergeReadiness, NotificationRouting, NotifierRegistry,
     OrchestratorEvent, PidFile, PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm,
     Session, SessionId, SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
@@ -422,9 +422,14 @@ async fn spawn(
         return Err(format!("not a git repo: {}", repo_path.display()).into());
     }
 
-    // ---- 1b. Resolve task, branch, and issue metadata ----
+    // ---- 1b. Resolve task, branch, issue metadata, and project config ----
     // Either --issue <n> (fetch from GitHub) or --task "..." (free-form).
-    let (resolved_task, branch_prefix, resolved_issue_id, resolved_issue_url) =
+    //
+    // `resolved_task` is stored in `Session::task` for display in `ao-rs status`.
+    // For issue-first, it's just the title (the full issue body is rendered
+    // by the prompt builder via `Tracker::generate_prompt`).
+    // `issue_context` is the pre-formatted issue section for the prompt builder.
+    let (resolved_task, branch_prefix, resolved_issue_id, resolved_issue_url, issue_context) =
         if let Some(ref id) = issue {
             // Normalize: strip leading `#` so `#42` and `42` match the stored
             // `issue_id` (which is always a bare number from `gh issue view`).
@@ -447,21 +452,26 @@ async fn spawn(
             let tracker = GitHubTracker::from_repo(&repo_path).await?;
             let fetched = tracker.get_issue(id).await?;
             let branch = tracker.branch_name(id);
-            let task_body = if fetched.description.is_empty() {
-                fetched.title.clone()
-            } else {
-                format!("{}\n\n{}", fetched.title, fetched.description)
-            };
+            // Generate structured issue context via the tracker plugin's
+            // generate_prompt() — this is the extension point for custom
+            // formatting (Linear cycle info, Jira sprint fields, etc.).
+            let ctx = tracker.generate_prompt(&fetched);
             println!("  issue:     #{} — {}", fetched.id, fetched.title);
             (
-                task_body,
+                fetched.title.clone(),
                 Some(branch),
                 Some(fetched.id.clone()),
                 Some(fetched.url.clone()),
+                Some(ctx),
             )
         } else {
-            (task.unwrap(), None, None, None)
+            (task.unwrap(), None, None, None, None)
         };
+
+    // Load project config for the prompt builder. Non-fatal: if no config
+    // exists, the prompt builder still works — it just omits repo context.
+    let ao_config = AoConfig::load_from_or_default(&AoConfig::path_in(&repo_path)).ok();
+    let project_config = ao_config.as_ref().and_then(|c| c.projects.get(&project));
 
     // ---- 2. Allocate ids ----
     let session_id = SessionId::new();
@@ -524,7 +534,7 @@ async fn spawn(
         let agent = ClaudeCodeAgent::with_default_rules();
         let launch_command = agent.launch_command(&session);
         let env = agent.environment(&session);
-        let initial_prompt = agent.initial_prompt(&session);
+        let initial_prompt = build_prompt(&session, project_config, issue_context.as_deref());
 
         // ---- 5. Runtime: spawn tmux session running the agent ----
         let runtime = TmuxRuntime::new();

--- a/crates/ao-core/src/lib.rs
+++ b/crates/ao-core/src/lib.rs
@@ -6,6 +6,7 @@ pub mod lifecycle;
 pub mod lockfile;
 pub mod notifier;
 pub mod paths;
+pub mod prompt_builder;
 pub mod reaction_engine;
 pub mod reactions;
 pub mod restore;
@@ -26,6 +27,7 @@ pub use lockfile::{is_process_alive, read_pidfile, LockError, PidFile};
 pub use notifier::{
     NotificationPayload, NotificationRouting, Notifier, NotifierError, NotifierRegistry,
 };
+pub use prompt_builder::build_prompt;
 pub use reaction_engine::{status_to_reaction_key, ReactionEngine};
 pub use reactions::{
     EscalateAfter, EventPriority, ReactionAction, ReactionConfig, ReactionOutcome,

--- a/crates/ao-core/src/prompt_builder.rs
+++ b/crates/ao-core/src/prompt_builder.rs
@@ -1,0 +1,311 @@
+//! Structured prompt builder for agent sessions.
+//!
+//! Composes a three-layer initial prompt sent via `Runtime::send_message`
+//! after the agent process launches:
+//!
+//! 1. **Session context** — branch, project, repo slug, default branch.
+//! 2. **Issue context** (issue-first only) — title, description, labels,
+//!    assignee, URL formatted by `Tracker::generate_prompt()`.
+//! 3. **Task directive** — a closing instruction telling the agent what
+//!    to do with the above context.
+//!
+//! For `--task` (prompt-first) spawns, layer 2 is omitted and the raw
+//! task text becomes the body.
+//!
+//! ## Design: rules stay in the system prompt
+//!
+//! Agent workflow rules (dev-lifecycle phases, coding standards, testing
+//! requirements) are injected via `--append-system-prompt` on the agent's
+//! launch command — persistent system-level guidance, not per-task
+//! instructions. The prompt builder only composes the *user message*.
+
+use crate::config::ProjectConfig;
+use crate::scm::Issue;
+use crate::types::Session;
+
+/// Build a structured initial prompt for a session.
+///
+/// All parameters except `session` are optional — the builder degrades
+/// gracefully when context is missing:
+///
+/// - No `project`: omits repo/branch metadata (prompt-first without config).
+/// - No `issue_context`: uses `session.task` as a plain task directive
+///   (prompt-first).
+/// - Both `project` + `issue_context`: full structured prompt (issue-first).
+///
+/// `issue_context` is a pre-formatted string describing the issue. Callers
+/// produce it via `Tracker::generate_prompt(&issue)` (which lets tracker
+/// plugins add platform-specific context) or via the standalone
+/// [`format_issue_context`] helper.
+pub fn build_prompt(
+    session: &Session,
+    project: Option<&ProjectConfig>,
+    issue_context: Option<&str>,
+) -> String {
+    let mut sections: Vec<String> = Vec::new();
+
+    // Layer 1: session context
+    sections.push(format_session_context(session, project));
+
+    // Layer 2: issue context (issue-first only)
+    if let Some(ctx) = issue_context {
+        sections.push(ctx.to_string());
+    }
+
+    // Layer 3: task directive
+    // Issue-first is derived from session metadata, not from whether
+    // issue_context was passed — a session spawned with --issue always
+    // has issue_id set.
+    let is_issue_first = session.issue_id.is_some();
+    sections.push(format_task_directive(session, is_issue_first));
+
+    sections.join("\n\n")
+}
+
+/// Format a standalone issue prompt from an `Issue`, suitable for use
+/// outside the full `build_prompt` flow (e.g. `Tracker::generate_prompt`
+/// default impl).
+pub fn format_issue_context(issue: &Issue) -> String {
+    let mut lines = vec![format!("## Issue: {}", issue.title)];
+
+    if !issue.url.is_empty() {
+        lines.push(format!("URL: {}", issue.url));
+    }
+    if !issue.labels.is_empty() {
+        lines.push(format!("Labels: {}", issue.labels.join(", ")));
+    }
+    if let Some(ref assignee) = issue.assignee {
+        lines.push(format!("Assignee: {assignee}"));
+    }
+
+    if !issue.description.is_empty() {
+        lines.push(String::new());
+        lines.push(issue.description.clone());
+    }
+
+    lines.join("\n")
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+fn format_session_context(session: &Session, project: Option<&ProjectConfig>) -> String {
+    let mut lines = vec![format!("You are working on branch `{}`.", session.branch)];
+
+    if let Some(proj) = project {
+        lines.push(format!("Repository: {}", proj.repo));
+        lines.push(format!("Default branch: {}", proj.default_branch));
+    }
+
+    if let Some(ref id) = session.issue_id {
+        let url_part = session
+            .issue_url
+            .as_deref()
+            .map(|u| format!(" — {u}"))
+            .unwrap_or_default();
+        lines.push(format!("Issue: #{id}{url_part}"));
+    }
+
+    lines.join("\n")
+}
+
+fn format_task_directive(session: &Session, is_issue_first: bool) -> String {
+    if is_issue_first {
+        // Issue-first: the issue context (layer 2) already describes the work.
+        // The directive tells the agent to implement it and open a PR.
+        "Read the issue above carefully. Implement the required changes, \
+         verify with tests and linting, then push your branch and open a \
+         pull request."
+            .to_string()
+    } else {
+        // Prompt-first: the raw task IS the directive.
+        session.task.clone()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{SessionId, SessionStatus};
+
+    fn base_session() -> Session {
+        Session {
+            id: SessionId("test-prompt-builder".into()),
+            project_id: "my-app".into(),
+            status: SessionStatus::Working,
+            branch: "ao-abc123-feat-issue-42".into(),
+            task: "Fix the login bug".into(),
+            workspace_path: None,
+            runtime_handle: None,
+            activity: None,
+            created_at: 0,
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+        }
+    }
+
+    fn sample_project() -> ProjectConfig {
+        ProjectConfig {
+            repo: "acme/widgets".into(),
+            path: "/home/user/widgets".into(),
+            default_branch: "main".into(),
+            agent_config: None,
+        }
+    }
+
+    fn sample_issue() -> Issue {
+        Issue {
+            id: "42".into(),
+            title: "Add dark mode".into(),
+            description: "Users keep asking for dark mode support.".into(),
+            url: "https://github.com/acme/widgets/issues/42".into(),
+            state: crate::scm::IssueState::Open,
+            labels: vec!["feature".into(), "ui".into()],
+            assignee: Some("bob".into()),
+        }
+    }
+
+    // ---- build_prompt: task-first ----
+
+    #[test]
+    fn task_first_no_project_returns_branch_and_task() {
+        let session = base_session();
+        let prompt = build_prompt(&session, None, None);
+
+        assert!(prompt.contains("branch `ao-abc123-feat-issue-42`"));
+        assert!(prompt.contains("Fix the login bug"));
+        // No issue section.
+        assert!(!prompt.contains("## Issue"));
+    }
+
+    #[test]
+    fn task_first_with_project_includes_repo_context() {
+        let session = base_session();
+        let proj = sample_project();
+        let prompt = build_prompt(&session, Some(&proj), None);
+
+        assert!(prompt.contains("acme/widgets"));
+        assert!(prompt.contains("Default branch: main"));
+        assert!(prompt.contains("Fix the login bug"));
+    }
+
+    // ---- build_prompt: issue-first ----
+
+    #[test]
+    fn issue_first_full_context() {
+        let mut session = base_session();
+        session.issue_id = Some("42".into());
+        session.issue_url = Some("https://github.com/acme/widgets/issues/42".into());
+        let proj = sample_project();
+        let issue = sample_issue();
+        let issue_ctx = format_issue_context(&issue);
+
+        let prompt = build_prompt(&session, Some(&proj), Some(&issue_ctx));
+
+        // Layer 1: session context
+        assert!(prompt.contains("branch `ao-abc123-feat-issue-42`"));
+        assert!(prompt.contains("acme/widgets"));
+        assert!(prompt.contains("Issue: #42"));
+
+        // Layer 2: issue context
+        assert!(prompt.contains("## Issue: Add dark mode"));
+        assert!(prompt.contains("Labels: feature, ui"));
+        assert!(prompt.contains("Assignee: bob"));
+        assert!(prompt.contains("Users keep asking"));
+
+        // Layer 3: directive (not the raw task)
+        assert!(prompt.contains("push your branch and open a pull request"));
+    }
+
+    #[test]
+    fn issue_first_without_project_still_works() {
+        let mut session = base_session();
+        session.issue_id = Some("42".into());
+        let issue = sample_issue();
+        let issue_ctx = format_issue_context(&issue);
+
+        let prompt = build_prompt(&session, None, Some(&issue_ctx));
+
+        assert!(prompt.contains("## Issue: Add dark mode"));
+        assert!(prompt.contains("open a pull request"));
+        // No repo context line (the issue URL still contains the repo slug
+        // naturally, but there's no "Repository:" metadata line).
+        assert!(!prompt.contains("Repository:"));
+        assert!(!prompt.contains("Default branch:"));
+    }
+
+    // ---- format_issue_context ----
+
+    #[test]
+    fn issue_context_includes_all_fields() {
+        let issue = sample_issue();
+        let ctx = format_issue_context(&issue);
+
+        assert!(ctx.contains("## Issue: Add dark mode"));
+        assert!(ctx.contains("https://github.com/acme/widgets/issues/42"));
+        assert!(ctx.contains("Labels: feature, ui"));
+        assert!(ctx.contains("Assignee: bob"));
+        assert!(ctx.contains("Users keep asking"));
+    }
+
+    #[test]
+    fn issue_context_minimal_issue() {
+        let issue = Issue {
+            id: "7".into(),
+            title: "Fix typo".into(),
+            description: String::new(),
+            url: String::new(),
+            state: crate::scm::IssueState::Open,
+            labels: vec![],
+            assignee: None,
+        };
+        let ctx = format_issue_context(&issue);
+
+        assert!(ctx.contains("## Issue: Fix typo"));
+        assert!(!ctx.contains("URL:"));
+        assert!(!ctx.contains("Labels:"));
+        assert!(!ctx.contains("Assignee:"));
+    }
+
+    // ---- format_session_context ----
+
+    #[test]
+    fn session_context_with_issue_url() {
+        let mut session = base_session();
+        session.issue_id = Some("42".into());
+        session.issue_url = Some("https://github.com/acme/widgets/issues/42".into());
+
+        let ctx = format_session_context(&session, None);
+        assert!(ctx.contains("Issue: #42 — https://github.com/acme/widgets/issues/42"));
+    }
+
+    #[test]
+    fn session_context_issue_without_url() {
+        let mut session = base_session();
+        session.issue_id = Some("7".into());
+
+        let ctx = format_session_context(&session, None);
+        assert!(ctx.contains("Issue: #7"));
+        assert!(!ctx.contains(" — "));
+    }
+
+    // ---- format_task_directive ----
+
+    #[test]
+    fn task_directive_issue_first_instructs_pr() {
+        let session = base_session();
+        let directive = format_task_directive(&session, true);
+        assert!(directive.contains("open a pull request"));
+        // Should NOT contain the raw task text — issue context covers it.
+        assert!(!directive.contains("Fix the login bug"));
+    }
+
+    #[test]
+    fn task_directive_prompt_first_returns_raw_task() {
+        let session = base_session();
+        let directive = format_task_directive(&session, false);
+        assert_eq!(directive, "Fix the login bug");
+    }
+}

--- a/crates/ao-core/src/session_manager.rs
+++ b/crates/ao-core/src/session_manager.rs
@@ -152,6 +152,19 @@ impl SessionManager {
         Ok(first)
     }
 
+    /// Find all non-terminal sessions with a matching `issue_id`.
+    ///
+    /// Used for duplicate detection before `ao-rs spawn --issue` — if another
+    /// active session is already working on the same issue, the user should
+    /// either wait or use `--force`.
+    pub async fn find_by_issue_id(&self, issue_id: &str) -> Result<Vec<Session>> {
+        let all = self.list().await?;
+        Ok(all
+            .into_iter()
+            .filter(|s| !s.is_terminal() && s.issue_id.as_deref() == Some(issue_id))
+            .collect())
+    }
+
     /// Remove a session's yaml file. No-op if it doesn't exist.
     pub async fn delete(&self, project_id: &str, id: &SessionId) -> Result<()> {
         let path = self.session_path(project_id, id);
@@ -268,6 +281,40 @@ mod tests {
     async fn list_returns_empty_when_dir_missing() {
         let manager = SessionManager::new(unique_temp_dir("missing"));
         assert!(manager.list().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
+    async fn find_by_issue_id_returns_active_matches_only() {
+        let base = unique_temp_dir("find-issue");
+        let manager = SessionManager::new(base.clone());
+
+        // Active session on issue 42.
+        let mut active = fake_session("uuid-active", "demo", "fix it");
+        active.issue_id = Some("42".into());
+        active.status = SessionStatus::Working;
+        manager.save(&active).await.unwrap();
+
+        // Terminal session on same issue (should not match).
+        let mut killed = fake_session("uuid-killed", "demo", "old attempt");
+        killed.issue_id = Some("42".into());
+        killed.status = SessionStatus::Killed;
+        manager.save(&killed).await.unwrap();
+
+        // Active session on different issue (should not match).
+        let mut other = fake_session("uuid-other", "demo", "other thing");
+        other.issue_id = Some("99".into());
+        other.status = SessionStatus::Working;
+        manager.save(&other).await.unwrap();
+
+        let matches = manager.find_by_issue_id("42").await.unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].id.0, "uuid-active");
+
+        // No match for unknown issue.
+        let empty = manager.find_by_issue_id("999").await.unwrap();
+        assert!(empty.is_empty());
+
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]

--- a/crates/ao-core/src/session_manager.rs
+++ b/crates/ao-core/src/session_manager.rs
@@ -63,6 +63,11 @@ impl SessionManager {
     }
 
     /// Read every session across all projects, sorted newest-first.
+    ///
+    /// `.archive/` subdirectories inside each project dir are safe because
+    /// the inner `read_dir` is non-recursive — only direct children of the
+    /// project directory are inspected, and `.archive` (a directory) is
+    /// skipped by the `.yaml` extension filter.
     pub async fn list(&self) -> Result<Vec<Session>> {
         let mut result = Vec::new();
         if !self.base_dir.exists() {
@@ -154,6 +159,48 @@ impl SessionManager {
             fs::remove_file(&path).await?;
         }
         Ok(())
+    }
+
+    /// Archive a session: move its YAML from the active directory into
+    /// `sessions/<project>/.archive/<uuid>.yaml`. Archiving removes the
+    /// session from `list()` results while preserving it on disk for
+    /// historical reference. No-op if the source file doesn't exist
+    /// (already archived or never persisted).
+    pub async fn archive(&self, session: &Session) -> Result<()> {
+        let source = self.session_path(&session.project_id, &session.id);
+        let archive_dir = self.project_dir(&session.project_id).join(".archive");
+        fs::create_dir_all(&archive_dir).await?;
+        let target = archive_dir.join(format!("{}.yaml", session.id.0));
+        // Attempt the rename directly — treat NotFound as success (already
+        // archived or never persisted) to avoid a TOCTOU race with concurrent
+        // callers.
+        match fs::rename(&source, &target).await {
+            Ok(()) => Ok(()),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(()),
+            Err(e) => Err(e.into()),
+        }
+    }
+
+    /// List archived sessions for a project, sorted newest-first.
+    pub async fn list_archived(&self, project_id: &str) -> Result<Vec<Session>> {
+        let archive_dir = self.project_dir(project_id).join(".archive");
+        if !archive_dir.exists() {
+            return Ok(Vec::new());
+        }
+        let mut result = Vec::new();
+        let mut entries = fs::read_dir(&archive_dir).await?;
+        while let Some(file) = entries.next_entry().await? {
+            let path = file.path();
+            if path.extension().and_then(|s| s.to_str()) != Some("yaml") {
+                continue;
+            }
+            match load_file(&path).await {
+                Ok(session) => result.push(session),
+                Err(e) => tracing::warn!("skipping archived {path:?}: {e}"),
+            }
+        }
+        result.sort_by(|a, b| b.created_at.cmp(&a.created_at));
+        Ok(result)
     }
 }
 
@@ -306,6 +353,47 @@ mod tests {
         let msg = format!("{err}");
         assert!(msg.contains("ambiguous"), "got: {msg}");
         assert!(msg.contains("3 matches"), "got: {msg}");
+    }
+
+    #[tokio::test]
+    async fn archive_moves_yaml_to_dot_archive_dir() {
+        let base = unique_temp_dir("archive");
+        let manager = SessionManager::new(base.clone());
+        let s = fake_session("uuid-arc", "demo", "archivable");
+        manager.save(&s).await.unwrap();
+        assert_eq!(manager.list().await.unwrap().len(), 1);
+
+        manager.archive(&s).await.unwrap();
+
+        // No longer in active list.
+        assert_eq!(manager.list().await.unwrap().len(), 0);
+        // Present in archived list.
+        let archived = manager.list_archived("demo").await.unwrap();
+        assert_eq!(archived.len(), 1);
+        assert_eq!(archived[0].id.0, "uuid-arc");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn archive_is_noop_when_source_missing() {
+        let base = unique_temp_dir("archive-noop");
+        let manager = SessionManager::new(base.clone());
+        let s = fake_session("uuid-gone", "demo", "already gone");
+        // Don't save — source doesn't exist on disk.
+        manager.archive(&s).await.unwrap(); // should not error
+        let archived = manager.list_archived("demo").await.unwrap();
+        assert!(archived.is_empty());
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn list_archived_returns_empty_when_no_archive() {
+        let base = unique_temp_dir("archive-empty");
+        let manager = SessionManager::new(base.clone());
+        let archived = manager.list_archived("nonexistent").await.unwrap();
+        assert!(archived.is_empty());
+        let _ = std::fs::remove_dir_all(&base);
     }
 
     #[tokio::test]

--- a/crates/ao-core/src/traits.rs
+++ b/crates/ao-core/src/traits.rs
@@ -1,5 +1,6 @@
 use crate::{
     error::Result,
+    prompt_builder,
     scm::{
         CheckRun, CiStatus, Issue, MergeMethod, MergeReadiness, PrState, PullRequest, Review,
         ReviewComment, ReviewDecision,
@@ -141,8 +142,8 @@ pub trait Scm: Send + Sync {
 /// - No `project: ProjectConfig` parameter on every method. The plugin
 ///   holds any project config it needs via `::new()`, matching how
 ///   `Runtime` / `Agent` already work.
-/// - `generate_prompt`, `list_issues`, `update_issue`, `create_issue`
-///   are cut. The port needs exactly `get_issue` + `branch_name` today;
+/// - `list_issues`, `update_issue`, `create_issue` are cut. The port
+///   needs exactly `get_issue` + `branch_name` + `generate_prompt` today;
 ///   the rest can come back when a real use case demands them.
 #[async_trait]
 pub trait Tracker: Send + Sync {
@@ -167,4 +168,15 @@ pub trait Tracker: Send + Sync {
     /// plugin decides the format (`issue-42-add-dark-mode`, `LIN-1327`,
     /// etc.); `ao-rs spawn` prepends its own short-id prefix if needed.
     fn branch_name(&self, identifier: &str) -> String;
+
+    /// Format an issue into a structured prompt section suitable for
+    /// inclusion in the agent's initial message.
+    ///
+    /// Default impl uses `prompt_builder::format_issue_context` which
+    /// renders title, URL, labels, assignee, and description. Override
+    /// in tracker plugins that need platform-specific context (e.g.
+    /// Linear cycle info, Jira sprint fields).
+    fn generate_prompt(&self, issue: &Issue) -> String {
+        prompt_builder::format_issue_context(issue)
+    }
 }

--- a/crates/plugins/agent-claude-code/Cargo.toml
+++ b/crates/plugins/agent-claude-code/Cargo.toml
@@ -11,3 +11,6 @@ async-trait = { workspace = true }
 serde_json = { workspace = true }
 tokio = { workspace = true }
 tracing = { workspace = true }
+
+[dev-dependencies]
+filetime = "0.2"

--- a/crates/plugins/agent-claude-code/src/lib.rs
+++ b/crates/plugins/agent-claude-code/src/lib.rs
@@ -82,6 +82,11 @@ impl Agent for ClaudeCodeAgent {
     }
 
     fn initial_prompt(&self, session: &Session) -> String {
+        // NOTE: The CLI spawn flow uses `prompt_builder::build_prompt()` for
+        // richer 3-layer prompts (session context + issue context + directive).
+        // This method is a backward-compat fallback for callers that don't
+        // have access to the full Issue / ProjectConfig context.
+        //
         // Issue-first spawns get structured context so the agent knows its
         // branch, the issue source, and is explicitly told to open a PR.
         // Prompt-first spawns (`--task`) get the raw task as-is — the user

--- a/crates/plugins/agent-claude-code/src/lib.rs
+++ b/crates/plugins/agent-claude-code/src/lib.rs
@@ -16,7 +16,7 @@ use ao_core::{
     default_agent_rules, ActivityState, Agent, AgentConfig, CostEstimate, Result, Session,
 };
 use async_trait::async_trait;
-use std::io::BufRead;
+use std::io::{BufRead, Seek};
 use std::path::PathBuf;
 
 pub struct ClaudeCodeAgent {
@@ -104,8 +104,15 @@ impl Agent for ClaudeCodeAgent {
         }
     }
 
-    async fn detect_activity(&self, _session: &Session) -> Result<ActivityState> {
-        Ok(ActivityState::Ready)
+    async fn detect_activity(&self, session: &Session) -> Result<ActivityState> {
+        let Some(ref ws) = session.workspace_path else {
+            return Ok(ActivityState::Ready);
+        };
+        // JSONL reads are blocking file I/O — run off the executor thread.
+        let ws = ws.clone();
+        tokio::task::spawn_blocking(move || detect_activity_from_jsonl(&ws))
+            .await
+            .map_err(|e| ao_core::AoError::Other(format!("detect_activity panicked: {e}")))?
     }
 
     async fn cost_estimate(&self, session: &Session) -> Result<Option<CostEstimate>> {
@@ -165,6 +172,124 @@ fn find_session_jsonl(workspace_path: &std::path::Path) -> Option<PathBuf> {
     }
     best.map(|(p, _)| p)
 }
+
+// ---- Activity detection constants ----
+
+/// If the JSONL file hasn't been modified in this many seconds, the agent is
+/// considered idle. 5 minutes matches the TS reference's default.
+const IDLE_THRESHOLD_SECS: u64 = 300;
+
+/// How many bytes to read from the tail of the JSONL file. 64 KB is enough
+/// to capture the last few conversation turns without reading the whole file.
+const TAIL_READ_BYTES: u64 = 64 * 1024;
+
+// ---- Activity detection ----
+
+/// Determine agent activity by tailing the Claude Code JSONL session file.
+///
+/// Strategy:
+///   1. File mtime older than `IDLE_THRESHOLD_SECS` → `Idle`.
+///   2. Seek to last ~64 KB, find the last `assistant` or `user` entry.
+///   3. Map `stop_reason`:
+///      - `"end_turn"` → `Ready` (agent finished, waiting for input)
+///      - `"tool_use"` / `null` → `Active` (agent running tools or streaming)
+///   4. Last entry is `user` → `Active` (tool results or human input flowing,
+///      agent will respond).
+///   5. No JSONL file or no entries → `Ready` (agent just started).
+fn detect_activity_from_jsonl(workspace_path: &std::path::Path) -> ao_core::Result<ActivityState> {
+    let Some(path) = find_session_jsonl(workspace_path) else {
+        // No JSONL yet — agent just started or hasn't written anything.
+        return Ok(ActivityState::Ready);
+    };
+
+    let metadata = std::fs::metadata(&path)?;
+
+    // Check file modification time for idle detection.
+    // If mtime is unavailable (exotic platform), assume fresh to avoid false
+    // Idle — the lifecycle's stuck-detection clock handles prolonged inactivity.
+    let modified = metadata
+        .modified()
+        .unwrap_or_else(|_| std::time::SystemTime::now());
+    let age = std::time::SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default();
+
+    if age.as_secs() > IDLE_THRESHOLD_SECS {
+        return Ok(ActivityState::Idle);
+    }
+
+    // Read the tail of the file to find the last meaningful entry.
+    // Note: does not detect process exit — that is handled by the runtime
+    // probe (`Runtime::is_alive`) in the lifecycle's step 1.
+    let file_len = metadata.len();
+    let read_start = file_len.saturating_sub(TAIL_READ_BYTES);
+
+    let mut file = std::fs::File::open(&path)?;
+    if read_start > 0 {
+        file.seek(std::io::SeekFrom::Start(read_start))?;
+    }
+
+    let mut reader = std::io::BufReader::new(file);
+
+    // If we seeked into the middle of a line, discard the partial fragment
+    // so the parse loop only sees complete JSON lines.
+    if read_start > 0 {
+        let mut _discard = String::new();
+        let _ = reader.read_line(&mut _discard);
+    }
+
+    let mut last_entry: Option<serde_json::Value> = None;
+
+    for line in reader.lines() {
+        let Ok(line) = line else { continue };
+        if line.is_empty() {
+            continue;
+        }
+        let Ok(v) = serde_json::from_str::<serde_json::Value>(&line) else {
+            continue;
+        };
+        // Only track interaction entries — `system`, `queue-operation`, etc.
+        // don't reflect agent activity.
+        let entry_type = v.get("type").and_then(|t| t.as_str()).unwrap_or("");
+        if matches!(entry_type, "assistant" | "user") {
+            last_entry = Some(v);
+        }
+    }
+
+    let Some(entry) = last_entry else {
+        return Ok(ActivityState::Ready);
+    };
+
+    Ok(classify_entry(&entry))
+}
+
+/// Map a single JSONL entry to an `ActivityState`.
+fn classify_entry(entry: &serde_json::Value) -> ActivityState {
+    let entry_type = entry.get("type").and_then(|t| t.as_str()).unwrap_or("");
+
+    match entry_type {
+        "assistant" => {
+            let stop_reason = entry
+                .get("message")
+                .and_then(|m| m.get("stop_reason"))
+                .and_then(|s| s.as_str());
+
+            match stop_reason {
+                // end_turn: model chose to stop — waiting for user input.
+                Some("end_turn") => ActivityState::Ready,
+                // tool_use: model is invoking tools — more work coming.
+                // null / streaming partial: model is mid-response.
+                Some("tool_use") | None => ActivityState::Active,
+                // Any other stop reason (shouldn't happen, but be safe).
+                _ => ActivityState::Active,
+            }
+        }
+        // user entry (tool_result or human message) → model will respond.
+        _ => ActivityState::Active,
+    }
+}
+
+// ---- Cost estimation ----
 
 /// Pricing constants (USD per million tokens). Sonnet 4 pricing.
 const INPUT_PRICE: f64 = 3.0;
@@ -370,6 +495,180 @@ mod tests {
         assert!(prompt.contains("issue #7"));
         assert!(!prompt.contains("Issue URL:"));
         assert!(prompt.contains("open a pull request"));
+    }
+
+    // ---- classify_entry unit tests ----
+
+    #[test]
+    fn classify_assistant_end_turn_is_ready() {
+        let entry: serde_json::Value =
+            serde_json::from_str(r#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#)
+                .unwrap();
+        assert_eq!(classify_entry(&entry), ActivityState::Ready);
+    }
+
+    #[test]
+    fn classify_assistant_tool_use_is_active() {
+        let entry: serde_json::Value =
+            serde_json::from_str(r#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#)
+                .unwrap();
+        assert_eq!(classify_entry(&entry), ActivityState::Active);
+    }
+
+    #[test]
+    fn classify_assistant_null_stop_reason_is_active() {
+        // Streaming partial — stop_reason is null in JSON.
+        let entry: serde_json::Value =
+            serde_json::from_str(r#"{"type":"assistant","message":{"stop_reason":null}}"#).unwrap();
+        assert_eq!(classify_entry(&entry), ActivityState::Active);
+    }
+
+    #[test]
+    fn classify_assistant_no_message_is_active() {
+        // Defensive: assistant entry without message object.
+        let entry: serde_json::Value = serde_json::from_str(r#"{"type":"assistant"}"#).unwrap();
+        assert_eq!(classify_entry(&entry), ActivityState::Active);
+    }
+
+    #[test]
+    fn classify_user_entry_is_active() {
+        // User entry (tool_result or human input) means agent will respond.
+        let entry: serde_json::Value = serde_json::from_str(
+            r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result"}]}}"#,
+        )
+        .unwrap();
+        assert_eq!(classify_entry(&entry), ActivityState::Active);
+    }
+
+    // ---- detect_activity_from_jsonl integration tests ----
+
+    /// Build a fake `~/.claude/projects/{encoded}/sessions/` tree so
+    /// `find_session_jsonl` discovers the test file. Returns the workspace
+    /// path (the key `detect_activity_from_jsonl` uses).
+    fn setup_jsonl_env(label: &str, lines: &[&str]) -> (PathBuf, PathBuf) {
+        let workspace = std::env::temp_dir().join(format!("ao-activity-ws-{label}"));
+        std::fs::create_dir_all(&workspace).unwrap();
+
+        let encoded = encode_path(&workspace);
+        let home = std::env::var("HOME").unwrap();
+        let sessions_dir = PathBuf::from(&home)
+            .join(".claude")
+            .join("projects")
+            .join(&encoded)
+            .join("sessions");
+        std::fs::create_dir_all(&sessions_dir).unwrap();
+
+        let jsonl_path = sessions_dir.join("test-detect-activity.jsonl");
+        let mut f = std::fs::File::create(&jsonl_path).unwrap();
+        for line in lines {
+            writeln!(f, "{line}").unwrap();
+        }
+
+        (workspace, jsonl_path)
+    }
+
+    fn teardown_jsonl_env(workspace: &std::path::Path) {
+        let encoded = encode_path(workspace);
+        let home = std::env::var("HOME").unwrap();
+        let sessions_dir = PathBuf::from(&home)
+            .join(".claude")
+            .join("projects")
+            .join(&encoded);
+        std::fs::remove_dir_all(&sessions_dir).ok();
+        std::fs::remove_dir_all(workspace).ok();
+    }
+
+    #[test]
+    fn detect_activity_no_jsonl_returns_ready() {
+        let workspace = std::env::temp_dir().join("ao-activity-no-jsonl");
+        std::fs::create_dir_all(&workspace).unwrap();
+        let result = detect_activity_from_jsonl(&workspace).unwrap();
+        assert_eq!(result, ActivityState::Ready);
+        std::fs::remove_dir_all(&workspace).ok();
+    }
+
+    #[test]
+    fn detect_activity_end_turn_returns_ready() {
+        let (workspace, _jsonl) = setup_jsonl_env(
+            "end-turn",
+            &[
+                r#"{"type":"user","message":{"role":"user"}}"#,
+                r#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+                r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result"}]}}"#,
+                r#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+            ],
+        );
+        let result = detect_activity_from_jsonl(&workspace).unwrap();
+        assert_eq!(result, ActivityState::Ready);
+        teardown_jsonl_env(&workspace);
+    }
+
+    #[test]
+    fn detect_activity_tool_use_returns_active() {
+        let (workspace, _jsonl) = setup_jsonl_env(
+            "tool-use",
+            &[
+                r#"{"type":"user","message":{"role":"user"}}"#,
+                r#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+            ],
+        );
+        let result = detect_activity_from_jsonl(&workspace).unwrap();
+        assert_eq!(result, ActivityState::Active);
+        teardown_jsonl_env(&workspace);
+    }
+
+    #[test]
+    fn detect_activity_user_last_returns_active() {
+        let (workspace, _jsonl) = setup_jsonl_env(
+            "user-last",
+            &[
+                r#"{"type":"assistant","message":{"stop_reason":"tool_use"}}"#,
+                r#"{"type":"user","message":{"role":"user","content":[{"type":"tool_result"}]}}"#,
+            ],
+        );
+        let result = detect_activity_from_jsonl(&workspace).unwrap();
+        assert_eq!(result, ActivityState::Active);
+        teardown_jsonl_env(&workspace);
+    }
+
+    #[test]
+    fn detect_activity_stale_file_returns_idle() {
+        let (workspace, jsonl) = setup_jsonl_env(
+            "stale",
+            &[r#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#],
+        );
+        // Backdate the file modification time by IDLE_THRESHOLD + 60s.
+        let old_time = filetime::FileTime::from_unix_time(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64
+                - IDLE_THRESHOLD_SECS as i64
+                - 60,
+            0,
+        );
+        filetime::set_file_mtime(&jsonl, old_time).unwrap();
+
+        let result = detect_activity_from_jsonl(&workspace).unwrap();
+        assert_eq!(result, ActivityState::Idle);
+        teardown_jsonl_env(&workspace);
+    }
+
+    #[test]
+    fn detect_activity_skips_system_entries() {
+        // System and queue-operation entries should not affect activity.
+        let (workspace, _jsonl) = setup_jsonl_env(
+            "skip-system",
+            &[
+                r#"{"type":"assistant","message":{"stop_reason":"end_turn"}}"#,
+                r#"{"type":"system","message":{}}"#,
+                r#"{"type":"queue-operation"}"#,
+            ],
+        );
+        // Last interaction entry is the assistant end_turn → Ready.
+        let result = detect_activity_from_jsonl(&workspace).unwrap();
+        assert_eq!(result, ActivityState::Ready);
+        teardown_jsonl_env(&workspace);
     }
 
     // ---- JSONL cost parsing tests ----

--- a/crates/plugins/agent-cursor/Cargo.toml
+++ b/crates/plugins/agent-cursor/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ao-plugin-agent-cursor"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }

--- a/crates/plugins/agent-cursor/src/lib.rs
+++ b/crates/plugins/agent-cursor/src/lib.rs
@@ -1,0 +1,332 @@
+//! Cursor Agent CLI plugin.
+//!
+//! Launches the Cursor background agent (`agent`) in permissionless mode
+//! inside a tmux session. Mirrors `packages/plugins/agent-cursor/src/index.ts`
+//! in the TypeScript agent-orchestrator.
+//!
+//! ## Launch strategy
+//!
+//! The TS reference embeds the full prompt in the launch command's positional
+//! argument (`agent -- <prompt>`). This Rust port uses **post-launch delivery**
+//! instead — same as the Claude Code plugin — where the orchestrator runs
+//! `agent` interactively, then sends the task via `Runtime::send_message`.
+//! This keeps the architecture consistent across agent plugins and avoids
+//! shell-escaping multi-kilobyte prompts in tmux commands.
+//!
+//! ## Activity detection
+//!
+//! Cursor doesn't write JSONL session logs like Claude Code. Detection uses:
+//! 1. `.cursor/chat.md` file mtime — if recently modified, agent is active.
+//! 2. Recent git commits in the workspace — if any within 60s, agent is active.
+//! 3. Fallback: `ActivityState::Ready` (runtime liveness covers process exit).
+//!
+//! ## Cost tracking
+//!
+//! Cursor doesn't expose token/cost data via CLI. Returns `None`.
+
+use ao_core::{ActivityState, Agent, AgentConfig, Result, Session};
+use async_trait::async_trait;
+use std::path::Path;
+
+/// Idle threshold: if `.cursor/chat.md` hasn't been modified in this many
+/// seconds, consider the agent idle. Matches the Claude Code plugin's 5 min.
+const IDLE_THRESHOLD_SECS: u64 = 300;
+
+/// Active window: if `.cursor/chat.md` was modified within this many seconds,
+/// the agent is actively working (not just "ready").
+const ACTIVE_WINDOW_SECS: u64 = 30;
+
+pub struct CursorAgent {
+    /// Rules prepended to the prompt. Cursor doesn't have a system prompt
+    /// flag, so rules are delivered as part of the initial prompt.
+    rules: Option<String>,
+}
+
+impl CursorAgent {
+    pub fn new() -> Self {
+        Self { rules: None }
+    }
+
+    /// Create from project agent config.
+    pub fn from_config(config: &AgentConfig) -> Self {
+        let rules = if let Some(ref path) = config.rules_file {
+            match std::fs::read_to_string(path) {
+                Ok(content) => Some(content),
+                Err(e) => {
+                    tracing::warn!("could not read rules file {path}: {e}, using inline rules");
+                    config.rules.clone()
+                }
+            }
+        } else {
+            config.rules.clone()
+        };
+        Self { rules }
+    }
+}
+
+impl Default for CursorAgent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Agent for CursorAgent {
+    fn launch_command(&self, _session: &Session) -> String {
+        // Cursor agent in permissionless mode:
+        //   --force: auto-approve all changes (alias: --yolo)
+        //   --sandbox disabled: skip workspace trust prompts
+        //   --approve-mcps: auto-approve MCP servers
+        "agent --force --sandbox disabled --approve-mcps".to_string()
+    }
+
+    fn environment(&self, session: &Session) -> Vec<(String, String)> {
+        vec![
+            ("AO_SESSION_ID".to_string(), session.id.to_string()),
+            // Issue ID for workspace hooks / prompt enrichment.
+            (
+                "AO_ISSUE_ID".to_string(),
+                session.issue_id.clone().unwrap_or_default(),
+            ),
+        ]
+    }
+
+    fn initial_prompt(&self, session: &Session) -> String {
+        // NOTE: The CLI spawn flow uses `prompt_builder::build_prompt()` for
+        // richer 3-layer prompts. This is a backward-compat fallback.
+        //
+        // Cursor doesn't have --append-system-prompt, so if rules are
+        // configured, prepend them to the task.
+        let task_part = if let Some(ref id) = session.issue_id {
+            let url_line = session
+                .issue_url
+                .as_deref()
+                .map(|u| format!("\nIssue URL: {u}"))
+                .unwrap_or_default();
+            format!(
+                "You are working on issue #{id} on branch `{branch}`.{url_line}\n\n\
+                 Task:\n{task}\n\n\
+                 When complete, push your branch and open a pull request.",
+                branch = session.branch,
+                task = session.task,
+            )
+        } else {
+            session.task.clone()
+        };
+
+        match &self.rules {
+            Some(rules) => format!("{rules}\n\n---\n\n{task_part}"),
+            None => task_part,
+        }
+    }
+
+    async fn detect_activity(&self, session: &Session) -> Result<ActivityState> {
+        let Some(ref ws) = session.workspace_path else {
+            return Ok(ActivityState::Ready);
+        };
+        // File I/O is blocking — run off the executor thread.
+        let ws = ws.clone();
+        tokio::task::spawn_blocking(move || detect_cursor_activity(&ws))
+            .await
+            .map_err(|e| ao_core::AoError::Other(format!("detect_activity panicked: {e}")))?
+    }
+
+    // Cursor doesn't expose token/cost data — use the default (None).
+}
+
+// ---------------------------------------------------------------------------
+// Activity detection
+// ---------------------------------------------------------------------------
+
+/// Determine agent activity by checking Cursor workspace artifacts.
+///
+/// Strategy (multi-fallback, mirrors TS):
+///   1. `.cursor/chat.md` mtime — direct evidence of Cursor writes.
+///   2. Recent git commits (within 60s) — indirect evidence of agent work.
+///   3. Fallback: `Ready` — runtime liveness covers process exit.
+fn detect_cursor_activity(workspace_path: &Path) -> Result<ActivityState> {
+    // 1. Check .cursor/chat.md mtime.
+    let chat_file = workspace_path.join(".cursor").join("chat.md");
+    if let Ok(metadata) = std::fs::metadata(&chat_file) {
+        let Ok(modified) = metadata.modified() else {
+            // Platform doesn't support mtime — fall back to Ready rather
+            // than silently reporting Active with a faked timestamp.
+            return Ok(ActivityState::Ready);
+        };
+        let age = std::time::SystemTime::now()
+            .duration_since(modified)
+            .unwrap_or_default();
+
+        if age.as_secs() <= ACTIVE_WINDOW_SECS {
+            return Ok(ActivityState::Active);
+        }
+        if age.as_secs() <= IDLE_THRESHOLD_SECS {
+            return Ok(ActivityState::Ready);
+        }
+        return Ok(ActivityState::Idle);
+    }
+
+    // 2. Check for recent git commits.
+    if has_recent_commits(workspace_path) {
+        return Ok(ActivityState::Active);
+    }
+
+    // 3. Fallback — no cursor artifacts, agent may have just started.
+    Ok(ActivityState::Ready)
+}
+
+/// Check if any git commits were made in the workspace within the last 60s.
+fn has_recent_commits(workspace_path: &Path) -> bool {
+    let output = std::process::Command::new("git")
+        .args(["log", "--since=60 seconds ago", "--format=%H"])
+        .current_dir(workspace_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => !String::from_utf8_lossy(&o.stdout).trim().is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ao_core::{now_ms, SessionId, SessionStatus};
+    use std::path::PathBuf;
+
+    fn fake_session() -> Session {
+        Session {
+            id: SessionId("cursor-test".into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Working,
+            branch: "ao-abc123-feat-test".into(),
+            task: "fix the bug".into(),
+            workspace_path: Some(PathBuf::from("/tmp/cursor-demo")),
+            runtime_handle: None,
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+        }
+    }
+
+    #[test]
+    fn launch_command_is_permissionless() {
+        let agent = CursorAgent::new();
+        let cmd = agent.launch_command(&fake_session());
+        assert!(cmd.contains("agent"));
+        assert!(cmd.contains("--force"));
+        assert!(cmd.contains("--sandbox disabled"));
+        assert!(cmd.contains("--approve-mcps"));
+    }
+
+    #[test]
+    fn environment_includes_session_id() {
+        let agent = CursorAgent::new();
+        let env = agent.environment(&fake_session());
+        assert!(env
+            .iter()
+            .any(|(k, v)| k == "AO_SESSION_ID" && v == "cursor-test"));
+    }
+
+    #[test]
+    fn environment_includes_empty_issue_id_when_none() {
+        let agent = CursorAgent::new();
+        let env = agent.environment(&fake_session());
+        assert!(env.iter().any(|(k, v)| k == "AO_ISSUE_ID" && v.is_empty()));
+    }
+
+    #[test]
+    fn environment_includes_issue_id_when_set() {
+        let agent = CursorAgent::new();
+        let mut session = fake_session();
+        session.issue_id = Some("42".into());
+        let env = agent.environment(&session);
+        assert!(env.iter().any(|(k, v)| k == "AO_ISSUE_ID" && v == "42"));
+    }
+
+    #[test]
+    fn initial_prompt_task_first() {
+        let agent = CursorAgent::new();
+        assert_eq!(agent.initial_prompt(&fake_session()), "fix the bug");
+    }
+
+    #[test]
+    fn initial_prompt_issue_first() {
+        let agent = CursorAgent::new();
+        let mut session = fake_session();
+        session.issue_id = Some("7".into());
+        session.issue_url = Some("https://github.com/acme/repo/issues/7".into());
+        session.task = "Add dark mode".into();
+
+        let prompt = agent.initial_prompt(&session);
+        assert!(prompt.contains("issue #7"));
+        assert!(prompt.contains("https://github.com/acme/repo/issues/7"));
+        assert!(prompt.contains("Add dark mode"));
+        assert!(prompt.contains("open a pull request"));
+    }
+
+    #[test]
+    fn initial_prompt_with_rules_prepends_rules() {
+        let agent = CursorAgent {
+            rules: Some("Always run tests before committing.".into()),
+        };
+        let prompt = agent.initial_prompt(&fake_session());
+        assert!(prompt.starts_with("Always run tests"));
+        assert!(prompt.contains("---"));
+        assert!(prompt.contains("fix the bug"));
+    }
+
+    #[test]
+    fn from_config_reads_inline_rules() {
+        let config = AgentConfig {
+            permissions: "permissionless".into(),
+            rules: Some("custom cursor rules".into()),
+            rules_file: None,
+        };
+        let agent = CursorAgent::from_config(&config);
+        let prompt = agent.initial_prompt(&fake_session());
+        assert!(prompt.contains("custom cursor rules"));
+    }
+
+    #[test]
+    fn from_config_no_rules() {
+        let config = AgentConfig {
+            permissions: "permissionless".into(),
+            rules: None,
+            rules_file: None,
+        };
+        let agent = CursorAgent::from_config(&config);
+        assert_eq!(agent.initial_prompt(&fake_session()), "fix the bug");
+    }
+
+    // ---- activity detection ----
+
+    #[test]
+    fn detect_activity_no_workspace_returns_ready() {
+        let ws = std::env::temp_dir().join("ao-cursor-no-ws");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        // No .cursor dir, no git commits → fallback Ready.
+        let result = detect_cursor_activity(&ws).unwrap();
+        assert_eq!(result, ActivityState::Ready);
+
+        std::fs::remove_dir_all(&ws).ok();
+    }
+
+    #[test]
+    fn detect_activity_fresh_chat_file_returns_active() {
+        let ws = std::env::temp_dir().join("ao-cursor-active-chat");
+        let cursor_dir = ws.join(".cursor");
+        std::fs::create_dir_all(&cursor_dir).unwrap();
+        std::fs::write(cursor_dir.join("chat.md"), "# Session\nHello").unwrap();
+
+        let result = detect_cursor_activity(&ws).unwrap();
+        assert_eq!(result, ActivityState::Active);
+
+        std::fs::remove_dir_all(&ws).ok();
+    }
+}


### PR DESCRIPTION
## Summary
- **Slice 7**: Session kill/cleanup/archive — `ao-rs kill`, `ao-rs cleanup`, `ao-rs session attach`
- **Slice 8**: Real JSONL-based activity detection for Claude Code agent
- **Slice 9**: Batch-spawn + duplicate issue detection
- **Slice 10**: 3-layer structured prompt builder with `Tracker::generate_prompt()` extension point
- **Slice 12**: `ao-rs doctor` + `ao-rs review-check` diagnostic commands
- **Agent-Cursor**: New `ao-plugin-agent-cursor` crate with `--agent` CLI flag

## Test plan
- [x] `cargo test --workspace` — 353 tests pass
- [x] `cargo clippy --workspace --tests -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Rust reviewer pass on agent-cursor plugin — all BLOCK items resolved

🤖 Generated with [Claude Code](https://claude.com/claude-code)