### PR TITLE
feat: persist agent selection and config in sessions

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -83,6 +83,7 @@ dependencies = [
  "ao-plugin-scm-github",
  "ao-plugin-tracker-github",
  "ao-plugin-workspace-worktree",
+ "async-trait",
  "clap",
  "tokio",
  "tracing",

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -24,6 +24,7 @@ ao-plugin-notifier-discord = { path = "../plugins/notifier-discord" }
 ao-dashboard = { path = "../ao-dashboard" }
 
 tokio = { workspace = true }
+async-trait = { workspace = true }
 clap = { version = "4", features = ["derive"] }
 tracing = { workspace = true }
 tracing-subscriber = { workspace = true }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -15,11 +15,11 @@
 //! it twice concurrently fails fast instead of racing two polling loops.
 
 use ao_core::{
-    build_prompt, generate_config, install_skills, now_ms, paths, restore_session, Agent,
-    AgentConfig, AoConfig, CiStatus, LifecycleManager, LockError, MergeReadiness,
+    build_prompt, generate_config, install_skills, now_ms, paths, restore_session, ActivityState,
+    Agent, AgentConfig, AoConfig, CiStatus, LifecycleManager, LockError, MergeReadiness,
     NotificationRouting, NotifierRegistry, OrchestratorEvent, PidFile, PrState, PullRequest,
-    ReactionEngine, ReviewDecision, Runtime, Scm, Session, SessionId, SessionManager,
-    SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
+    ReactionEngine, ReviewDecision, Runtime, Scm, Session, SessionId, SessionManager, SessionStatus,
+    Tracker, Workspace, WorkspaceCreateConfig,
 };
 use ao_plugin_agent_claude_code::ClaudeCodeAgent;
 use ao_plugin_agent_cursor::CursorAgent;
@@ -35,6 +35,7 @@ use clap::{Parser, Subcommand};
 use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
+use async_trait::async_trait;
 
 /// Typed error for duplicate issue detection so `batch_spawn` can distinguish
 /// "skipped duplicate" from "real failure" without string matching.
@@ -77,6 +78,86 @@ fn select_agent(name: &str, agent_config: Option<&AgentConfig>) -> Box<dyn Agent
                 None => Box::new(ClaudeCodeAgent::with_default_rules()),
             }
         }
+    }
+}
+
+/// Resolve a project agent config into a session-storable, self-contained form.
+///
+/// If `rules_file` is set, read its contents and inline them into `rules`,
+/// clearing `rules_file`. This makes session restore independent of the
+/// original project directory.
+fn resolve_agent_config(base: Option<&AgentConfig>, repo_path: &std::path::Path) -> Option<AgentConfig> {
+    let cfg = base.cloned()?;
+
+    let Some(rules_file) = cfg.rules_file.as_deref() else {
+        return Some(cfg);
+    };
+
+    let path = std::path::Path::new(rules_file);
+    let full = if path.is_absolute() {
+        path.to_path_buf()
+    } else {
+        repo_path.join(path)
+    };
+
+    let mut out = cfg;
+    match std::fs::read_to_string(&full) {
+        Ok(contents) => {
+            out.rules = Some(contents);
+            out.rules_file = None;
+        }
+        Err(e) => {
+            if out.rules.is_some() {
+                eprintln!(
+                    "warning: could not read rules file {}: {e}; using existing inline rules",
+                    full.display()
+                );
+            } else {
+                eprintln!(
+                    "warning: could not read rules file {}: {e}; no inline rules set",
+                    full.display()
+                );
+            }
+            // Avoid persisting a path that likely won't resolve during restore.
+            out.rules_file = None;
+        }
+    }
+    Some(out)
+}
+
+/// Delegating agent that picks an underlying implementation per session.
+///
+/// Needed because `ao-rs watch`/`dashboard` manage a fleet of sessions that may
+/// have been spawned with different `--agent` values.
+struct MultiAgent;
+
+#[async_trait]
+impl Agent for MultiAgent {
+    fn launch_command(&self, session: &Session) -> String {
+        select_agent(&session.agent, session.agent_config.as_ref()).launch_command(session)
+    }
+
+    fn environment(&self, session: &Session) -> Vec<(String, String)> {
+        select_agent(&session.agent, session.agent_config.as_ref()).environment(session)
+    }
+
+    fn initial_prompt(&self, session: &Session) -> String {
+        select_agent(&session.agent, session.agent_config.as_ref()).initial_prompt(session)
+    }
+
+    async fn detect_activity(&self, session: &Session) -> ao_core::Result<ActivityState> {
+        select_agent(&session.agent, session.agent_config.as_ref())
+            .detect_activity(session)
+            .await
+    }
+
+    async fn cost_estimate(
+        &self,
+        session: &Session,
+    ) -> ao_core::Result<Option<ao_core::CostEstimate>> {
+        select_agent(&session.agent, session.agent_config.as_ref())
+            .cost_estimate(session)
+            .await
     }
 }
 
@@ -606,6 +687,8 @@ async fn spawn(
             id: session_id.clone(),
             project_id: project.clone(),
             status: SessionStatus::Spawning,
+            agent: agent_name.clone(),
+            agent_config: None,
             branch: branch.clone(),
             task: resolved_task,
             workspace_path: Some(workspace_path.clone()),
@@ -622,7 +705,9 @@ async fn spawn(
 
         // ---- 4. Agent: get launch command + env ----
         let agent_config = project_config.and_then(|p| p.agent_config.as_ref());
-        let agent: Box<dyn Agent> = select_agent(&agent_name, agent_config);
+        let resolved_agent_config = resolve_agent_config(agent_config, &repo_path);
+        session.agent_config = resolved_agent_config.clone();
+        let agent: Box<dyn Agent> = select_agent(&agent_name, resolved_agent_config.as_ref());
         let launch_command = agent.launch_command(&session);
         let env = agent.environment(&session);
         let initial_prompt = build_prompt(&session, project_config, issue_context.as_deref());
@@ -1090,10 +1175,7 @@ async fn watch(interval: Duration) -> Result<(), Box<dyn std::error::Error>> {
 
     let sessions = Arc::new(SessionManager::with_default());
     let runtime: Arc<dyn Runtime> = Arc::new(TmuxRuntime::new());
-    // TODO: Hardcoded to ClaudeCodeAgent — sessions spawned with `--agent cursor`
-    // will get incorrect activity detection. Need to persist agent name in Session
-    // and reconstruct the right plugin here.
-    let agent: Arc<dyn Agent> = Arc::new(ClaudeCodeAgent::with_default_rules());
+    let agent: Arc<dyn Agent> = Arc::new(MultiAgent);
     // Phase F: SCM plugin is compile-time GitHubScm. Zero-sized, so the
     // Arc here is just for trait-object uniformity with Runtime/Agent.
     let scm: Arc<dyn Scm> = Arc::new(GitHubScm::new());
@@ -1236,9 +1318,7 @@ async fn dashboard(port: u16, interval: Duration) -> Result<(), Box<dyn std::err
 
     let sessions = Arc::new(SessionManager::with_default());
     let runtime: Arc<dyn Runtime> = Arc::new(TmuxRuntime::new());
-    // TODO: Hardcoded to ClaudeCodeAgent — same limitation as `watch`.
-    // Need agent name persisted in Session to reconstruct the right plugin.
-    let agent: Arc<dyn Agent> = Arc::new(ClaudeCodeAgent::with_default_rules());
+    let agent: Arc<dyn Agent> = Arc::new(MultiAgent);
     let scm: Arc<dyn Scm> = Arc::new(GitHubScm::new());
 
     let config_path = AoConfig::local_path();
@@ -1780,10 +1860,13 @@ async fn review_check(
 async fn restore(session_id_or_prefix: String) -> Result<(), Box<dyn std::error::Error>> {
     let sessions = SessionManager::with_default();
     let runtime = TmuxRuntime::new();
-    let agent = ClaudeCodeAgent::with_default_rules();
+    // Resolve the session first so we can reconstruct the correct agent plugin
+    // (and its captured config) for the restore call.
+    let session = sessions.find_by_prefix(&session_id_or_prefix).await?;
+    let agent_box = select_agent(&session.agent, session.agent_config.as_ref());
 
     println!("→ restoring session: {session_id_or_prefix}");
-    let outcome = restore_session(&session_id_or_prefix, &sessions, &runtime, &agent).await?;
+    let outcome = restore_session(&session_id_or_prefix, &sessions, &runtime, agent_box.as_ref()).await?;
 
     let short: String = outcome.session.id.0.chars().take(8).collect();
     println!();
@@ -1895,6 +1978,8 @@ mod tests {
             id: SessionId("3a4b5c6d-aaaa-bbbb-cccc-dddd".into()),
             project_id: "demo".into(),
             status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: "ao-3a4b5c6d".into(),
             task: "fix the widgets".into(),
             workspace_path: None,

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -963,6 +963,8 @@ mod tests {
             id: SessionId(id.into()),
             project_id: project.into(),
             status: SessionStatus::Spawning,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: format!("ao-{id}"),
             task: "test task".into(),
             workspace_path: Some(PathBuf::from("/tmp/ws")),

--- a/crates/ao-core/src/prompt_builder.rs
+++ b/crates/ao-core/src/prompt_builder.rs
@@ -134,6 +134,8 @@ mod tests {
             id: SessionId("test-prompt-builder".into()),
             project_id: "my-app".into(),
             status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: "ao-abc123-feat-issue-42".into(),
             task: "Fix the login bug".into(),
             workspace_path: None,

--- a/crates/ao-core/src/reaction_engine.rs
+++ b/crates/ao-core/src/reaction_engine.rs
@@ -1015,6 +1015,8 @@ mod tests {
             id: SessionId(id.into()),
             project_id: "demo".into(),
             status: SessionStatus::CiFailed,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: format!("ao-{id}"),
             task: "t".into(),
             workspace_path: Some(PathBuf::from("/tmp/ws")),

--- a/crates/ao-core/src/restore.rs
+++ b/crates/ao-core/src/restore.rs
@@ -248,6 +248,8 @@ mod tests {
             id: SessionId(id.into()),
             project_id: "demo".into(),
             status,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: format!("ao-{id}"),
             task: "restored task".into(),
             workspace_path: Some(workspace.to_path_buf()),

--- a/crates/ao-core/src/session_manager.rs
+++ b/crates/ao-core/src/session_manager.rs
@@ -242,6 +242,8 @@ mod tests {
             id: SessionId(id.into()),
             project_id: project.into(),
             status: SessionStatus::Spawning,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: format!("ao-{id}"),
             task: task.into(),
             workspace_path: None,

--- a/crates/ao-core/src/types.rs
+++ b/crates/ao-core/src/types.rs
@@ -1,3 +1,4 @@
+use crate::config::AgentConfig;
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 use uuid::Uuid;
@@ -192,6 +193,19 @@ pub struct Session {
     pub id: SessionId,
     pub project_id: String,
     pub status: SessionStatus,
+    /// Agent plugin name used to spawn this session (e.g. "claude-code", "cursor").
+    ///
+    /// `#[serde(default)]` keeps older session YAML (written before multiple
+    /// agents were supported) deserializable.
+    #[serde(default = "default_agent_name")]
+    pub agent: String,
+    /// Agent config captured at spawn time (effective/inline).
+    ///
+    /// We persist this on the session so `restore` can relaunch with the same
+    /// rules/permissions even when the original repo-level `ao-rs.yaml` is not
+    /// available from the worktree path.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub agent_config: Option<AgentConfig>,
     pub branch: String,
     pub task: String,
     pub workspace_path: Option<PathBuf>,
@@ -244,6 +258,10 @@ pub fn now_ms() -> u64 {
         .duration_since(std::time::UNIX_EPOCH)
         .map(|d| d.as_millis() as u64)
         .unwrap_or(0)
+}
+
+fn default_agent_name() -> String {
+    "claude-code".into()
 }
 
 /// Aggregated token usage and estimated dollar cost for a session.
@@ -359,6 +377,8 @@ mod tests {
             id: SessionId("x".into()),
             project_id: "demo".into(),
             status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: "feat-x".into(),
             task: "t".into(),
             workspace_path: None,
@@ -389,6 +409,8 @@ mod tests {
             id: SessionId("x".into()),
             project_id: "demo".into(),
             status: SessionStatus::Merged,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: "feat-x".into(),
             task: "t".into(),
             workspace_path: None,
@@ -433,6 +455,8 @@ created_at: 1700000000000
 "#;
         let s: Session = serde_yaml::from_str(yaml).unwrap();
         assert_eq!(s.id.0, "abc");
+        assert_eq!(s.agent, "claude-code");
+        assert!(s.agent_config.is_none());
         assert!(s.activity.is_none());
         assert!(s.cost.is_none());
     }
@@ -457,6 +481,8 @@ created_at: 1700000000000
             id: SessionId("cost-test".into()),
             project_id: "demo".into(),
             status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: "feat-cost".into(),
             task: "track tokens".into(),
             workspace_path: None,
@@ -492,6 +518,8 @@ runtime_handle: null
 created_at: 0
 "#;
         let s: Session = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(s.agent, "claude-code");
+        assert!(s.agent_config.is_none());
         assert!(s.cost.is_none());
     }
 }

--- a/crates/ao-core/tests/notification_flow.rs
+++ b/crates/ao-core/tests/notification_flow.rs
@@ -45,6 +45,8 @@ fn fake_session(short: &str, project: &str) -> Session {
         id: SessionId(format!("{short}-0000-0000-0000-000000000000")),
         project_id: project.to_string(),
         status: SessionStatus::Working,
+        agent: "claude-code".to_string(),
+        agent_config: None,
         branch: format!("ao-{short}"),
         task: "test task".to_string(),
         workspace_path: Some(PathBuf::from("/tmp/fake-ws")),

--- a/crates/plugins/agent-claude-code/src/lib.rs
+++ b/crates/plugins/agent-claude-code/src/lib.rs
@@ -381,6 +381,8 @@ mod tests {
             id: SessionId("test-id".into()),
             project_id: "demo".into(),
             status: SessionStatus::Spawning,
+            agent: "claude-code".into(),
+            agent_config: None,
             branch: "feat-x".into(),
             task: "fix the typo in README".into(),
             workspace_path: Some(PathBuf::from("/tmp/demo")),

--- a/crates/plugins/agent-cursor/src/lib.rs
+++ b/crates/plugins/agent-cursor/src/lib.rs
@@ -201,6 +201,8 @@ mod tests {
             id: SessionId("cursor-test".into()),
             project_id: "demo".into(),
             status: SessionStatus::Working,
+            agent: "cursor".into(),
+            agent_config: None,
             branch: "ao-abc123-feat-test".into(),
             task: "fix the bug".into(),
             workspace_path: Some(PathBuf::from("/tmp/cursor-demo")),


### PR DESCRIPTION
Store agent name and effective agent config in session YAML so watch/dashboard/restore can run mixed-agent fleets and restore sessions with the same rules/permissions.

Made-with: Cursor