### PR TITLE
feat(workspace-clone): add git clone workspace plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -278,6 +278,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "ao-plugin-workspace-clone"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "ao-plugin-workspace-worktree"
 version = "0.0.1"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,7 @@ members = [
     "crates/ao-dashboard",
     "crates/ao-desktop/src-tauri",
     "crates/plugins/workspace-worktree",
+    "crates/plugins/workspace-clone",
     "crates/plugins/runtime-tmux",
     "crates/plugins/runtime-process",
     "crates/plugins/agent-claude-code",
@@ -27,6 +28,7 @@ rust-version = "1.80"
 [workspace.dependencies]
 ao-core = { path = "crates/ao-core" }
 ao-plugin-workspace-worktree = { path = "crates/plugins/workspace-worktree" }
+ao-plugin-workspace-clone = { path = "crates/plugins/workspace-clone" }
 ao-plugin-runtime-process = { path = "crates/plugins/runtime-process" }
 
 tokio = { version = "1", features = ["full"] }

--- a/crates/plugins/workspace-clone/Cargo.toml
+++ b/crates/plugins/workspace-clone/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "ao-plugin-workspace-clone"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }

--- a/crates/plugins/workspace-clone/src/lib.rs
+++ b/crates/plugins/workspace-clone/src/lib.rs
@@ -1,0 +1,206 @@
+//! Git clone workspace plugin.
+//!
+//! Creates an isolated working directory under `~/.clones/{project}/{session}`
+//! by running `git clone` against the source repo. Each session gets a fully
+//! independent clone — no shared `.git` — so processes inside cannot interfere
+//! with each other or with the origin repo.
+//!
+//! Equivalent to `packages/plugins/workspace-clone` in the reference TypeScript
+//! repo but scoped to the same minimal surface as the worktree plugin:
+//! no symlinks, no postCreate hooks, no list/restore.
+
+use ao_core::{AoError, Result, Workspace, WorkspaceCreateConfig};
+use async_trait::async_trait;
+use std::path::{Path, PathBuf};
+use tokio::process::Command;
+
+/// Workspace implementation backed by `git clone`.
+///
+/// The clone layout is `base_dir/{project_id}/{session_id}`.
+///
+/// # Shallow clones
+///
+/// By default a full clone is performed. Pass a depth via [`CloneWorkspace::with_depth`]
+/// to get a shallow clone (`--depth N`). Depth `1` is the most common choice and
+/// produces the smallest clone at the cost of missing earlier history.
+pub struct CloneWorkspace {
+    base_dir: PathBuf,
+    /// When `Some(n)`, passes `--depth n` to `git clone` for a shallow clone.
+    /// `None` (default) performs a full clone.
+    depth: Option<u32>,
+}
+
+impl CloneWorkspace {
+    /// Create with the default base dir `~/.clones` and a full (non-shallow) clone.
+    pub fn new() -> Self {
+        Self {
+            base_dir: home_dir().join(".clones"),
+            depth: None,
+        }
+    }
+
+    /// Create with an explicit base dir (useful for tests).
+    pub fn with_base_dir(base_dir: PathBuf) -> Self {
+        Self {
+            base_dir,
+            depth: None,
+        }
+    }
+
+    /// Set the clone depth for shallow clones (e.g. `1`).
+    /// Call after `new()` or `with_base_dir()`.
+    pub fn with_depth(mut self, depth: u32) -> Self {
+        self.depth = Some(depth);
+        self
+    }
+}
+
+impl Default for CloneWorkspace {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Workspace for CloneWorkspace {
+    /// Clone the repo into `base_dir/{project_id}/{session_id}` and create
+    /// a new branch `cfg.branch` starting from `cfg.default_branch`.
+    async fn create(&self, cfg: &WorkspaceCreateConfig) -> Result<PathBuf> {
+        assert_safe_segment(&cfg.project_id, "project_id")?;
+        assert_safe_segment(&cfg.session_id, "session_id")?;
+
+        let project_dir = self.base_dir.join(&cfg.project_id);
+        let clone_path = project_dir.join(&cfg.session_id);
+
+        tokio::fs::create_dir_all(&project_dir).await?;
+
+        let repo_str = path_to_str(&cfg.repo_path)?;
+        let clone_str = path_to_str(&clone_path)?;
+        let depth_str = self.depth.map(|d| d.to_string());
+
+        // Build the clone argument list.
+        // --local + --no-hardlinks: safe copy even across filesystems.
+        // --single-branch: only fetch the default branch history, keeping the
+        //   clone lean while still allowing new branches to be created locally.
+        let mut args: Vec<&str> = vec![
+            "clone",
+            "--local",
+            "--no-hardlinks",
+            "--single-branch",
+            "--branch",
+            &cfg.default_branch,
+        ];
+
+        if let Some(ref d) = depth_str {
+            args.extend_from_slice(&["--depth", d]);
+        }
+
+        args.push(&repo_str);
+        args.push(&clone_str);
+
+        git(&project_dir, &args).await?;
+
+        // Create the target session branch from the cloned default branch.
+        git(&clone_path, &["checkout", "-b", &cfg.branch]).await?;
+
+        tracing::debug!(
+            clone = %clone_path.display(),
+            branch = %cfg.branch,
+            "workspace clone created"
+        );
+
+        Ok(clone_path)
+    }
+
+    /// Remove the cloned directory entirely. Unlike worktrees, there is no
+    /// shared git bookkeeping to update — a plain directory removal is enough.
+    async fn destroy(&self, workspace_path: &Path) -> Result<()> {
+        if workspace_path.exists() {
+            tokio::fs::remove_dir_all(workspace_path).await?;
+            tracing::debug!(path = %workspace_path.display(), "workspace clone destroyed");
+        }
+        Ok(())
+    }
+}
+
+// ---------- helpers ----------
+
+/// Run `git <args>` with `cwd` as the working directory.
+/// Returns trimmed stdout on success, or a structured `AoError::Workspace` on failure.
+async fn git(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(args)
+        .current_dir(cwd)
+        .output()
+        .await
+        .map_err(|e| AoError::Workspace(format!("git spawn failed: {e}")))?;
+
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AoError::Workspace(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout)
+        .trim_end()
+        .to_string())
+}
+
+/// Reject anything that isn't `[a-zA-Z0-9_-]+` to prevent path traversal.
+fn assert_safe_segment(value: &str, label: &str) -> Result<()> {
+    let ok = !value.is_empty()
+        && value
+            .chars()
+            .all(|c| c.is_ascii_alphanumeric() || c == '_' || c == '-');
+    if !ok {
+        return Err(AoError::Workspace(format!(
+            "invalid {label} \"{value}\": must be [a-zA-Z0-9_-]+"
+        )));
+    }
+    Ok(())
+}
+
+fn path_to_str(p: &Path) -> Result<String> {
+    p.to_str()
+        .map(str::to_owned)
+        .ok_or_else(|| AoError::Workspace(format!("path is not valid UTF-8: {}", p.display())))
+}
+
+fn home_dir() -> PathBuf {
+    std::env::var("HOME")
+        .map(PathBuf::from)
+        .unwrap_or_else(|_| PathBuf::from("/tmp"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn safe_segment_accepts_normal_ids() {
+        assert!(assert_safe_segment("my-project_42", "x").is_ok());
+        assert!(assert_safe_segment("a", "x").is_ok());
+    }
+
+    #[test]
+    fn safe_segment_rejects_traversal() {
+        assert!(assert_safe_segment("../etc", "x").is_err());
+        assert!(assert_safe_segment("foo/bar", "x").is_err());
+        assert!(assert_safe_segment("", "x").is_err());
+        assert!(assert_safe_segment("foo bar", "x").is_err());
+    }
+
+    #[test]
+    fn with_depth_sets_field() {
+        let ws = CloneWorkspace::with_base_dir(PathBuf::from("/tmp")).with_depth(1);
+        assert_eq!(ws.depth, Some(1));
+    }
+
+    #[test]
+    fn default_depth_is_none() {
+        let ws = CloneWorkspace::with_base_dir(PathBuf::from("/tmp"));
+        assert_eq!(ws.depth, None);
+    }
+}

--- a/crates/plugins/workspace-clone/tests/integration.rs
+++ b/crates/plugins/workspace-clone/tests/integration.rs
@@ -1,0 +1,180 @@
+//! Integration tests against a real on-disk git repo.
+//!
+//! Each test creates a temporary git repository, runs the plugin, and verifies
+//! the clone appears correctly and is cleaned up by `destroy`.
+
+use ao_core::{Workspace, WorkspaceCreateConfig};
+use ao_plugin_workspace_clone::CloneWorkspace;
+use std::path::PathBuf;
+use std::process::Command;
+use std::sync::atomic::{AtomicU64, Ordering};
+use std::time::{SystemTime, UNIX_EPOCH};
+
+/// Monotonic suffix so parallel tests never pick the same tempdir.
+static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+fn unique_dir(label: &str) -> PathBuf {
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+    std::env::temp_dir().join(format!("ao-rs-test-clone-{label}-{nanos}-{n}"))
+}
+
+fn run(cmd: &str, args: &[&str], cwd: &PathBuf) {
+    let status = Command::new(cmd)
+        .args(args)
+        .current_dir(cwd)
+        .status()
+        .unwrap_or_else(|e| panic!("failed to spawn {cmd}: {e}"));
+    assert!(status.success(), "{cmd} {args:?} failed in {cwd:?}");
+}
+
+/// Create a minimal git repo with one commit on `main`.
+fn init_repo() -> PathBuf {
+    let dir = unique_dir("repo");
+    std::fs::create_dir_all(&dir).unwrap();
+    run("git", &["init", "-q", "-b", "main"], &dir);
+    run("git", &["config", "user.email", "test@example.com"], &dir);
+    run("git", &["config", "user.name", "Test"], &dir);
+    std::fs::write(dir.join("README.md"), "hello\n").unwrap();
+    run("git", &["add", "README.md"], &dir);
+    run("git", &["commit", "-q", "-m", "init"], &dir);
+    dir
+}
+
+#[tokio::test]
+async fn create_and_destroy_clone() {
+    let repo = init_repo();
+    let base = unique_dir("clones");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess1".to_string(),
+        branch: "feat-test".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+    };
+
+    let path = workspace.create(&cfg).await.expect("create failed");
+
+    // The clone must exist at the expected path.
+    assert!(path.exists(), "clone path not created");
+    assert_eq!(path, base.join("demo").join("sess1"));
+
+    // The cloned content must be present.
+    assert!(
+        path.join("README.md").exists(),
+        "README.md not present in clone"
+    );
+
+    // The session branch must be checked out.
+    let branch_output = std::process::Command::new("git")
+        .args(["rev-parse", "--abbrev-ref", "HEAD"])
+        .current_dir(&path)
+        .output()
+        .expect("git rev-parse failed");
+    let branch = String::from_utf8_lossy(&branch_output.stdout)
+        .trim()
+        .to_string();
+    assert_eq!(branch, "feat-test", "wrong branch checked out");
+
+    workspace.destroy(&path).await.expect("destroy failed");
+    assert!(!path.exists(), "clone path not cleaned up after destroy");
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn shallow_clone_creates_valid_workspace() {
+    let repo = init_repo();
+    let base = unique_dir("clones-shallow");
+    let workspace = CloneWorkspace::with_base_dir(base.clone()).with_depth(1);
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "shallow1".to_string(),
+        branch: "feat-shallow".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+    };
+
+    let path = workspace.create(&cfg).await.expect("shallow create failed");
+    assert!(path.exists(), "shallow clone path not created");
+    assert!(
+        path.join("README.md").exists(),
+        "README.md missing in shallow clone"
+    );
+
+    workspace.destroy(&path).await.expect("destroy failed");
+    assert!(!path.exists(), "shallow clone not cleaned up");
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn rejects_unsafe_session_id() {
+    let repo = init_repo();
+    let base = unique_dir("clones-bad");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "../escape".to_string(),
+        branch: "feat-test".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+    };
+
+    let result = workspace.create(&cfg).await;
+    assert!(
+        result.is_err(),
+        "should reject path traversal in session_id"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn rejects_unsafe_project_id() {
+    let repo = init_repo();
+    let base = unique_dir("clones-bad-proj");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "bad/project".to_string(),
+        session_id: "sess1".to_string(),
+        branch: "feat-test".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+    };
+
+    let result = workspace.create(&cfg).await;
+    assert!(
+        result.is_err(),
+        "should reject path traversal in project_id"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn destroy_is_idempotent() {
+    let base = unique_dir("clones-idempotent");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    // Destroying a path that does not exist must succeed (no error).
+    let nonexistent = base.join("proj").join("no-such-session");
+    workspace
+        .destroy(&nonexistent)
+        .await
+        .expect("destroy of nonexistent path should succeed");
+
+    let _ = std::fs::remove_dir_all(&base);
+}


### PR DESCRIPTION
## Summary

- Adds new crate `crates/plugins/workspace-clone` implementing `ao_core::Workspace` via `git clone`
- Each session gets a fully independent clone under `~/.clones/{project}/{session}` — no shared `.git`, no cross-session interference
- Supports full and shallow clones (configurable via `.with_depth(n)` builder method)
- Path-traversal guards on `project_id` and `session_id` (same `[a-zA-Z0-9_-]+` rule as worktree plugin)
- Idempotent `destroy` — safe to call even if the path doesn't exist
- Registers the crate in the workspace `Cargo.toml` members and `[workspace.dependencies]`

## How it works

**`create`:** validates IDs → `mkdir -p base/{project}` → `git clone --local --no-hardlinks --single-branch --branch <default_branch> <repo> <dest>` → `git checkout -b <session_branch>` → returns the clone path.

**`destroy`:** `tokio::fs::remove_dir_all` on the clone directory. No worktree bookkeeping needed.

**Shallow clone:** opt-in via `CloneWorkspace::with_base_dir(…).with_depth(1)` — passes `--depth N` to `git clone`.

## Test plan

- [x] 4 unit tests (safe segment validation, depth field accessors)
- [x] `create_and_destroy_clone` — creates a real temp git repo, clones it, asserts path + file + branch, destroys and checks cleanup
- [x] `shallow_clone_creates_valid_workspace` — same but with depth=1
- [x] `rejects_unsafe_session_id` — path traversal blocked
- [x] `rejects_unsafe_project_id` — path traversal blocked
- [x] `destroy_is_idempotent` — no error when path doesn't exist
- [x] `cargo clippy -- -D warnings` clean
- [x] `cargo fmt -- --check` clean

Closes #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)