### PR TITLE
feat: add aider agent plugin

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ version = "0.0.1"
 dependencies = [
  "ao-core",
  "ao-dashboard",
+ "ao-plugin-agent-aider",
  "ao-plugin-agent-claude-code",
  "ao-plugin-agent-cursor",
  "ao-plugin-notifier-desktop",
@@ -162,6 +163,17 @@ dependencies = [
  "serde_json",
  "tauri",
  "tauri-build",
+]
+
+[[package]]
+name = "ao-plugin-agent-aider"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "filetime",
+ "tokio",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
     "crates/plugins/runtime-process",
     "crates/plugins/agent-claude-code",
     "crates/plugins/agent-cursor",
+    "crates/plugins/agent-aider",
     "crates/plugins/scm-github",
     "crates/plugins/tracker-github",
     "crates/plugins/notifier-stdout",

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -16,6 +16,7 @@ ao-plugin-runtime-tmux = { path = "../plugins/runtime-tmux" }
 ao-plugin-runtime-process = { path = "../plugins/runtime-process" }
 ao-plugin-agent-claude-code = { path = "../plugins/agent-claude-code" }
 ao-plugin-agent-cursor = { path = "../plugins/agent-cursor" }
+ao-plugin-agent-aider = { path = "../plugins/agent-aider" }
 ao-plugin-scm-github = { path = "../plugins/scm-github" }
 ao-plugin-tracker-github = { path = "../plugins/tracker-github" }
 ao-plugin-notifier-stdout = { path = "../plugins/notifier-stdout" }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -17,11 +17,12 @@
 
 use ao_core::{
     build_prompt, default_agent_rules, detect_git_repo, generate_config, install_skills, now_ms,
-    paths, restore_session, ActivityState, Agent, AgentConfig, AoConfig, CiStatus, LifecycleManager,
-    LockError, MergeReadiness, NotificationRouting, NotifierRegistry, OrchestratorEvent, PidFile,
-    PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm, Session, SessionId,
-    SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
+    paths, restore_session, ActivityState, Agent, AgentConfig, AoConfig, CiStatus,
+    LifecycleManager, LockError, MergeReadiness, NotificationRouting, NotifierRegistry,
+    OrchestratorEvent, PidFile, PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm,
+    Session, SessionId, SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
+use ao_plugin_agent_aider::AiderAgent;
 use ao_plugin_agent_claude_code::ClaudeCodeAgent;
 use ao_plugin_agent_cursor::CursorAgent;
 use ao_plugin_notifier_desktop::DesktopNotifier;
@@ -66,6 +67,10 @@ impl std::error::Error for DuplicateIssue {}
 /// `claude-code` so that older configs still work.
 fn select_agent(name: &str, agent_config: Option<&AgentConfig>) -> Box<dyn Agent> {
     match name {
+        "aider" => match agent_config {
+            Some(cfg) => Box::new(AiderAgent::from_config(cfg)),
+            None => Box::new(AiderAgent::new()),
+        },
         "cursor" => match agent_config {
             Some(cfg) => Box::new(CursorAgent::from_config(cfg)),
             None => Box::new(CursorAgent::new()),
@@ -266,7 +271,7 @@ enum Command {
         force: bool,
 
         /// Agent plugin to use (overrides `defaults.agent` in `ao-rs.yaml`).
-        /// Supported: `claude-code`, `cursor`.
+        /// Supported: `claude-code`, `cursor`, `aider`.
         #[arg(long)]
         agent: Option<String>,
 
@@ -310,7 +315,7 @@ enum Command {
         force: bool,
 
         /// Agent plugin to use (overrides `defaults.agent` in `ao-rs.yaml`).
-        /// Supported: `claude-code`, `cursor`.
+        /// Supported: `claude-code`, `cursor`, `aider`.
         #[arg(long)]
         agent: Option<String>,
 
@@ -1017,13 +1022,15 @@ fn resolve_project_id(
         let canon = std::fs::canonicalize(p).unwrap_or_else(|_| p.to_path_buf());
         (canon == repo_canon).then(|| id.clone())
     });
-    let matched_by_repo_slug = detect_git_repo(repo_path)
-        .ok()
-        .and_then(|(owner_repo, _repo_name, _branch)| {
-            ao_config.projects.iter().find_map(|(id, cfg)| {
-                (cfg.repo == owner_repo).then(|| id.clone())
-            })
-        });
+    let matched_by_repo_slug =
+        detect_git_repo(repo_path)
+            .ok()
+            .and_then(|(owner_repo, _repo_name, _branch)| {
+                ao_config
+                    .projects
+                    .iter()
+                    .find_map(|(id, cfg)| (cfg.repo == owner_repo).then(|| id.clone()))
+            });
     let matched_single = (ao_config.projects.len() == 1)
         .then(|| ao_config.projects.keys().next().cloned())
         .flatten();
@@ -2668,8 +2675,14 @@ mod tests {
 
         // And that means spawn would see the right per-project config.
         let proj = loaded.projects.get(&project_id).unwrap();
-        assert_eq!(proj.agent_config.as_ref().unwrap().permissions, "permissionless");
-        assert_eq!(proj.agent_config.as_ref().unwrap().rules.as_deref(), Some("rules from config"));
+        assert_eq!(
+            proj.agent_config.as_ref().unwrap().permissions,
+            "permissionless"
+        );
+        assert_eq!(
+            proj.agent_config.as_ref().unwrap().rules.as_deref(),
+            Some("rules from config")
+        );
 
         // And the right defaults.
         assert_eq!(loaded.defaults.as_ref().unwrap().agent, "cursor");

--- a/crates/plugins/agent-aider/Cargo.toml
+++ b/crates/plugins/agent-aider/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "ao-plugin-agent-aider"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+async-trait = { workspace = true }
+tokio = { workspace = true }
+tracing = { workspace = true }
+
+[dev-dependencies]
+filetime = "0.2"
+

--- a/crates/plugins/agent-aider/src/lib.rs
+++ b/crates/plugins/agent-aider/src/lib.rs
@@ -1,0 +1,288 @@
+//! Aider agent plugin.
+//!
+//! Launches the `aider` CLI in interactive mode and delivers the initial task
+//! via post-launch `send_message` (same flow as Claude Code).
+//!
+//! ## Activity detection
+//!
+//! Aider writes local history files in the workspace by default:
+//! - `.aider.chat.history.md`
+//! - `.aider.input.history`
+//!
+//! Detection mirrors the TS plugin strategy:
+//! 1. If `.aider.chat.history.md` mtime is fresh → Active/Ready/Idle.
+//! 2. Else if `.aider.input.history` mtime is fresh → Active/Ready/Idle.
+//! 3. Else if git has recent commits → Active.
+//! 4. Fallback: Ready.
+
+use ao_core::{ActivityState, Agent, AgentConfig, Result, Session};
+use async_trait::async_trait;
+use std::path::Path;
+
+/// If the history file was modified within this many seconds, consider the
+/// agent actively working.
+const ACTIVE_WINDOW_SECS: u64 = 30;
+
+/// If the history file was modified within this many seconds, consider the
+/// agent alive and ready (but not actively writing right now).
+const IDLE_THRESHOLD_SECS: u64 = 300;
+
+pub struct AiderAgent {
+    /// Rules prepended to the task. Aider doesn't expose a stable system-prompt
+    /// flag across providers, so we deliver rules as part of the first message.
+    rules: Option<String>,
+}
+
+impl AiderAgent {
+    pub fn new() -> Self {
+        Self { rules: None }
+    }
+
+    /// Create from project agent config.
+    pub fn from_config(config: &AgentConfig) -> Self {
+        let rules = if let Some(ref path) = config.rules_file {
+            match std::fs::read_to_string(path) {
+                Ok(content) => Some(content),
+                Err(e) => {
+                    tracing::warn!("could not read rules file {path}: {e}, using inline rules");
+                    config.rules.clone()
+                }
+            }
+        } else {
+            config.rules.clone()
+        };
+        Self { rules }
+    }
+}
+
+impl Default for AiderAgent {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[async_trait]
+impl Agent for AiderAgent {
+    fn launch_command(&self, _session: &Session) -> String {
+        // Keep it minimal: users can configure model/provider via env or aider config.
+        // `--yes` would auto-accept all changes; we intentionally don't default to it.
+        "aider".to_string()
+    }
+
+    fn environment(&self, session: &Session) -> Vec<(String, String)> {
+        vec![("AO_SESSION_ID".to_string(), session.id.to_string())]
+    }
+
+    fn initial_prompt(&self, session: &Session) -> String {
+        let task_part = if let Some(ref id) = session.issue_id {
+            let url_line = session
+                .issue_url
+                .as_deref()
+                .map(|u| format!("\nIssue URL: {u}"))
+                .unwrap_or_default();
+            format!(
+                "You are working on issue #{id} on branch `{branch}`.{url_line}\n\n\
+                 Task:\n{task}\n\n\
+                 When complete, push your branch and open a pull request.",
+                branch = session.branch,
+                task = session.task,
+            )
+        } else {
+            session.task.clone()
+        };
+
+        match &self.rules {
+            Some(rules) => format!("{rules}\n\n---\n\n{task_part}"),
+            None => task_part,
+        }
+    }
+
+    async fn detect_activity(&self, session: &Session) -> Result<ActivityState> {
+        let Some(ref ws) = session.workspace_path else {
+            return Ok(ActivityState::Ready);
+        };
+        let ws = ws.clone();
+        tokio::task::spawn_blocking(move || detect_aider_activity(&ws))
+            .await
+            .map_err(|e| ao_core::AoError::Other(format!("detect_activity panicked: {e}")))?
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Activity detection
+// ---------------------------------------------------------------------------
+
+fn detect_aider_activity(workspace_path: &Path) -> Result<ActivityState> {
+    let chat = workspace_path.join(".aider.chat.history.md");
+    if let Ok(s) = classify_mtime(&chat) {
+        return Ok(s);
+    }
+
+    let input = workspace_path.join(".aider.input.history");
+    if let Ok(s) = classify_mtime(&input) {
+        return Ok(s);
+    }
+
+    if has_recent_commits(workspace_path) {
+        return Ok(ActivityState::Active);
+    }
+
+    Ok(ActivityState::Ready)
+}
+
+fn classify_mtime(path: &Path) -> std::io::Result<ActivityState> {
+    let meta = std::fs::metadata(path)?;
+    let modified = meta.modified()?;
+    let age = std::time::SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default();
+
+    if age.as_secs() <= ACTIVE_WINDOW_SECS {
+        Ok(ActivityState::Active)
+    } else if age.as_secs() <= IDLE_THRESHOLD_SECS {
+        Ok(ActivityState::Ready)
+    } else {
+        Ok(ActivityState::Idle)
+    }
+}
+
+fn has_recent_commits(workspace_path: &Path) -> bool {
+    let output = std::process::Command::new("git")
+        .args(["log", "--since=60 seconds ago", "--format=%H"])
+        .current_dir(workspace_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output();
+
+    match output {
+        Ok(o) if o.status.success() => !String::from_utf8_lossy(&o.stdout).trim().is_empty(),
+        _ => false,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ao_core::{now_ms, SessionId, SessionStatus};
+    use std::path::PathBuf;
+
+    fn fake_session() -> Session {
+        Session {
+            id: SessionId("aider-test".into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Working,
+            agent: "aider".into(),
+            agent_config: None,
+            branch: "ao-abc123-feat-test".into(),
+            task: "fix the bug".into(),
+            workspace_path: Some(PathBuf::from("/tmp/aider-demo")),
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+        }
+    }
+
+    #[test]
+    fn launch_command_is_aider() {
+        let agent = AiderAgent::new();
+        assert_eq!(agent.launch_command(&fake_session()), "aider");
+    }
+
+    #[test]
+    fn environment_includes_session_id() {
+        let agent = AiderAgent::new();
+        let env = agent.environment(&fake_session());
+        assert!(env
+            .iter()
+            .any(|(k, v)| k == "AO_SESSION_ID" && v == "aider-test"));
+    }
+
+    #[test]
+    fn initial_prompt_task_first() {
+        let agent = AiderAgent::new();
+        assert_eq!(agent.initial_prompt(&fake_session()), "fix the bug");
+    }
+
+    #[test]
+    fn initial_prompt_issue_first() {
+        let agent = AiderAgent::new();
+        let mut session = fake_session();
+        session.issue_id = Some("22".into());
+        session.issue_url = Some("https://github.com/org/repo/issues/22".into());
+        session.task = "Port plugin".into();
+        let p = agent.initial_prompt(&session);
+        assert!(p.contains("issue #22"));
+        assert!(p.contains("https://github.com/org/repo/issues/22"));
+        assert!(p.contains("Port plugin"));
+        assert!(p.contains("open a pull request"));
+    }
+
+    #[test]
+    fn initial_prompt_with_rules_prepends_rules() {
+        let agent = AiderAgent {
+            rules: Some("Always run tests.".into()),
+        };
+        let p = agent.initial_prompt(&fake_session());
+        assert!(p.starts_with("Always run tests."));
+        assert!(p.contains("---"));
+        assert!(p.contains("fix the bug"));
+    }
+
+    #[test]
+    fn from_config_reads_inline_rules() {
+        let cfg = AgentConfig {
+            permissions: "permissionless".into(),
+            rules: Some("custom rules".into()),
+            rules_file: None,
+        };
+        let agent = AiderAgent::from_config(&cfg);
+        let p = agent.initial_prompt(&fake_session());
+        assert!(p.contains("custom rules"));
+    }
+
+    #[test]
+    fn detect_activity_no_files_returns_ready() {
+        let ws = std::env::temp_dir().join("ao-aider-no-files");
+        std::fs::create_dir_all(&ws).unwrap();
+        let s = detect_aider_activity(&ws).unwrap();
+        assert_eq!(s, ActivityState::Ready);
+        std::fs::remove_dir_all(&ws).ok();
+    }
+
+    #[test]
+    fn detect_activity_fresh_chat_file_returns_active() {
+        let ws = std::env::temp_dir().join("ao-aider-fresh-chat");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join(".aider.chat.history.md"), "hi").unwrap();
+        let s = detect_aider_activity(&ws).unwrap();
+        assert_eq!(s, ActivityState::Active);
+        std::fs::remove_dir_all(&ws).ok();
+    }
+
+    #[test]
+    fn detect_activity_stale_chat_file_returns_idle() {
+        let ws = std::env::temp_dir().join("ao-aider-stale-chat");
+        std::fs::create_dir_all(&ws).unwrap();
+        let p = ws.join(".aider.chat.history.md");
+        std::fs::write(&p, "hi").unwrap();
+
+        let old_time = filetime::FileTime::from_unix_time(
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_secs() as i64
+                - IDLE_THRESHOLD_SECS as i64
+                - 60,
+            0,
+        );
+        filetime::set_file_mtime(&p, old_time).unwrap();
+
+        let s = detect_aider_activity(&ws).unwrap();
+        assert_eq!(s, ActivityState::Idle);
+        std::fs::remove_dir_all(&ws).ok();
+    }
+}


### PR DESCRIPTION
## Summary
- Adds new agent plugin crate `ao-plugin-agent-aider` (launches `aider`).
- Implements activity detection via `.aider.chat.history.md` / `.aider.input.history` mtimes with git-commit fallback.
- Wires `aider` into `ao-rs spawn --agent` selection.

## Test plan
- `cargo test ./...`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo run -p ao-cli -- spawn --help` (shows `aider` in supported agents)

Made with [Cursor](https://cursor.com)