### PR TITLE
Fix session PR status semantics parity (TS reference)

### DIFF
--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -102,6 +102,50 @@ pub struct LifecycleManager {
 }
 
 impl LifecycleManager {
+    /// Decide whether the session should transition to `Stuck` *right now*,
+    /// based on the idle-since bookkeeping and the configured `agent-stuck`
+    /// threshold.
+    ///
+    /// This is the shared predicate used by:
+    /// - `check_stuck` (step 6), which runs when no other transition happened
+    ///   this tick.
+    /// - `poll_scm` (step 5), which may override a would-be `PrOpen` transition
+    ///   to `Stuck` so the tick still performs **one** status transition while
+    ///   matching the TS reference behavior (where stuck detection can win over
+    ///   the fallback `pr_open` state).
+    fn should_mark_stuck(&self, session: &Session) -> bool {
+        if !is_stuck_eligible(session.status) {
+            return false;
+        }
+
+        let idle_started = {
+            let map = self
+                .idle_since
+                .lock()
+                .expect("lifecycle idle_since mutex poisoned");
+            map.get(&session.id).copied()
+        };
+        let Some(idle_started) = idle_started else {
+            return false;
+        };
+
+        let Some(engine) = self.reaction_engine.as_ref() else {
+            return false;
+        };
+        let Some(cfg) = engine.reaction_config("agent-stuck") else {
+            return false;
+        };
+        let Some(raw) = cfg.threshold.as_deref() else {
+            return false;
+        };
+        let Some(threshold) = parse_duration(raw) else {
+            engine.warn_once_parse_failure("agent-stuck", "threshold", raw);
+            return false;
+        };
+
+        idle_started.elapsed() > threshold
+    }
+
     pub fn new(
         sessions: Arc<SessionManager>,
         runtime: Arc<dyn Runtime>,
@@ -434,7 +478,14 @@ impl LifecycleManager {
         };
 
         // ---- 4. Pure decision + transition ----
-        if let Some(next) = derive_scm_status(session.status, observation.as_ref()) {
+        if let Some(mut next) = derive_scm_status(session.status, observation.as_ref()) {
+            // TS stuck detection can override the fallback `pr_open` state when
+            // the agent has been idle beyond threshold. To preserve the Rust
+            // invariant of **one transition per tick**, we apply that override
+            // here before persisting/emitting the transition.
+            if next == SessionStatus::PrOpen && self.should_mark_stuck(session) {
+                next = SessionStatus::Stuck;
+            }
             self.transition(session, next).await?;
         }
         Ok(())
@@ -636,49 +687,7 @@ impl LifecycleManager {
     /// `agent-stuck` reaction. Subsequent ticks see `Stuck` (not
     /// stuck-eligible) and stay stable until activity flips back.
     async fn check_stuck(&self, session: &mut Session) -> Result<()> {
-        // Guard 1: stuck-eligible status?
-        if !is_stuck_eligible(session.status) {
-            return Ok(());
-        }
-
-        // Guard 2: has this session been idle long enough to even
-        // have a clock running?
-        let idle_started = {
-            let map = self
-                .idle_since
-                .lock()
-                .expect("lifecycle idle_since mutex poisoned");
-            map.get(&session.id).copied()
-        };
-        let Some(idle_started) = idle_started else {
-            return Ok(());
-        };
-
-        // Guard 3: is a reaction engine attached with an agent-stuck
-        // config? The earlier `self.reaction_engine.is_some()` check
-        // in `poll_one` already handled the `None` case, but we
-        // re-check here so the helper is safe to call in isolation.
-        let Some(engine) = self.reaction_engine.as_ref() else {
-            return Ok(());
-        };
-        let Some(cfg) = engine.reaction_config("agent-stuck") else {
-            return Ok(());
-        };
-
-        // Guard 4: parse the threshold. Missing → silent no-op
-        // (stuck detection disabled). Malformed → one-shot warn via
-        // the engine's warn_once helper so operators see it once in
-        // the logs but don't get spammed every tick.
-        let Some(raw) = cfg.threshold.as_deref() else {
-            return Ok(());
-        };
-        let Some(threshold) = parse_duration(raw) else {
-            engine.warn_once_parse_failure("agent-stuck", "threshold", raw);
-            return Ok(());
-        };
-
-        // Guard 5: has enough wall-clock time elapsed?
-        if idle_started.elapsed() <= threshold {
+        if !self.should_mark_stuck(session) {
             return Ok(());
         }
 
@@ -1953,6 +1962,80 @@ mod tests {
                 }
             )),
             "must NOT transition to Stuck on same tick as SCM transition: {events:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn stuck_overrides_pr_open_in_same_tick_when_idle_beyond_threshold() {
+        // TS determineStatus can return `stuck` instead of the fallback `pr_open`
+        // when an agent has a PR open but has been idle beyond the configured
+        // threshold. Rust matches this by overriding a would-be `PrOpen`
+        // transition inside `poll_scm` so we still do only one transition.
+        let base = unique_temp_dir("stuck_overrides_pr_open");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Idle));
+        let scm = Arc::new(MockScm::new());
+
+        let lifecycle = LifecycleManager::new(sessions.clone(), runtime, agent);
+
+        let mut stuck_cfg = ReactionConfig::new(ReactionAction::Notify);
+        stuck_cfg.threshold = Some("1s".into());
+        let mut map = std::collections::HashMap::new();
+        map.insert("agent-stuck".into(), stuck_cfg);
+        let engine_runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let engine = Arc::new(ReactionEngine::new(
+            map,
+            engine_runtime,
+            lifecycle.events_sender(),
+        ));
+
+        let lifecycle = Arc::new(
+            lifecycle
+                .with_reaction_engine(engine)
+                .with_scm(scm.clone() as Arc<dyn Scm>),
+        );
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::Working;
+        sessions.save(&s).await.unwrap();
+
+        // Pre-seed idle_since as if we've been idle for 2s (> 1s threshold).
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+
+        // Script SCM to the "fallback pr_open" case: open PR, no failures, no approvals yet.
+        scm.set_pr(Some(fake_pr(42, "ao-s1")));
+        scm.set_state(PrState::Open);
+        scm.set_ci(CiStatus::Pending);
+        scm.set_review(ReviewDecision::None);
+
+        let mut rx = lifecycle.subscribe();
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    from: SessionStatus::Working,
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "expected Working → Stuck transition, got {events:?}"
+        );
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    to: SessionStatus::PrOpen,
+                    ..
+                }
+            )),
+            "must not emit an intermediate PrOpen transition: {events:?}"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -1879,6 +1879,86 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn one_transition_per_tick_prefers_scm_transition_over_stuck() {
+        // If a session is already beyond the stuck threshold *and* SCM
+        // observes a PR transition (e.g. Working → CiFailed) on the same
+        // tick, the lifecycle must perform only the SCM-driven transition.
+        //
+        // This mirrors the TS `determineStatus` behavior where PR/CI/review
+        // semantics win over stuck detection in a single poll cycle.
+        let base = unique_temp_dir("one_transition_per_tick_scm_over_stuck");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Idle));
+        let scm = Arc::new(MockScm::new());
+
+        let lifecycle = LifecycleManager::new(sessions.clone(), runtime, agent);
+
+        // Reaction engine includes both `agent-stuck` (threshold) and
+        // `ci-failed` so both would be eligible if allowed.
+        let mut stuck_cfg = ReactionConfig::new(ReactionAction::Notify);
+        stuck_cfg.threshold = Some("1s".into());
+        let ci_cfg = ReactionConfig::new(ReactionAction::Notify);
+        let mut map = std::collections::HashMap::new();
+        map.insert("agent-stuck".into(), stuck_cfg);
+        map.insert("ci-failed".into(), ci_cfg);
+        let engine_runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let engine = Arc::new(ReactionEngine::new(
+            map,
+            engine_runtime,
+            lifecycle.events_sender(),
+        ));
+
+        let lifecycle = Arc::new(
+            lifecycle
+                .with_reaction_engine(engine)
+                .with_scm(scm.clone() as Arc<dyn Scm>),
+        );
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::Working;
+        sessions.save(&s).await.unwrap();
+
+        // Pre-seed idle_since as if we've been idle for 2s (> 1s threshold).
+        rewind_idle_since(&lifecycle, &s.id, Duration::from_secs(2));
+
+        // Script SCM to force a status transition on this tick.
+        scm.set_pr(Some(fake_pr(42, "ao-s1")));
+        scm.set_state(PrState::Open);
+        scm.set_ci(CiStatus::Failing);
+        scm.set_review(ReviewDecision::Pending);
+
+        let mut rx = lifecycle.subscribe();
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let events = drain_events(&mut rx).await;
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    from: SessionStatus::Working,
+                    to: SessionStatus::CiFailed,
+                    ..
+                }
+            )),
+            "expected Working → CiFailed transition, got {events:?}"
+        );
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::StatusChanged {
+                    to: SessionStatus::Stuck,
+                    ..
+                }
+            )),
+            "must NOT transition to Stuck on same tick as SCM transition: {events:?}"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
     async fn stuck_detection_fires_on_working_after_threshold() {
         // Session starts in Working, MockAgent reports Idle. After the
         // threshold has elapsed we expect a transition to Stuck and

--- a/crates/ao-core/src/scm_transitions.rs
+++ b/crates/ao-core/src/scm_transitions.rs
@@ -29,16 +29,15 @@
 //! one status at a time, so we pick:
 //!
 //! 1. `mergeability.is_ready()` → `Mergeable` (fires `approved-and-green`)
-//! 2. `review == ChangesRequested` → `ChangesRequested` (fires the reaction)
-//! 3. `ci == Failing` → `CiFailed` (fires `ci-failed`)
+//! 2. `ci == Failing` → `CiFailed` (fires `ci-failed`)
+//! 3. `review == ChangesRequested` → `ChangesRequested` (fires the reaction)
 //! 4. `review == Approved` (but not ready — e.g. CI still pending) → `Approved`
-//! 5. Everything else → `PrOpen`
+//! 5. `review == Pending` → `ReviewPending`
+//! 6. Everything else → `PrOpen`
 //!
-//! Rationale for `ChangesRequested > CiFailed`: human feedback is usually
-//! the higher-order bit (addressing it often re-runs CI anyway), and the
-//! reaction the agent gets back is strictly more informative. The TS
-//! reference folds the two into the same reaction slot; we preserve the
-//! priority explicitly so the state-machine is easier to reason about.
+//! The TS reference prioritizes `ci_failed` over `changes_requested` when both
+//! are true. Rust matches that ordering for parity (a red CI signal is the
+//! higher-urgency loop to close before re-review).
 //!
 //! ## No-PR handling
 //!
@@ -64,23 +63,12 @@
 //! `derive_scm_status` has no visibility into "did the merge call just
 //! fail?". See `LifecycleManager::transition` for the parking hook.
 //!
-//! ## `ReviewPending` is never produced here
+//! ## `ReviewPending`
 //!
-//! `ReviewPending` is part of the `is_pr_track` set (`derive_scm_status`
-//! can *leave* it back to `Working` on detect_pr(None), and the engine
-//! clears trackers on exit) but the open-PR priority ladder above
-//! never *enters* it: a PR with CI pending and no review today
-//! falls through rung 5 and lands in `PrOpen`. The status exists as
-//! a hook for future code — e.g. an explicit "reviewer was requested
-//! but hasn't started yet" signal from GitHub's review-request API —
-//! but today it is set only by callers outside this module (e.g. a
-//! hypothetical `ao-rs pr await-review <id>` command that parks the
-//! session in `ReviewPending` until a reviewer appears).
-//!
-//! If you're porting a TS behaviour that sets `ReviewPending`, add a
-//! new rung to the priority ladder here — don't sneak it into
-//! `is_pr_track` alone, because the tests would pass without you
-//! noticing the transition is unreachable.
+//! The TS lifecycle-manager sets `review_pending` when the overall review
+//! decision is `"pending"` ("REVIEW_REQUIRED" in GitHub terms). Rust matches
+//! that by explicitly mapping `ReviewDecision::Pending` to
+//! `SessionStatus::ReviewPending` (rung #5).
 
 use crate::{
     scm::{CiStatus, MergeReadiness, PrState, ReviewDecision},
@@ -182,10 +170,8 @@ fn status_with_pr(obs: &ScmObservation) -> SessionStatus {
         return SessionStatus::Merged;
     }
     if matches!(obs.state, PrState::Closed) {
-        // TS has a dedicated `pr_closed` terminal state; we fold it into
-        // `Terminated` because the session semantics are identical:
-        // the runtime is gone and the user has to decide what's next.
-        return SessionStatus::Terminated;
+        // TS maps a closed PR to `killed`.
+        return SessionStatus::Killed;
     }
 
     // Open PR — walk the priority ladder.
@@ -197,14 +183,17 @@ fn status_with_pr(obs: &ScmObservation) -> SessionStatus {
     if obs.readiness.is_ready() {
         return SessionStatus::Mergeable;
     }
-    if matches!(obs.review, ReviewDecision::ChangesRequested) {
-        return SessionStatus::ChangesRequested;
-    }
     if matches!(obs.ci, CiStatus::Failing) {
         return SessionStatus::CiFailed;
     }
+    if matches!(obs.review, ReviewDecision::ChangesRequested) {
+        return SessionStatus::ChangesRequested;
+    }
     if matches!(obs.review, ReviewDecision::Approved) {
         return SessionStatus::Approved;
+    }
+    if matches!(obs.review, ReviewDecision::Pending) {
+        return SessionStatus::ReviewPending;
     }
     // Default: a PR exists but nothing urgent — CI pending / no review
     // yet / etc. The session sits in PrOpen until something changes.
@@ -412,7 +401,7 @@ mod tests {
     }
 
     #[test]
-    fn closed_pr_transitions_working_to_terminated() {
+    fn closed_pr_transitions_working_to_killed() {
         let o = obs(
             PrState::Closed,
             CiStatus::None,
@@ -421,7 +410,7 @@ mod tests {
         );
         assert_eq!(
             derive_scm_status(SessionStatus::Working, Some(&o)),
-            Some(SessionStatus::Terminated)
+            Some(SessionStatus::Killed)
         );
     }
 
@@ -443,8 +432,7 @@ mod tests {
 
     #[test]
     fn changes_requested_beats_ci_failing() {
-        // Both conditions true — human feedback wins. Locks in the
-        // priority documented in the module comment.
+        // Both conditions true — TS prioritizes CI failing over changes requested.
         let o = obs(
             PrState::Open,
             CiStatus::Failing,
@@ -453,7 +441,7 @@ mod tests {
         );
         assert_eq!(
             derive_scm_status(SessionStatus::PrOpen, Some(&o)),
-            Some(SessionStatus::ChangesRequested)
+            Some(SessionStatus::CiFailed)
         );
     }
 
@@ -506,6 +494,20 @@ mod tests {
         assert_eq!(
             derive_scm_status(SessionStatus::Working, Some(&o)),
             Some(SessionStatus::PrOpen)
+        );
+    }
+
+    #[test]
+    fn review_pending_when_review_required_and_not_mergeable() {
+        let o = obs(
+            PrState::Open,
+            CiStatus::Pending,
+            ReviewDecision::Pending,
+            readiness_blocked(),
+        );
+        assert_eq!(
+            derive_scm_status(SessionStatus::PrOpen, Some(&o)),
+            Some(SessionStatus::ReviewPending)
         );
     }
 

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -346,7 +346,10 @@ pub(crate) fn compose_merge_readiness(
         .as_deref()
         .unwrap_or("")
         .to_ascii_uppercase();
-    let approved = review_decision == "APPROVED";
+    // TS treats "no review required / no decision" as effectively approved
+    // for the purpose of merge readiness so CI-green PRs can reach the
+    // `mergeable` session status.
+    let approved = review_decision.is_empty() || review_decision == "APPROVED";
     if review_decision == "CHANGES_REQUESTED" {
         blockers.push("Changes requested in review".into());
     } else if review_decision == "REVIEW_REQUIRED" {

--- a/docs/issue-14-phase1-audit.md
+++ b/docs/issue-14-phase1-audit.md
@@ -1,0 +1,51 @@
+# Issue #14 Phase 1 — State machine parity audit (TS → Rust)
+
+Reference TS implementation (upstream):
+- `packages/core/src/types.ts`
+- `packages/core/src/lifecycle-manager.ts` (`determineStatus`, PR/CI/review ladder)
+
+Rust implementation (this repo):
+- `crates/ao-core/src/types.rs` (`SessionStatus`, `ActivityState`)
+- `crates/ao-core/src/scm_transitions.rs` (`derive_scm_status`)
+- `crates/ao-core/src/lifecycle.rs` (tick order + “one transition per tick” gate)
+- `crates/plugins/scm-github/src/lib.rs` (`compose_merge_readiness`)
+
+## Status mapping (TS ↔ Rust)
+
+All TS `SessionStatus` variants map 1:1 to Rust **except**:
+
+- **TS**: (no equivalent) → **Rust**: `merge_failed`
+  - **Why**: Rust filters self-loop transitions (`X → X`) to avoid event spam. TS allows `mergeable → mergeable` and uses that to retry auto-merge on later ticks. Rust adds `merge_failed` as a parking state so the merge retry loop remains possible without reintroducing self-loops.
+
+## PR/CI/Review transition semantics (TS vs Rust)
+
+### Open PR priority ladder
+
+TS (`determineStatus`, PR branch) order:
+1. merged → `merged`
+2. closed → `killed`
+3. CI failing → `ci_failed`
+4. review changes requested → `changes_requested`
+5. review approved OR none:
+   - mergeability true → `mergeable`
+   - else (approved only) → `approved`
+6. review pending → `review_pending`
+7. else → `pr_open`
+
+Rust (`derive_scm_status`) now matches this ordering with two deliberate differences:
+- It computes mergeability via `MergeReadiness::is_ready()` (a composite of CI + approvals + conflicts + blockers) rather than TS’s separate `reviewDecision` + `mergeable` booleans.
+- It retains the `merge_failed` parking loop (see above).
+
+### Fixes applied (parity gaps)
+
+- **Made `review_pending` reachable** in Rust PR ladder when `ReviewDecision::Pending`.
+- **Matched TS priority** for “CI failing vs changes requested”: `ci_failed` wins.
+- **Matched TS terminal mapping** for closed PRs: `PrState::Closed → killed`.
+- **Matched TS “review none counts as approved for merge readiness”** by treating missing `reviewDecision` as `approved=true` in GitHub merge-readiness composition so CI-green/no-review-required PRs can reach `mergeable`.
+
+## Tick order / one-transition-per-tick
+
+Rust `lifecycle.rs` enforces: **at most one status transition per tick**. This mirrors TS’s “one `determineStatus()` result per poll cycle” semantics.
+
+Added regression test: a session beyond stuck threshold + an SCM transition on the same tick must yield only the SCM transition (no immediate `… → stuck`).
+

--- a/docs/state-machine.md
+++ b/docs/state-machine.md
@@ -136,23 +136,19 @@ wins:
 | # | Condition | Next status |
 | --- | --- | --- |
 | 1 | `mergeability.is_ready()` | `mergeable` |
-| 2 | `review == changes_requested` | `changes_requested` |
-| 3 | `ci == failing` | `ci_failed` |
+| 2 | `ci == failing` | `ci_failed` |
+| 3 | `review == changes_requested` | `changes_requested` |
 | 4 | `review == approved` (but not ready) | `approved` |
-| 5 | default | `pr_open` |
+| 5 | `review == pending` | `review_pending` |
+| 6 | default | `pr_open` |
 
-Rationale for `changes_requested > ci_failed`: human feedback is
-usually the higher-order bit (addressing it often re-runs CI anyway),
-and the agent's reaction response is strictly more informative. The TS
-reference folds the two into one reaction slot; we preserve the
-priority explicitly.
+The TS reference prioritizes `ci_failed` over `changes_requested` when
+both are true; Rust matches that order for parity.
 
 ### Terminal PR states
 
 - `state == merged` → `merged` (terminal; fires post-merge cleanup).
-- `state == closed` → `terminated` (TS has a dedicated `pr_closed`
-  terminal state; we fold it into `terminated` because the session
-  semantics are identical — runtime is gone, user decides what's next).
+- `state == closed` → `killed` (matches the TS reference).
 
 A `(next != current).then_some(next)` filter at the top of
 `derive_scm_status` elides self-loops so subscribers never see


### PR DESCRIPTION
Closes #14 (Phase 1).

## Summary
- Align `derive_scm_status` with upstream TS lifecycle semantics:
  - Prioritize `ci_failed` over `changes_requested` when both apply
  - Make `review_pending` reachable for `ReviewDecision::Pending`
  - Map closed PRs to `killed`
- Treat GitHub `reviewDecision: null` as "no review required" for merge readiness so CI-green PRs can reach `mergeable`
- Add a lifecycle regression test enforcing one-transition-per-tick when SCM + stuck conditions coincide
- Add audit report at `docs/issue-14-phase1-audit.md` and update `docs/state-machine.md`

## Test plan
- `cargo test -p ao-core`

Made with [Cursor](https://cursor.com)