### PR TITLE
feat(tracker-linear): add Linear issue tracker support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -113,6 +113,7 @@ dependencies = [
  "ao-plugin-runtime-tmux",
  "ao-plugin-scm-github",
  "ao-plugin-tracker-github",
+ "ao-plugin-tracker-linear",
  "ao-plugin-workspace-worktree",
  "async-trait",
  "clap",
@@ -271,6 +272,19 @@ version = "0.0.1"
 dependencies = [
  "ao-core",
  "async-trait",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "ao-plugin-tracker-linear"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "reqwest 0.12.28",
  "serde",
  "serde_json",
  "tokio",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,7 @@ members = [
     "crates/plugins/agent-cursor",
     "crates/plugins/scm-github",
     "crates/plugins/tracker-github",
+    "crates/plugins/tracker-linear",
     "crates/plugins/notifier-stdout",
     "crates/plugins/notifier-ntfy",
     "crates/plugins/notifier-desktop",

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -18,6 +18,7 @@ ao-plugin-agent-claude-code = { path = "../plugins/agent-claude-code" }
 ao-plugin-agent-cursor = { path = "../plugins/agent-cursor" }
 ao-plugin-scm-github = { path = "../plugins/scm-github" }
 ao-plugin-tracker-github = { path = "../plugins/tracker-github" }
+ao-plugin-tracker-linear = { path = "../plugins/tracker-linear" }
 ao-plugin-notifier-stdout = { path = "../plugins/notifier-stdout" }
 ao-plugin-notifier-ntfy = { path = "../plugins/notifier-ntfy" }
 ao-plugin-notifier-desktop = { path = "../plugins/notifier-desktop" }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -17,10 +17,10 @@
 
 use ao_core::{
     build_prompt, default_agent_rules, detect_git_repo, generate_config, install_skills, now_ms,
-    paths, restore_session, ActivityState, Agent, AgentConfig, AoConfig, CiStatus, LifecycleManager,
-    LockError, MergeReadiness, NotificationRouting, NotifierRegistry, OrchestratorEvent, PidFile,
-    PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm, Session, SessionId,
-    SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
+    paths, restore_session, ActivityState, Agent, AgentConfig, AoConfig, CiStatus,
+    LifecycleManager, LockError, MergeReadiness, NotificationRouting, NotifierRegistry,
+    OrchestratorEvent, PidFile, PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm,
+    Session, SessionId, SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
 use ao_plugin_agent_claude_code::ClaudeCodeAgent;
 use ao_plugin_agent_cursor::CursorAgent;
@@ -32,6 +32,7 @@ use ao_plugin_runtime_process::ProcessRuntime;
 use ao_plugin_runtime_tmux::TmuxRuntime;
 use ao_plugin_scm_github::GitHubScm;
 use ao_plugin_tracker_github::GitHubTracker;
+use ao_plugin_tracker_linear::LinearTracker;
 use ao_plugin_workspace_worktree::WorktreeWorkspace;
 use async_trait::async_trait;
 use clap::{Parser, Subcommand};
@@ -1017,13 +1018,15 @@ fn resolve_project_id(
         let canon = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
         (canon == repo_canon).then(|| id.clone())
     });
-    let matched_by_repo_slug = detect_git_repo(repo_path)
-        .ok()
-        .and_then(|(owner_repo, _repo_name, _branch)| {
-            ao_config.projects.iter().find_map(|(id, cfg)| {
-                (cfg.repo == owner_repo).then(|| id.clone())
-            })
-        });
+    let matched_by_repo_slug =
+        detect_git_repo(repo_path)
+            .ok()
+            .and_then(|(owner_repo, _repo_name, _branch)| {
+                ao_config
+                    .projects
+                    .iter()
+                    .find_map(|(id, cfg)| (cfg.repo == owner_repo).then(|| id.clone()))
+            });
     let matched_single = (ao_config.projects.len() == 1)
         .then(|| ao_config.projects.keys().next().cloned())
         .flatten();
@@ -1081,6 +1084,7 @@ async fn spawn(
     // - otherwise try to match by `projects.*.path == repo_root`
     // - otherwise default to repo directory name
     let project = resolve_project_id(&repo_path, &ao_config, project);
+    let project_config = ao_config.projects.get(&project);
 
     // ---- 1b. Resolve task, branch, issue metadata, and project config ----
     // One of: --issue (GitHub), --local-issue (markdown file), --task (free-form).
@@ -1109,7 +1113,17 @@ async fn spawn(
                 }
             }
             println!("→ fetching issue {}...", id);
-            let tracker = GitHubTracker::from_repo(&repo_path).await?;
+            let tracker_name = project_config
+                .and_then(|p| p.tracker.as_deref())
+                .or_else(|| ao_config.defaults.as_ref().map(|d| d.tracker.as_str()))
+                .unwrap_or("github");
+
+            let tracker: Box<dyn Tracker> = match tracker_name {
+                "linear" => Box::new(LinearTracker::from_env()?),
+                // Default + fallback: github
+                _ => Box::new(GitHubTracker::from_repo(&repo_path).await?),
+            };
+
             let fetched = tracker.get_issue(id).await?;
             let branch = tracker.branch_name(id);
             // Generate structured issue context via the tracker plugin's
@@ -1152,7 +1166,6 @@ async fn spawn(
             (task.unwrap(), None, None, None, None)
         };
 
-    let project_config = ao_config.projects.get(&project);
     let agent_name = agent_name
         .or_else(|| ao_config.defaults.as_ref().map(|d| d.agent.clone()))
         .unwrap_or_else(|| "claude-code".to_string());
@@ -2640,6 +2653,7 @@ mod tests {
                 repo: "duonghb53/ao-rs".into(),
                 path: repo_dir.to_string_lossy().to_string(),
                 default_branch: "main".into(),
+                tracker: None,
                 agent_config: Some(AgentConfig {
                     permissions: "permissionless".into(),
                     rules: Some("rules from config".into()),
@@ -2652,6 +2666,7 @@ mod tests {
                 runtime: "tmux".into(),
                 agent: "cursor".into(),
                 workspace: "worktree".into(),
+                tracker: "github".into(),
                 notifiers: vec![],
             }),
             projects,
@@ -2668,8 +2683,14 @@ mod tests {
 
         // And that means spawn would see the right per-project config.
         let proj = loaded.projects.get(&project_id).unwrap();
-        assert_eq!(proj.agent_config.as_ref().unwrap().permissions, "permissionless");
-        assert_eq!(proj.agent_config.as_ref().unwrap().rules.as_deref(), Some("rules from config"));
+        assert_eq!(
+            proj.agent_config.as_ref().unwrap().permissions,
+            "permissionless"
+        );
+        assert_eq!(
+            proj.agent_config.as_ref().unwrap().rules.as_deref(),
+            Some("rules from config")
+        );
 
         // And the right defaults.
         assert_eq!(loaded.defaults.as_ref().unwrap().agent, "cursor");

--- a/crates/ao-core/src/config.rs
+++ b/crates/ao-core/src/config.rs
@@ -29,6 +29,9 @@ fn default_agent() -> String {
 fn default_workspace() -> String {
     "worktree".into()
 }
+fn default_tracker() -> String {
+    "github".into()
+}
 fn default_branch_name() -> String {
     "main".into()
 }
@@ -47,6 +50,8 @@ pub struct DefaultsConfig {
     pub agent: String,
     #[serde(default = "default_workspace")]
     pub workspace: String,
+    #[serde(default = "default_tracker")]
+    pub tracker: String,
     #[serde(default)]
     pub notifiers: Vec<String>,
 }
@@ -57,6 +62,7 @@ impl Default for DefaultsConfig {
             runtime: default_runtime(),
             agent: default_agent(),
             workspace: default_workspace(),
+            tracker: default_tracker(),
             notifiers: vec![],
         }
     }
@@ -76,6 +82,9 @@ pub struct ProjectConfig {
         rename = "default_branch"
     )]
     pub default_branch: String,
+    /// Issue tracker plugin for `spawn --issue` ("github", "linear", ...).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub tracker: Option<String>,
     /// Agent-specific overrides.
     #[serde(
         default,
@@ -541,6 +550,7 @@ pub fn generate_config(cwd: &Path) -> Result<AoConfig> {
             repo: owner_repo,
             path: abs_path.to_string_lossy().to_string(),
             default_branch,
+            tracker: None,
             agent_config: Some(AgentConfig::default()),
         },
     );
@@ -798,6 +808,7 @@ notification-routing:
         assert_eq!(dc.runtime, "tmux");
         assert_eq!(dc.agent, "claude-code");
         assert_eq!(dc.workspace, "worktree");
+        assert_eq!(dc.tracker, "github");
         assert!(dc.notifiers.is_empty());
 
         let yaml = serde_yaml::to_string(&dc).unwrap();
@@ -811,6 +822,7 @@ notification-routing:
             repo: "owner/repo".into(),
             path: "/tmp/test".into(),
             default_branch: "main".into(),
+            tracker: Some("github".into()),
             agent_config: Some(AgentConfig::default()),
         };
         let yaml = serde_yaml::to_string(&pc).unwrap();
@@ -824,6 +836,7 @@ notification-routing:
             repo: "owner/repo".into(),
             path: "/tmp/test".into(),
             default_branch: "develop".into(),
+            tracker: None,
             agent_config: None,
         };
         let yaml = serde_yaml::to_string(&pc).unwrap();
@@ -841,6 +854,7 @@ notification-routing:
                 repo: "org/my-app".into(),
                 path: "/home/user/my-app".into(),
                 default_branch: "main".into(),
+                tracker: Some("github".into()),
                 agent_config: Some(AgentConfig {
                     permissions: "default".into(),
                     rules: None,

--- a/crates/ao-core/src/prompt_builder.rs
+++ b/crates/ao-core/src/prompt_builder.rs
@@ -155,6 +155,7 @@ mod tests {
             repo: "acme/widgets".into(),
             path: "/home/user/widgets".into(),
             default_branch: "main".into(),
+            tracker: None,
             agent_config: None,
         }
     }

--- a/crates/plugins/tracker-linear/Cargo.toml
+++ b/crates/plugins/tracker-linear/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ao-plugin-tracker-linear"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["json", "rustls-tls"] }
+

--- a/crates/plugins/tracker-linear/src/lib.rs
+++ b/crates/plugins/tracker-linear/src/lib.rs
@@ -1,0 +1,376 @@
+//! Linear issue tracker plugin — HTTP to Linear GraphQL API.
+//!
+//! Auth via env var `LINEAR_API_TOKEN` (personal API key) and requests sent to:
+//! `https://api.linear.app/graphql`.
+
+use ao_core::{AoError, Issue, IssueState, Result, Tracker};
+use async_trait::async_trait;
+use reqwest::Client;
+use serde::Deserialize;
+use serde_json::json;
+use std::time::Duration;
+
+const DEFAULT_ENDPOINT: &str = "https://api.linear.app/graphql";
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone)]
+pub struct LinearTracker {
+    endpoint: String,
+    token: String,
+    http: Client,
+}
+
+impl LinearTracker {
+    pub fn new(token: impl Into<String>) -> Result<Self> {
+        let http = Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .map_err(|e| AoError::Other(format!("failed to build http client: {e}")))?;
+        Ok(Self {
+            endpoint: DEFAULT_ENDPOINT.to_string(),
+            token: token.into(),
+            http,
+        })
+    }
+
+    pub fn from_env() -> Result<Self> {
+        let token = std::env::var("LINEAR_API_TOKEN")
+            .or_else(|_| std::env::var("LINEAR_API_KEY"))
+            .map_err(|_| {
+                AoError::Other(
+                    "missing Linear API token: set LINEAR_API_TOKEN (or LINEAR_API_KEY)".into(),
+                )
+            })?;
+        Self::new(token)
+    }
+
+    fn normalize_identifier(id: &str) -> String {
+        let trimmed = id.trim();
+        if let Some(rest) = trimmed.strip_prefix("https://linear.app/") {
+            // URL form: https://linear.app/<workspace>/issue/LIN-123/some-title
+            // Also accept https://linear.app/issue/LIN-123/... (rare).
+            let parts: Vec<&str> = rest.split('/').collect();
+            if let Some(pos) = parts.iter().position(|p| *p == "issue") {
+                if let Some(key) = parts.get(pos + 1) {
+                    if !key.is_empty() {
+                        return key.to_string();
+                    }
+                }
+            }
+        }
+        trimmed.to_string()
+    }
+
+    async fn graphql<T: for<'de> Deserialize<'de>>(
+        &self,
+        query: &str,
+        variables: serde_json::Value,
+    ) -> Result<T> {
+        let body = json!({ "query": query, "variables": variables });
+        let resp = self
+            .http
+            .post(&self.endpoint)
+            .header("Content-Type", "application/json")
+            .header("Authorization", self.token.clone())
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| AoError::Other(format!("Linear request failed: {e}")))?;
+
+        let status = resp.status();
+        let text = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Other(format!("Linear response read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Other(format!(
+                "Linear API error (HTTP {status}): {text}"
+            )));
+        }
+
+        let parsed: GraphqlResponse<T> = serde_json::from_str(&text)
+            .map_err(|e| AoError::Other(format!("Linear response parse failed: {e}")))?;
+        if let Some(errors) = parsed.errors {
+            let msg = errors
+                .into_iter()
+                .map(|e| e.message)
+                .collect::<Vec<_>>()
+                .join("; ");
+            return Err(AoError::Other(format!("Linear GraphQL error: {msg}")));
+        }
+        parsed
+            .data
+            .ok_or_else(|| AoError::Other("Linear GraphQL response missing data".into()))
+    }
+}
+
+#[async_trait]
+impl Tracker for LinearTracker {
+    fn name(&self) -> &str {
+        "linear"
+    }
+
+    async fn get_issue(&self, identifier: &str) -> Result<Issue> {
+        let id = Self::normalize_identifier(identifier);
+
+        // Linear docs: issue(id: "LIN-123") works with the human identifier.
+        let q = r#"
+          query Issue($id: String!) {
+            issue(id: $id) {
+              id
+              identifier
+              title
+              description
+              url
+              state { type name }
+              labels { nodes { name } }
+              assignee { name }
+              team { key name }
+              project { name }
+              cycle { name startsAt endsAt }
+            }
+          }
+        "#;
+
+        let data: IssueQueryData = self.graphql(q, json!({ "id": id })).await?;
+        let issue = data
+            .issue
+            .ok_or_else(|| AoError::Other("Linear issue not found".into()))?;
+
+        Ok(Issue {
+            id: issue.identifier.clone(),
+            title: issue.title.unwrap_or_default(),
+            description: issue.description.unwrap_or_default(),
+            url: issue
+                .url
+                .unwrap_or_else(|| self.issue_url(&issue.identifier)),
+            state: map_state(issue.state.as_ref().map(|s| s.r#type.as_str())),
+            labels: issue
+                .labels
+                .as_ref()
+                .map(|c| {
+                    c.nodes
+                        .iter()
+                        .map(|n| n.name.clone())
+                        .filter(|s| !s.is_empty())
+                        .collect::<Vec<_>>()
+                })
+                .unwrap_or_default(),
+            assignee: issue
+                .assignee
+                .as_ref()
+                .and_then(|a| a.name.clone())
+                .filter(|s| !s.is_empty()),
+        })
+    }
+
+    async fn is_completed(&self, identifier: &str) -> Result<bool> {
+        let issue = self.get_issue(identifier).await?;
+        Ok(matches!(
+            issue.state,
+            IssueState::Closed | IssueState::Cancelled
+        ))
+    }
+
+    fn issue_url(&self, identifier: &str) -> String {
+        let id = Self::normalize_identifier(identifier);
+        format!("https://linear.app/issue/{id}")
+    }
+
+    fn branch_name(&self, identifier: &str) -> String {
+        let id = Self::normalize_identifier(identifier);
+        format!("feat/linear-{id}")
+    }
+
+    fn generate_prompt(&self, issue: &Issue) -> String {
+        // Keep it structured and “issue-first”: identifiers + URL + description.
+        // We intentionally do not include token/config hints here.
+        let labels = if issue.labels.is_empty() {
+            "none".to_string()
+        } else {
+            issue.labels.join(", ")
+        };
+        let assignee = issue.assignee.as_deref().unwrap_or("unassigned");
+        format!(
+            "## Issue (Linear)\n\
+**ID**: {id}\n\
+**Title**: {title}\n\
+**URL**: {url}\n\
+**State**: {state}\n\
+**Assignee**: {assignee}\n\
+**Labels**: {labels}\n\
+\n\
+## Description\n\
+{desc}\n",
+            id = issue.id,
+            title = issue.title,
+            url = issue.url,
+            state = format_issue_state(issue.state),
+            assignee = assignee,
+            labels = labels,
+            desc = if issue.description.trim().is_empty() {
+                "(no description)".to_string()
+            } else {
+                issue.description.clone()
+            }
+        )
+    }
+}
+
+fn format_issue_state(s: IssueState) -> &'static str {
+    match s {
+        IssueState::Open => "open",
+        IssueState::InProgress => "in_progress",
+        IssueState::Closed => "closed",
+        IssueState::Cancelled => "cancelled",
+    }
+}
+
+fn map_state(state_type: Option<&str>) -> IssueState {
+    match state_type
+        .unwrap_or("")
+        .trim()
+        .to_ascii_uppercase()
+        .as_str()
+    {
+        "COMPLETED" => IssueState::Closed,
+        "CANCELED" | "CANCELLED" => IssueState::Cancelled,
+        "STARTED" => IssueState::InProgress,
+        // Backlog, Triage, Unstarted, etc.
+        _ => IssueState::Open,
+    }
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlResponse<T> {
+    data: Option<T>,
+    errors: Option<Vec<GraphqlError>>,
+}
+
+#[derive(Debug, Deserialize)]
+struct GraphqlError {
+    message: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct IssueQueryData {
+    #[serde(default)]
+    issue: Option<LinearIssue>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearIssue {
+    #[serde(default)]
+    identifier: String,
+    #[serde(default)]
+    title: Option<String>,
+    #[serde(default)]
+    description: Option<String>,
+    #[serde(default)]
+    url: Option<String>,
+    #[serde(default)]
+    state: Option<LinearState>,
+    #[serde(default)]
+    labels: Option<LinearLabelConnection>,
+    #[serde(default)]
+    assignee: Option<LinearAssignee>,
+    // Extra fields fetched for future prompt richness (kept for forward compat)
+    #[allow(dead_code)]
+    #[serde(default)]
+    team: Option<LinearTeam>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    project: Option<LinearProject>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    cycle: Option<LinearCycle>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearState {
+    #[serde(rename = "type")]
+    r#type: String,
+    #[allow(dead_code)]
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearLabelConnection {
+    #[serde(default)]
+    nodes: Vec<LinearLabel>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearLabel {
+    #[serde(default)]
+    name: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearAssignee {
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearTeam {
+    #[allow(dead_code)]
+    #[serde(default)]
+    key: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearProject {
+    #[allow(dead_code)]
+    #[serde(default)]
+    name: Option<String>,
+}
+
+#[derive(Debug, Deserialize)]
+struct LinearCycle {
+    #[allow(dead_code)]
+    #[serde(default)]
+    name: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default, rename = "startsAt")]
+    starts_at: Option<String>,
+    #[allow(dead_code)]
+    #[serde(default, rename = "endsAt")]
+    ends_at: Option<String>,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn normalize_identifier_passthrough() {
+        assert_eq!(LinearTracker::normalize_identifier("LIN-123"), "LIN-123");
+        assert_eq!(LinearTracker::normalize_identifier("  ENG-7 "), "ENG-7");
+    }
+
+    #[test]
+    fn normalize_identifier_extracts_from_url() {
+        assert_eq!(
+            LinearTracker::normalize_identifier("https://linear.app/acme/issue/LIN-123/some-title"),
+            "LIN-123"
+        );
+        assert_eq!(
+            LinearTracker::normalize_identifier("https://linear.app/issue/ENG-7/another"),
+            "ENG-7"
+        );
+    }
+
+    #[test]
+    fn map_state_covers_common_types() {
+        assert_eq!(map_state(Some("COMPLETED")), IssueState::Closed);
+        assert_eq!(map_state(Some("canceled")), IssueState::Cancelled);
+        assert_eq!(map_state(Some("STARTED")), IssueState::InProgress);
+        assert_eq!(map_state(Some("BACKLOG")), IssueState::Open);
+        assert_eq!(map_state(None), IssueState::Open);
+    }
+}


### PR DESCRIPTION
## Summary
- Add new `ao-plugin-tracker-linear` crate that fetches Linear issues via GraphQL using `LINEAR_API_TOKEN`.
- Add config selection for tracker (`defaults.tracker` / `projects.<id>.tracker`) and wire `spawn --issue` to use GitHub vs Linear.

## Test plan
- `cargo fmt`
- `cargo test`
- `cargo clippy --all-targets --all-features`

## Usage
- Set `LINEAR_API_TOKEN` (or `LINEAR_API_KEY`).
- In `ao-rs.yaml`, set either:
  - `defaults.tracker: linear`, or
  - `projects.<project>.tracker: linear`
- Run: `ao-rs spawn --issue LIN-123`

Made with [Cursor](https://cursor.com)