### PR TITLE
feat(notifier): add Slack webhook notifier

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -108,6 +108,7 @@ dependencies = [
  "ao-plugin-notifier-desktop",
  "ao-plugin-notifier-discord",
  "ao-plugin-notifier-ntfy",
+ "ao-plugin-notifier-slack",
  "ao-plugin-notifier-stdout",
  "ao-plugin-runtime-process",
  "ao-plugin-runtime-tmux",
@@ -217,6 +218,19 @@ dependencies = [
  "ao-core",
  "async-trait",
  "reqwest 0.12.28",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
+name = "ao-plugin-notifier-slack"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
  "tokio",
  "tracing",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
     "crates/plugins/notifier-ntfy",
     "crates/plugins/notifier-desktop",
     "crates/plugins/notifier-discord",
+    "crates/plugins/notifier-slack",
 ]
 
 [workspace.package]

--- a/README.md
+++ b/README.md
@@ -165,6 +165,7 @@ notification_routing:
 | `AO_NTFY_TOPIC` | [ntfy.sh](https://ntfy.sh) topic for push notifications |
 | `AO_NTFY_URL` | Custom ntfy server (default: `https://ntfy.sh`) |
 | `AO_DISCORD_WEBHOOK_URL` | Discord webhook URL for notifications |
+| `AO_SLACK_WEBHOOK_URL` | Slack incoming webhook URL for notifications |
 | `RUST_LOG` | Log level (default: `warn,ao_core=info`) |
 
 </details>

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -22,6 +22,7 @@ ao-plugin-notifier-stdout = { path = "../plugins/notifier-stdout" }
 ao-plugin-notifier-ntfy = { path = "../plugins/notifier-ntfy" }
 ao-plugin-notifier-desktop = { path = "../plugins/notifier-desktop" }
 ao-plugin-notifier-discord = { path = "../plugins/notifier-discord" }
+ao-plugin-notifier-slack = { path = "../plugins/notifier-slack" }
 ao-dashboard = { path = "../ao-dashboard" }
 
 tokio = { workspace = true }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -27,6 +27,7 @@ use ao_plugin_agent_cursor::CursorAgent;
 use ao_plugin_notifier_desktop::DesktopNotifier;
 use ao_plugin_notifier_discord::DiscordNotifier;
 use ao_plugin_notifier_ntfy::NtfyNotifier;
+use ao_plugin_notifier_slack::SlackNotifier;
 use ao_plugin_notifier_stdout::StdoutNotifier;
 use ao_plugin_runtime_process::ProcessRuntime;
 use ao_plugin_runtime_tmux::TmuxRuntime;
@@ -1807,6 +1808,11 @@ async fn watch(interval: Duration) -> Result<(), Box<dyn std::error::Error>> {
         notifier_registry.register("discord", Arc::new(DiscordNotifier::new(webhook_url)));
     }
 
+    // Issue #19 Phase 2: register slack if the AO_SLACK_WEBHOOK_URL env var is set.
+    if let Ok(webhook_url) = std::env::var("AO_SLACK_WEBHOOK_URL") {
+        notifier_registry.register("slack", Arc::new(SlackNotifier::new(webhook_url)));
+    }
+
     // Phase F wires SCM into both engines. `LifecycleManager` uses it to
     // drive PR-driven status transitions; `ReactionEngine` uses it to
     // re-probe + actually merge on `approved-and-green`. Same
@@ -1962,6 +1968,9 @@ async fn dashboard(port: u16, interval: Duration) -> Result<(), Box<dyn std::err
     notifier_registry.register("desktop", Arc::new(DesktopNotifier::new()));
     if let Ok(webhook_url) = std::env::var("AO_DISCORD_WEBHOOK_URL") {
         notifier_registry.register("discord", Arc::new(DiscordNotifier::new(webhook_url)));
+    }
+    if let Ok(webhook_url) = std::env::var("AO_SLACK_WEBHOOK_URL") {
+        notifier_registry.register("slack", Arc::new(SlackNotifier::new(webhook_url)));
     }
 
     let engine = Arc::new(

--- a/crates/plugins/notifier-slack/Cargo.toml
+++ b/crates/plugins/notifier-slack/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "ao-plugin-notifier-slack"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+async-trait = { workspace = true }
+tracing = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+serde = { workspace = true }
+serde_json = { workspace = true }
+
+[dev-dependencies]
+tokio = { workspace = true }
+

--- a/crates/plugins/notifier-slack/src/lib.rs
+++ b/crates/plugins/notifier-slack/src/lib.rs
@@ -1,0 +1,288 @@
+//! Slack webhook notifier plugin — Issue #19 Phase 2.
+//!
+//! Delivers notifications via Slack Incoming Webhooks (HTTP POST).
+//! Uses a simple attachment + blocks layout with a color stripe so
+//! priority is visually scannable in-channel.
+//!
+//! ## Configuration
+//!
+//! Construction takes a webhook URL (required), typically passed from
+//! `ao-cli` via the `AO_SLACK_WEBHOOK_URL` environment variable.
+//!
+//! ## Priority mapping (attachment color)
+//!
+//! | ao-rs | Slack color |
+//! |-------|------------|
+//! | Urgent | red |
+//! | Action | orange |
+//! | Warning | yellow |
+//! | Info | green |
+//!
+//! Escalated notifications always use red regardless of priority and
+//! prefix the title with `[ESCALATED]`.
+
+use ao_core::{
+    notifier::{NotificationPayload, Notifier, NotifierError},
+    reactions::EventPriority,
+};
+use async_trait::async_trait;
+use serde::Serialize;
+
+const DEFAULT_TIMEOUT_SECS: u64 = 5;
+
+// Slack "color" field accepts a hex string like "#36a64f" (or named colors).
+const COLOR_RED: &str = "#E01E5A";
+const COLOR_ORANGE: &str = "#FF8C00";
+const COLOR_YELLOW: &str = "#FFD700";
+const COLOR_GREEN: &str = "#2EB67D";
+
+/// Notifier that POSTs to a Slack incoming webhook URL.
+pub struct SlackNotifier {
+    webhook_url: String,
+    client: reqwest::Client,
+}
+
+impl SlackNotifier {
+    /// Create a notifier for the given Slack webhook URL.
+    pub fn new(webhook_url: impl Into<String>) -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
+            .build()
+            .expect("failed to build reqwest client");
+        Self {
+            webhook_url: webhook_url.into(),
+            client,
+        }
+    }
+
+    /// Exposed for testing.
+    pub fn webhook_url(&self) -> &str {
+        &self.webhook_url
+    }
+}
+
+pub(crate) fn attachment_color(priority: EventPriority, escalated: bool) -> &'static str {
+    if escalated {
+        return COLOR_RED;
+    }
+    match priority {
+        EventPriority::Urgent => COLOR_RED,
+        EventPriority::Action => COLOR_ORANGE,
+        EventPriority::Warning => COLOR_YELLOW,
+        EventPriority::Info => COLOR_GREEN,
+    }
+}
+
+// --- Slack incoming webhook JSON types (private) ---
+
+#[derive(Serialize)]
+struct WebhookPayload {
+    attachments: Vec<Attachment>,
+}
+
+#[derive(Serialize)]
+struct Attachment {
+    color: &'static str,
+    blocks: Vec<Block>,
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum Block {
+    #[serde(rename = "header")]
+    Header { text: Text },
+    #[serde(rename = "section")]
+    Section { text: Text },
+    #[serde(rename = "context")]
+    Context { elements: Vec<Text> },
+}
+
+#[derive(Serialize)]
+#[serde(tag = "type")]
+enum Text {
+    #[serde(rename = "plain_text")]
+    PlainText { text: String },
+    #[serde(rename = "mrkdwn")]
+    Mrkdwn { text: String },
+}
+
+fn build_webhook_payload(payload: &NotificationPayload) -> WebhookPayload {
+    let title = if payload.escalated {
+        format!("[ESCALATED] {}", payload.title)
+    } else {
+        payload.title.clone()
+    };
+
+    let context = if payload.escalated {
+        format!(
+            "*ao-rs* · `{}` · `{}` · `{}` · escalated",
+            payload.session_id,
+            payload.reaction_key,
+            payload.priority.as_str()
+        )
+    } else {
+        format!(
+            "*ao-rs* · `{}` · `{}` · `{}`",
+            payload.session_id,
+            payload.reaction_key,
+            payload.priority.as_str()
+        )
+    };
+
+    WebhookPayload {
+        attachments: vec![Attachment {
+            color: attachment_color(payload.priority, payload.escalated),
+            blocks: vec![
+                Block::Header {
+                    text: Text::PlainText { text: title },
+                },
+                Block::Section {
+                    text: Text::Mrkdwn {
+                        text: payload.body.clone(),
+                    },
+                },
+                Block::Context {
+                    elements: vec![Text::Mrkdwn { text: context }],
+                },
+            ],
+        }],
+    }
+}
+
+#[async_trait]
+impl Notifier for SlackNotifier {
+    fn name(&self) -> &str {
+        "slack"
+    }
+
+    async fn send(&self, payload: &NotificationPayload) -> Result<(), NotifierError> {
+        let body = build_webhook_payload(payload);
+
+        let response = self
+            .client
+            .post(&self.webhook_url)
+            .json(&body)
+            .send()
+            .await
+            .map_err(|e| {
+                if e.is_timeout() {
+                    NotifierError::Timeout {
+                        elapsed_ms: DEFAULT_TIMEOUT_SECS * 1000,
+                    }
+                } else if e.is_connect() {
+                    NotifierError::Unavailable(format!("slack connection failed: {e}"))
+                } else {
+                    NotifierError::Io(format!("slack request failed: {e}"))
+                }
+            })?;
+
+        let status = response.status().as_u16();
+        if !response.status().is_success() {
+            let body = response
+                .text()
+                .await
+                .unwrap_or_else(|_| "<unreadable>".into());
+            return Err(NotifierError::Service {
+                status,
+                message: body,
+            });
+        }
+
+        tracing::debug!("slack notification sent");
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ao_core::{
+        reactions::{EventPriority, ReactionAction},
+        types::SessionId,
+    };
+
+    fn fake_payload(escalated: bool, priority: EventPriority) -> NotificationPayload {
+        NotificationPayload {
+            session_id: SessionId("sess-test".into()),
+            reaction_key: "ci-failed".into(),
+            action: ReactionAction::Notify,
+            priority,
+            title: "CI failed".into(),
+            body: "Tests failed on main".into(),
+            escalated,
+        }
+    }
+
+    #[test]
+    fn name_is_slack() {
+        let n = SlackNotifier::new("https://hooks.slack.com/services/T000/B000/XXX");
+        assert_eq!(n.name(), "slack");
+    }
+
+    #[test]
+    fn webhook_url_is_preserved() {
+        let url = "https://hooks.slack.com/services/T000/B000/XXX";
+        let n = SlackNotifier::new(url);
+        assert_eq!(n.webhook_url(), url);
+    }
+
+    #[test]
+    fn color_mapping_covers_all_variants() {
+        assert_eq!(attachment_color(EventPriority::Urgent, false), COLOR_RED);
+        assert_eq!(attachment_color(EventPriority::Action, false), COLOR_ORANGE);
+        assert_eq!(attachment_color(EventPriority::Warning, false), COLOR_YELLOW);
+        assert_eq!(attachment_color(EventPriority::Info, false), COLOR_GREEN);
+    }
+
+    #[test]
+    fn escalated_color_is_always_red() {
+        assert_eq!(attachment_color(EventPriority::Urgent, true), COLOR_RED);
+        assert_eq!(attachment_color(EventPriority::Action, true), COLOR_RED);
+        assert_eq!(attachment_color(EventPriority::Warning, true), COLOR_RED);
+        assert_eq!(attachment_color(EventPriority::Info, true), COLOR_RED);
+    }
+
+    #[test]
+    fn webhook_payload_structure_serializes_correctly() {
+        let payload = fake_payload(false, EventPriority::Action);
+        let body = build_webhook_payload(&payload);
+        let json = serde_json::to_value(&body).unwrap();
+
+        assert!(json["attachments"].is_array());
+        assert_eq!(json["attachments"][0]["color"], COLOR_ORANGE);
+
+        // Blocks: header + section + context
+        assert_eq!(json["attachments"][0]["blocks"][0]["type"], "header");
+        assert_eq!(
+            json["attachments"][0]["blocks"][0]["text"]["type"],
+            "plain_text"
+        );
+        assert_eq!(json["attachments"][0]["blocks"][0]["text"]["text"], "CI failed");
+
+        assert_eq!(json["attachments"][0]["blocks"][1]["type"], "section");
+        assert_eq!(
+            json["attachments"][0]["blocks"][1]["text"]["type"],
+            "mrkdwn"
+        );
+        assert_eq!(
+            json["attachments"][0]["blocks"][1]["text"]["text"],
+            "Tests failed on main"
+        );
+
+        assert_eq!(json["attachments"][0]["blocks"][2]["type"], "context");
+        assert!(json["attachments"][0]["blocks"][2]["elements"].is_array());
+    }
+
+    #[test]
+    fn escalated_prefix_is_applied_in_header_text() {
+        let payload = fake_payload(true, EventPriority::Warning);
+        let body = build_webhook_payload(&payload);
+        let json = serde_json::to_value(&body).unwrap();
+        assert_eq!(
+            json["attachments"][0]["blocks"][0]["text"]["text"],
+            "[ESCALATED] CI failed"
+        );
+        assert_eq!(json["attachments"][0]["color"], COLOR_RED);
+    }
+}
+

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -305,6 +305,7 @@ ao-rs issue show <PATH|NNNN> [--repo PATH]
 | `AO_NTFY_TOPIC` | [ntfy.sh](https://ntfy.sh) topic for push notifications. Required to activate the ntfy notifier. |
 | `AO_NTFY_URL` | Custom ntfy server URL. Default: `https://ntfy.sh`. |
 | `AO_DISCORD_WEBHOOK_URL` | Discord webhook URL for the discord notifier. |
+| `AO_SLACK_WEBHOOK_URL` | Slack incoming webhook URL for the slack notifier. |
 
 ## Roadmap (not implemented)
 


### PR DESCRIPTION
## Summary
- Add `ao-plugin-notifier-slack` implementing `ao_core::Notifier` (Slack Incoming Webhooks)
- Wire Slack notifier into `ao-cli` registry via `AO_SLACK_WEBHOOK_URL`
- Add unit tests for Slack payload formatting + color mapping; document env var

## Test plan
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

## Config
- Set `AO_SLACK_WEBHOOK_URL`
- Add `slack` to `notification_routing` for desired priorities


Made with [Cursor](https://cursor.com)