### PR TITLE
feat(scm): add GitLab MR support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -114,6 +114,7 @@ dependencies = [
  "ao-plugin-runtime-process",
  "ao-plugin-runtime-tmux",
  "ao-plugin-scm-github",
+ "ao-plugin-scm-gitlab",
  "ao-plugin-tracker-github",
  "ao-plugin-tracker-linear",
  "ao-plugin-workspace-worktree",
@@ -293,6 +294,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "ao-plugin-scm-gitlab"
+version = "0.0.1"
+dependencies = [
+ "ao-core",
+ "async-trait",
+ "reqwest 0.12.28",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tracing",
+ "urlencoding",
+ "wiremock",
+]
+
+[[package]]
 name = "ao-plugin-tracker-github"
 version = "0.0.1"
 dependencies = [
@@ -335,6 +351,16 @@ dependencies = [
  "async-trait",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "assert-json-diff"
+version = "2.0.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
+dependencies = [
+ "serde",
+ "serde_json",
 ]
 
 [[package]]
@@ -1062,6 +1088,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deadpool"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0be2b1d1d6ec8d846f05e137292d0b89133caf95ef33695424c09568bdd39b1b"
+dependencies = [
+ "deadpool-runtime",
+ "lazy_static",
+ "num_cpus",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "deranged"
 version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1462,12 +1506,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures"
+version = "0.3.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b147ee9d1f6d097cef9ce628cd2ee62288d963e16fb287bd9286455b241382d"
+dependencies = [
+ "futures-channel",
+ "futures-core",
+ "futures-executor",
+ "futures-io",
+ "futures-sink",
+ "futures-task",
+ "futures-util",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "07bbe89c50d7a535e539b8c17bc0b49bdb77747034daa8087407d655f3f7cc1d"
 dependencies = [
  "futures-core",
+ "futures-sink",
 ]
 
 [[package]]
@@ -1535,6 +1595,7 @@ version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "389ca41296e6190b48053de0321d02a77f32f8a5d2461dd38762c0593805c6d6"
 dependencies = [
+ "futures-channel",
  "futures-core",
  "futures-io",
  "futures-macro",
@@ -1863,6 +1924,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "h2"
+version = "0.4.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "fnv",
+ "futures-core",
+ "futures-sink",
+ "http",
+ "indexmap 2.14.0",
+ "slab",
+ "tokio",
+ "tokio-util",
+ "tracing",
+]
+
+[[package]]
 name = "hashbrown"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1984,6 +2064,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
+ "h2",
  "http",
  "http-body",
  "httparse",
@@ -2713,6 +2794,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "num_cpus"
+version = "1.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+dependencies = [
+ "hermit-abi",
+ "libc",
 ]
 
 [[package]]
@@ -5302,6 +5393,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
 name = "urlpattern"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6100,6 +6197,29 @@ checksum = "cb5a765337c50e9ec252c2069be9bf91c7df47afb103b642ba3a53bf8101be97"
 dependencies = [
  "cfg-if",
  "windows-sys 0.59.0",
+]
+
+[[package]]
+name = "wiremock"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08db1edfb05d9b3c1542e521aea074442088292f00b5f28e435c714a98f85031"
+dependencies = [
+ "assert-json-diff",
+ "base64 0.22.1",
+ "deadpool",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-util",
+ "log",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "tokio",
+ "url",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
     "crates/plugins/notifier-desktop",
     "crates/plugins/notifier-discord",
     "crates/plugins/notifier-slack",
+    "crates/plugins/scm-gitlab",
 ]
 
 [workspace.package]

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -18,6 +18,7 @@ ao-plugin-agent-claude-code = { path = "../plugins/agent-claude-code" }
 ao-plugin-agent-cursor = { path = "../plugins/agent-cursor" }
 ao-plugin-agent-aider = { path = "../plugins/agent-aider" }
 ao-plugin-scm-github = { path = "../plugins/scm-github" }
+ao-plugin-scm-gitlab = { path = "../plugins/scm-gitlab" }
 ao-plugin-tracker-github = { path = "../plugins/tracker-github" }
 ao-plugin-tracker-linear = { path = "../plugins/tracker-linear" }
 ao-plugin-notifier-stdout = { path = "../plugins/notifier-stdout" }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -33,6 +33,7 @@ use ao_plugin_notifier_stdout::StdoutNotifier;
 use ao_plugin_runtime_process::ProcessRuntime;
 use ao_plugin_runtime_tmux::TmuxRuntime;
 use ao_plugin_scm_github::GitHubScm;
+use ao_plugin_scm_gitlab::GitLabScm;
 use ao_plugin_tracker_github::GitHubTracker;
 use ao_plugin_tracker_linear::LinearTracker;
 use ao_plugin_workspace_worktree::WorktreeWorkspace;
@@ -42,6 +43,89 @@ use std::path::PathBuf;
 use std::process::Command as StdCommand;
 use std::sync::Arc;
 use std::time::Duration;
+
+#[derive(Debug, Default, Clone)]
+struct AutoScm {
+    github: GitHubScm,
+    gitlab: GitLabScm,
+}
+
+impl AutoScm {
+    fn new() -> Self {
+        Self {
+            github: GitHubScm::new(),
+            gitlab: GitLabScm::new(),
+        }
+    }
+
+    fn is_gitlab_pr(pr: &PullRequest) -> bool {
+        // Self-hosted GitLab still uses this path segment.
+        pr.url.contains("/-/merge_requests/")
+    }
+
+    fn delegate<'a>(&'a self, pr: &PullRequest) -> &'a dyn Scm {
+        if Self::is_gitlab_pr(pr) {
+            &self.gitlab
+        } else {
+            &self.github
+        }
+    }
+}
+
+#[async_trait]
+impl Scm for AutoScm {
+    fn name(&self) -> &str {
+        "auto"
+    }
+
+    async fn detect_pr(&self, session: &Session) -> ao_core::Result<Option<PullRequest>> {
+        // Try GitLab first — safe because GitLab `detect_pr` is tolerant and
+        // returns `Ok(None)` for "can't detect".
+        if let Ok(Some(pr)) = self.gitlab.detect_pr(session).await {
+            return Ok(Some(pr));
+        }
+        self.github.detect_pr(session).await
+    }
+
+    async fn pr_state(&self, pr: &PullRequest) -> ao_core::Result<PrState> {
+        self.delegate(pr).pr_state(pr).await
+    }
+
+    async fn ci_checks(&self, pr: &PullRequest) -> ao_core::Result<Vec<ao_core::CheckRun>> {
+        self.delegate(pr).ci_checks(pr).await
+    }
+
+    async fn ci_status(&self, pr: &PullRequest) -> ao_core::Result<CiStatus> {
+        self.delegate(pr).ci_status(pr).await
+    }
+
+    async fn reviews(&self, pr: &PullRequest) -> ao_core::Result<Vec<ao_core::Review>> {
+        self.delegate(pr).reviews(pr).await
+    }
+
+    async fn review_decision(&self, pr: &PullRequest) -> ao_core::Result<ReviewDecision> {
+        self.delegate(pr).review_decision(pr).await
+    }
+
+    async fn pending_comments(
+        &self,
+        pr: &PullRequest,
+    ) -> ao_core::Result<Vec<ao_core::ReviewComment>> {
+        self.delegate(pr).pending_comments(pr).await
+    }
+
+    async fn mergeability(&self, pr: &PullRequest) -> ao_core::Result<MergeReadiness> {
+        self.delegate(pr).mergeability(pr).await
+    }
+
+    async fn merge(
+        &self,
+        pr: &PullRequest,
+        method: Option<ao_core::MergeMethod>,
+    ) -> ao_core::Result<()> {
+        self.delegate(pr).merge(pr, method).await
+    }
+}
 
 /// Typed error for duplicate issue detection so `batch_spawn` can distinguish
 /// "skipped duplicate" from "real failure" without string matching.
@@ -1464,14 +1548,8 @@ async fn status(
     }
 
     // Build the SCM plugin once up front if `--pr` is on, rather than
-    // per-row. `GitHubScm` is a zero-sized type, but allocating it in a
-    // branch keeps the non-`--pr` path completely free of `gh` linkage at
-    // call time.
-    let scm = if with_pr {
-        Some(GitHubScm::new())
-    } else {
-        None
-    };
+    // per-row. `AutoScm` delegates based on the detected PR URL shape.
+    let scm = if with_pr { Some(AutoScm::new()) } else { None };
 
     for s in sessions {
         let short_id: String = s.id.0.chars().take(8).collect();
@@ -1530,7 +1608,7 @@ async fn status(
 ///   renders `?` for the missing half, so the row still shows `#N ?/?`
 ///   or `#N open/?`. That's distinct from `-` on purpose: "there's a PR
 ///   here, we just couldn't read all of it this tick".
-async fn fetch_pr_column(scm: &GitHubScm, session: &Session) -> String {
+async fn fetch_pr_column(scm: &dyn Scm, session: &Session) -> String {
     let Ok(Some(pr)) = scm.detect_pr(session).await else {
         return "-".to_string();
     };
@@ -1624,7 +1702,7 @@ async fn pr(session_id_or_prefix: String) -> Result<(), Box<dyn std::error::Erro
     let sessions = SessionManager::with_default();
     let session = sessions.find_by_prefix(&session_id_or_prefix).await?;
 
-    let scm = GitHubScm::new();
+    let scm = AutoScm::new();
     let Some(pr) = scm.detect_pr(&session).await? else {
         println!(
             "no PR found for session {} (branch {})",
@@ -1756,9 +1834,7 @@ async fn watch(interval: Duration) -> Result<(), Box<dyn std::error::Error>> {
 
     let sessions = Arc::new(SessionManager::with_default());
     let agent: Arc<dyn Agent> = Arc::new(MultiAgent);
-    // Phase F: SCM plugin is compile-time GitHubScm. Zero-sized, so the
-    // Arc here is just for trait-object uniformity with Runtime/Agent.
-    let scm: Arc<dyn Scm> = Arc::new(GitHubScm::new());
+    let scm: Arc<dyn Scm> = Arc::new(AutoScm::new());
 
     // Load config from the local project directory (ao-rs.yaml).
     // Missing config is silently empty; a broken YAML is a loud error.
@@ -1944,7 +2020,7 @@ async fn dashboard(port: u16, interval: Duration) -> Result<(), Box<dyn std::err
 
     let sessions = Arc::new(SessionManager::with_default());
     let agent: Arc<dyn Agent> = Arc::new(MultiAgent);
-    let scm: Arc<dyn Scm> = Arc::new(GitHubScm::new());
+    let scm: Arc<dyn Scm> = Arc::new(AutoScm::new());
 
     let config_path = AoConfig::local_path();
     let config = AoConfig::load_from_or_default(&config_path)
@@ -2362,7 +2438,7 @@ async fn review_check(
 
     use std::fmt::Write as _;
 
-    let scm = GitHubScm::new();
+    let scm = AutoScm::new();
     let fingerprint_dir = paths::data_dir().join("review-fingerprints");
 
     // Create fingerprint directory once, outside the loop.

--- a/crates/plugins/scm-gitlab/Cargo.toml
+++ b/crates/plugins/scm-gitlab/Cargo.toml
@@ -1,0 +1,19 @@
+[package]
+name = "ao-plugin-scm-gitlab"
+version.workspace = true
+edition.workspace = true
+license.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+ao-core = { workspace = true }
+tokio = { workspace = true }
+async-trait = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
+tracing = { workspace = true }
+reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
+urlencoding = "2"
+
+[dev-dependencies]
+wiremock = "0.6"

--- a/crates/plugins/scm-gitlab/src/lib.rs
+++ b/crates/plugins/scm-gitlab/src/lib.rs
@@ -1,0 +1,686 @@
+//! GitLab SCM plugin — GitLab Merge Requests via the GitLab REST API.
+//!
+//! Unlike `ao-plugin-scm-github` (which shells out to `gh`), this plugin uses
+//! HTTPS so we can test it with recorded fixtures (no real network).
+
+use ao_core::{
+    AoError, CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest, Result, Review,
+    ReviewComment, ReviewDecision, Scm, Session,
+};
+use async_trait::async_trait;
+use reqwest::header::{HeaderMap, HeaderValue};
+use std::path::Path;
+use std::time::Duration;
+use tokio::process::Command;
+
+pub(crate) mod parse;
+
+const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
+
+#[derive(Debug, Clone)]
+pub struct GitLabScm {
+    client: reqwest::Client,
+    /// Override `https://<host>` for tests (e.g. wiremock server base URL).
+    base_url_override: Option<String>,
+    /// Override token for tests; production reads from env each call.
+    token_override: Option<String>,
+}
+
+impl Default for GitLabScm {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl GitLabScm {
+    pub fn new() -> Self {
+        let client = reqwest::Client::builder()
+            .timeout(HTTP_TIMEOUT)
+            .build()
+            .expect("failed to build reqwest client");
+        Self {
+            client,
+            base_url_override: None,
+            token_override: None,
+        }
+    }
+
+    pub fn with_base_url_and_token(base_url: impl Into<String>, token: impl Into<String>) -> Self {
+        let mut me = Self::new();
+        me.base_url_override = Some(base_url.into());
+        me.token_override = Some(token.into());
+        me
+    }
+}
+
+#[async_trait]
+impl Scm for GitLabScm {
+    fn name(&self) -> &str {
+        "gitlab"
+    }
+
+    async fn detect_pr(&self, session: &Session) -> Result<Option<PullRequest>> {
+        // Same asymmetry as the GitHub plugin: polling-tolerant and returns
+        // `Ok(None)` for any "can't detect" failure mode.
+        let Some(workspace) = session.workspace_path.as_deref() else {
+            return Ok(None);
+        };
+        let origin = match discover_origin(workspace).await {
+            Ok(o) => o,
+            Err(e) => {
+                tracing::debug!("detect_pr: no gitlab origin in {:?}: {e}", workspace);
+                return Ok(None);
+            }
+        };
+        let base_url = self
+            .base_url_override
+            .clone()
+            .unwrap_or_else(|| origin.base_url.clone());
+        let token = match token_from_env(self.token_override.as_deref()) {
+            Ok(t) => t,
+            Err(e) => {
+                tracing::debug!("detect_pr: missing gitlab token: {e}");
+                return Ok(None);
+            }
+        };
+
+        let api = GitLabApi::new(&self.client, &base_url, &token);
+        let mrs = match api
+            .list_open_merge_requests_by_source_branch(&origin.project_path, &session.branch)
+            .await
+        {
+            Ok(mrs) => mrs,
+            Err(e) => {
+                tracing::debug!("detect_pr: gitlab mr list failed: {e}");
+                return Ok(None);
+            }
+        };
+
+        Ok(mrs.into_iter().next().map(|mr| {
+            let (owner, repo) = split_owner_repo(&origin.project_path);
+            mr.into_pull_request(&owner, &repo)
+        }))
+    }
+
+    async fn pr_state(&self, pr: &PullRequest) -> Result<PrState> {
+        let api = self.api_from_pr(pr)?;
+        let mr = api.get_merge_request(&project_path(pr), pr.number).await?;
+        Ok(parse::map_pr_state(mr.state.as_deref().unwrap_or("")))
+    }
+
+    async fn ci_checks(&self, pr: &PullRequest) -> Result<Vec<CheckRun>> {
+        let api = self.api_from_pr(pr)?;
+        let mr = api.get_merge_request(&project_path(pr), pr.number).await?;
+        Ok(parse::extract_ci_checks(&mr))
+    }
+
+    async fn ci_status(&self, pr: &PullRequest) -> Result<CiStatus> {
+        let checks = self.ci_checks(pr).await?;
+        Ok(parse::summarize_ci(&checks))
+    }
+
+    async fn reviews(&self, pr: &PullRequest) -> Result<Vec<Review>> {
+        let api = self.api_from_pr(pr)?;
+        let approvals = api.get_approvals(&project_path(pr), pr.number).await?;
+        Ok(parse::approvals_into_reviews(approvals))
+    }
+
+    async fn review_decision(&self, pr: &PullRequest) -> Result<ReviewDecision> {
+        let api = self.api_from_pr(pr)?;
+        let approvals = api.get_approvals(&project_path(pr), pr.number).await?;
+        Ok(parse::review_decision_from_approvals(&approvals))
+    }
+
+    async fn pending_comments(&self, pr: &PullRequest) -> Result<Vec<ReviewComment>> {
+        let api = self.api_from_pr(pr)?;
+        let discussions = api
+            .list_all_discussions(&project_path(pr), pr.number)
+            .await?;
+        Ok(parse::extract_pending_comments(&discussions, &pr.url))
+    }
+
+    async fn mergeability(&self, pr: &PullRequest) -> Result<MergeReadiness> {
+        let api = self.api_from_pr(pr)?;
+
+        if matches!(self.pr_state(pr).await?, PrState::Merged) {
+            return Ok(MergeReadiness {
+                mergeable: true,
+                ci_passing: true,
+                approved: true,
+                no_conflicts: true,
+                blockers: Vec::new(),
+            });
+        }
+
+        let mr = api.get_merge_request(&project_path(pr), pr.number).await?;
+        let approvals = api.get_approvals(&project_path(pr), pr.number).await?;
+        let ci_status = self.ci_status(pr).await?;
+        Ok(compose_merge_readiness(&mr, &approvals, ci_status))
+    }
+
+    async fn merge(&self, pr: &PullRequest, method: Option<MergeMethod>) -> Result<()> {
+        let api = self.api_from_pr(pr)?;
+        let squash = matches!(method.unwrap_or_default(), MergeMethod::Squash);
+        api.merge_merge_request(&project_path(pr), pr.number, squash)
+            .await?;
+        Ok(())
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Merge-readiness composer (pure, testable)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn compose_merge_readiness(
+    mr: &parse::MergeRequest,
+    approvals: &parse::Approvals,
+    ci_status: CiStatus,
+) -> MergeReadiness {
+    let mut blockers: Vec<String> = Vec::new();
+
+    // CI
+    let ci_passing = matches!(ci_status, CiStatus::Passing | CiStatus::None);
+    if !ci_passing {
+        blockers.push(format!("CI is {}", ci_status_label(ci_status)));
+    }
+
+    // Reviews / approvals
+    let decision = parse::review_decision_from_approvals(approvals);
+    let approved = matches!(decision, ReviewDecision::Approved | ReviewDecision::None);
+    match decision {
+        ReviewDecision::ChangesRequested => blockers.push("Changes requested in review".into()),
+        ReviewDecision::Pending => blockers.push("Review required".into()),
+        _ => {}
+    }
+
+    // Draft
+    if mr.is_draft() {
+        blockers.push("MR is still a draft".into());
+    }
+
+    // Conflicts / merge status
+    let no_conflicts = !mr.has_conflicts.unwrap_or(false);
+    if mr.has_conflicts.unwrap_or(false) {
+        blockers.push("Merge conflicts".into());
+    }
+    match mr
+        .merge_status
+        .as_deref()
+        .unwrap_or("")
+        .to_ascii_lowercase()
+        .as_str()
+    {
+        "cannot_be_merged" => blockers.push("Merge is blocked".into()),
+        "checking" | "" => blockers.push("Merge status unknown (GitLab is computing)".into()),
+        _ => {}
+    }
+
+    // Mergeable is the conjunction of our blockers.
+    MergeReadiness {
+        mergeable: blockers.is_empty(),
+        ci_passing,
+        approved,
+        no_conflicts,
+        blockers,
+    }
+}
+
+fn ci_status_label(s: CiStatus) -> &'static str {
+    match s {
+        CiStatus::Pending => "pending",
+        CiStatus::Passing => "passing",
+        CiStatus::Failing => "failing",
+        CiStatus::None => "none",
+    }
+}
+
+// ---------------------------------------------------------------------------
+// API client
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone)]
+struct GitLabApi<'a> {
+    client: &'a reqwest::Client,
+    base_url: String,
+    token: String,
+}
+
+impl<'a> GitLabApi<'a> {
+    fn new(client: &'a reqwest::Client, base_url: &str, token: &str) -> Self {
+        Self {
+            client,
+            base_url: base_url.trim_end_matches('/').to_string(),
+            token: token.to_string(),
+        }
+    }
+
+    fn api_base(&self) -> String {
+        format!("{}/api/v4", self.base_url)
+    }
+
+    fn headers(&self) -> Result<HeaderMap> {
+        let mut h = HeaderMap::new();
+        // GitLab supports both `PRIVATE-TOKEN` and `Authorization: Bearer`.
+        // `PRIVATE-TOKEN` is simplest for PATs and is what glab uses.
+        let v = HeaderValue::from_str(&self.token)
+            .map_err(|e| AoError::Scm(format!("invalid gitlab token header: {e}")))?;
+        h.insert("PRIVATE-TOKEN", v);
+        Ok(h)
+    }
+
+    async fn list_open_merge_requests_by_source_branch(
+        &self,
+        project_path: &str,
+        branch: &str,
+    ) -> Result<Vec<parse::MergeRequest>> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/merge_requests?state=opened&source_branch={}&per_page=1",
+            self.api_base(),
+            encoded,
+            urlencoding::encode(branch)
+        );
+        let resp = self
+            .client
+            .get(url)
+            .headers(self.headers()?)
+            .send()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab mr list failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab mr list read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Scm(format!(
+                "gitlab mr list failed: http {}: {}",
+                status.as_u16(),
+                body.trim()
+            )));
+        }
+        parse::parse_mr_list(&body)
+    }
+
+    async fn get_merge_request(&self, project_path: &str, iid: u32) -> Result<parse::MergeRequest> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}",
+            self.api_base(),
+            encoded,
+            iid
+        );
+        let resp = self
+            .client
+            .get(url)
+            .headers(self.headers()?)
+            .send()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab mr view failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab mr view read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Scm(format!(
+                "gitlab mr view failed: http {}: {}",
+                status.as_u16(),
+                body.trim()
+            )));
+        }
+        parse::parse_mr_view(&body)
+    }
+
+    async fn get_approvals(&self, project_path: &str, iid: u32) -> Result<parse::Approvals> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}/approvals",
+            self.api_base(),
+            encoded,
+            iid
+        );
+        let resp = self
+            .client
+            .get(url)
+            .headers(self.headers()?)
+            .send()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab approvals failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab approvals read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Scm(format!(
+                "gitlab approvals failed: http {}: {}",
+                status.as_u16(),
+                body.trim()
+            )));
+        }
+        parse::parse_approvals(&body)
+    }
+
+    async fn list_all_discussions(
+        &self,
+        project_path: &str,
+        iid: u32,
+    ) -> Result<Vec<parse::Discussion>> {
+        const PER_PAGE: usize = 100;
+        const MAX_PAGES: u32 = 100;
+
+        let mut all: Vec<parse::Discussion> = Vec::new();
+        for page in 1..=MAX_PAGES {
+            let encoded = urlencoding::encode(project_path);
+            let url = format!(
+                "{}/projects/{}/merge_requests/{}/discussions?per_page={PER_PAGE}&page={page}",
+                self.api_base(),
+                encoded,
+                iid
+            );
+            let resp = self
+                .client
+                .get(url)
+                .headers(self.headers()?)
+                .send()
+                .await
+                .map_err(|e| AoError::Scm(format!("gitlab discussions failed: {e}")))?;
+            let status = resp.status();
+            let body = resp
+                .text()
+                .await
+                .map_err(|e| AoError::Scm(format!("gitlab discussions read failed: {e}")))?;
+            if !status.is_success() {
+                return Err(AoError::Scm(format!(
+                    "gitlab discussions failed: http {}: {}",
+                    status.as_u16(),
+                    body.trim()
+                )));
+            }
+            let page_items = parse::parse_discussions(&body)?;
+            let got = page_items.len();
+            all.extend(page_items);
+            if got < PER_PAGE {
+                break;
+            }
+        }
+        Ok(all)
+    }
+
+    async fn merge_merge_request(&self, project_path: &str, iid: u32, squash: bool) -> Result<()> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}/merge",
+            self.api_base(),
+            encoded,
+            iid
+        );
+        let resp = self
+            .client
+            .put(url)
+            .headers(self.headers()?)
+            .json(&serde_json::json!({
+                "squash": squash,
+                "should_remove_source_branch": true
+            }))
+            .send()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab merge failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab merge read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Scm(format!(
+                "gitlab merge failed: http {}: {}",
+                status.as_u16(),
+                body.trim()
+            )));
+        }
+        Ok(())
+    }
+}
+
+impl GitLabScm {
+    fn api_from_pr(&self, pr: &PullRequest) -> Result<GitLabApi<'_>> {
+        let base_url = self
+            .base_url_override
+            .clone()
+            .unwrap_or_else(|| base_url_from_http_url(&pr.url));
+        let token = token_from_env(self.token_override.as_deref())?;
+        Ok(GitLabApi::new(&self.client, &base_url, &token))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Git helpers (discover origin)
+// ---------------------------------------------------------------------------
+
+async fn discover_origin(workspace: &Path) -> Result<GitLabOrigin> {
+    let url = git_in(workspace, &["remote", "get-url", "origin"]).await?;
+    parse_gitlab_remote(url.trim())
+        .ok_or_else(|| AoError::Scm(format!("origin is not a gitlab remote: {url:?}")))
+}
+
+async fn git_in(cwd: &Path, args: &[&str]) -> Result<String> {
+    let output = Command::new("git")
+        .args(["-C", cwd.to_string_lossy().as_ref()])
+        .args(args)
+        .output()
+        .await
+        .map_err(|e| AoError::Scm(format!("git spawn failed: {e}")))?;
+    if !output.status.success() {
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        return Err(AoError::Scm(format!(
+            "git {} failed: {}",
+            args.join(" "),
+            stderr.trim()
+        )));
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct GitLabOrigin {
+    base_url: String,
+    project_path: String,
+}
+
+pub(crate) fn parse_gitlab_remote(url: &str) -> Option<GitLabOrigin> {
+    let trimmed = url.strip_suffix(".git").unwrap_or(url).trim();
+
+    // https://gitlab.example.com/group/sub/repo
+    if let Some(rest) = trimmed
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
+    {
+        let mut parts = rest.splitn(2, '/');
+        let host = parts.next()?.trim();
+        let path = parts.next()?.trim().trim_matches('/');
+        if host.is_empty() || path.is_empty() {
+            return None;
+        }
+        if split_owner_repo(path).1.is_empty() {
+            return None;
+        }
+        let scheme = if trimmed.starts_with("http://") {
+            "http"
+        } else {
+            "https"
+        };
+        return Some(GitLabOrigin {
+            base_url: format!("{scheme}://{host}"),
+            project_path: path.to_string(),
+        });
+    }
+
+    // git@gitlab.example.com:group/sub/repo
+    if let Some(rest) = trimmed.strip_prefix("git@") {
+        let mut parts = rest.splitn(2, ':');
+        let host = parts.next()?.trim();
+        let path = parts.next()?.trim().trim_matches('/');
+        if host.is_empty() || path.is_empty() {
+            return None;
+        }
+        if split_owner_repo(path).1.is_empty() {
+            return None;
+        }
+        return Some(GitLabOrigin {
+            base_url: format!("https://{host}"),
+            project_path: path.to_string(),
+        });
+    }
+
+    // ssh://git@gitlab.example.com/group/sub/repo
+    if let Some(rest) = trimmed.strip_prefix("ssh://git@") {
+        let mut parts = rest.splitn(2, '/');
+        let host = parts.next()?.trim();
+        let path = parts.next()?.trim().trim_matches('/');
+        if host.is_empty() || path.is_empty() {
+            return None;
+        }
+        if split_owner_repo(path).1.is_empty() {
+            return None;
+        }
+        return Some(GitLabOrigin {
+            base_url: format!("https://{host}"),
+            project_path: path.to_string(),
+        });
+    }
+
+    None
+}
+
+fn split_owner_repo(project_path: &str) -> (String, String) {
+    let path = project_path.trim_matches('/');
+    let mut parts: Vec<&str> = path.split('/').filter(|p| !p.is_empty()).collect();
+    if parts.len() < 2 {
+        return ("".into(), "".into());
+    }
+    let repo = parts.pop().unwrap_or_default().to_string();
+    let owner = parts.join("/");
+    (owner, repo)
+}
+
+fn project_path(pr: &PullRequest) -> String {
+    format!("{}/{}", pr.owner, pr.repo)
+}
+
+fn base_url_from_http_url(url: &str) -> String {
+    // Extract scheme://host from an https URL without extra deps.
+    if let Some(idx) = url.find("://") {
+        let after = &url[(idx + 3)..];
+        if let Some(slash) = after.find('/') {
+            return format!("{}://{}", &url[..idx], &after[..slash]);
+        }
+        return url.to_string();
+    }
+    // Fall back to gitlab.com; better than panicking.
+    "https://gitlab.com".to_string()
+}
+
+fn token_from_env(override_token: Option<&str>) -> Result<String> {
+    if let Some(t) = override_token {
+        if !t.trim().is_empty() {
+            return Ok(t.to_string());
+        }
+    }
+    for k in ["GITLAB_TOKEN", "GITLAB_PRIVATE_TOKEN", "PRIVATE_TOKEN"] {
+        if let Ok(v) = std::env::var(k) {
+            if !v.trim().is_empty() {
+                return Ok(v);
+            }
+        }
+    }
+    Err(AoError::Scm(
+        "missing GitLab token (set GITLAB_TOKEN)".to_string(),
+    ))
+}
+
+// ---------------------------------------------------------------------------
+// Tests (fixtures + wiremock)
+// ---------------------------------------------------------------------------
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use wiremock::matchers::{method, path, query_param};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    #[test]
+    fn parse_gitlab_remote_accepts_https_and_ssh_and_nested_groups() {
+        let o = parse_gitlab_remote("https://gitlab.com/acme/sub/widgets.git").unwrap();
+        assert_eq!(o.base_url, "https://gitlab.com");
+        assert_eq!(o.project_path, "acme/sub/widgets");
+
+        let o = parse_gitlab_remote("git@gitlab.example.com:acme/sub/widgets.git").unwrap();
+        assert_eq!(o.base_url, "https://gitlab.example.com");
+        assert_eq!(o.project_path, "acme/sub/widgets");
+
+        let o = parse_gitlab_remote("ssh://git@gitlab.example.com/acme/widgets.git").unwrap();
+        assert_eq!(o.base_url, "https://gitlab.example.com");
+        assert_eq!(o.project_path, "acme/widgets");
+    }
+
+    #[tokio::test]
+    async fn detect_pr_uses_list_endpoint_and_maps_to_pull_request() {
+        let server = MockServer::start().await;
+
+        let body = include_str!("../tests/fixtures/mr_list_open.json");
+
+        Mock::given(method("GET"))
+            .and(path("/api/v4/projects/acme%2Fwidgets/merge_requests"))
+            .and(query_param("state", "opened"))
+            .and(query_param("source_branch", "ao-abc"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(body))
+            .mount(&server)
+            .await;
+
+        // We don't hit git in this unit test: call API parser directly.
+        let mrs = parse::parse_mr_list(body).unwrap();
+        let pr = mrs[0].clone().into_pull_request("acme", "widgets");
+        assert_eq!(pr.number, 7);
+        assert!(pr.is_draft);
+        assert_eq!(pr.branch, "ao-abc");
+        assert_eq!(pr.base_branch, "main");
+
+        // Also smoke the API client path and encoding.
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let api = GitLabApi::new(&scm.client, &server.uri(), "t");
+        let got = api
+            .list_open_merge_requests_by_source_branch("acme/widgets", "ao-abc")
+            .await
+            .unwrap();
+        assert_eq!(got.len(), 1);
+        assert_eq!(got[0].iid, Some(7));
+    }
+
+    #[test]
+    fn compose_merge_readiness_blocks_on_ci_and_conflicts_and_review_required() {
+        let mr = parse::MergeRequest {
+            iid: Some(1),
+            web_url: Some("u".into()),
+            title: Some("t".into()),
+            source_branch: Some("b".into()),
+            target_branch: Some("main".into()),
+            state: Some("opened".into()),
+            draft: Some(false),
+            work_in_progress: Some(false),
+            merge_status: Some("cannot_be_merged".into()),
+            has_conflicts: Some(true),
+            head_pipeline: None,
+        };
+        let approvals = parse::Approvals {
+            approvals_required: Some(1),
+            approvals_left: Some(1),
+            approved_by: vec![],
+        };
+        let r = compose_merge_readiness(&mr, &approvals, CiStatus::Failing);
+        assert!(!r.is_ready());
+        assert!(r.blockers.iter().any(|b| b.contains("CI is failing")));
+        assert!(r.blockers.iter().any(|b| b.contains("Review required")));
+        assert!(r.blockers.iter().any(|b| b.contains("Merge conflicts")));
+    }
+}

--- a/crates/plugins/scm-gitlab/src/parse.rs
+++ b/crates/plugins/scm-gitlab/src/parse.rs
@@ -1,0 +1,340 @@
+//! Pure JSON → domain-type parsers for the GitLab SCM plugin.
+
+use ao_core::{
+    AoError, CheckRun, CheckStatus, CiStatus, PrState, PullRequest, Result, Review, ReviewComment,
+    ReviewDecision, ReviewState,
+};
+use serde::Deserialize;
+
+fn bad(msg: impl Into<String>, err: impl std::fmt::Display) -> AoError {
+    AoError::Scm(format!("{}: {}", msg.into(), err))
+}
+
+// ---------------------------------------------------------------------------
+// Merge requests (list + view)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct MergeRequest {
+    #[serde(default)]
+    pub iid: Option<u32>,
+    #[serde(default)]
+    pub web_url: Option<String>,
+    #[serde(default)]
+    pub title: Option<String>,
+    #[serde(default)]
+    pub source_branch: Option<String>,
+    #[serde(default)]
+    pub target_branch: Option<String>,
+    #[serde(default)]
+    pub state: Option<String>,
+    #[serde(default)]
+    pub draft: Option<bool>,
+    // Older GitLab versions used `work_in_progress` before `draft`.
+    #[serde(default)]
+    pub work_in_progress: Option<bool>,
+    #[serde(default)]
+    pub merge_status: Option<String>,
+    #[serde(default)]
+    pub has_conflicts: Option<bool>,
+    #[serde(default)]
+    pub head_pipeline: Option<HeadPipeline>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct HeadPipeline {
+    #[serde(default)]
+    pub status: Option<String>,
+    #[serde(default)]
+    pub web_url: Option<String>,
+}
+
+impl MergeRequest {
+    pub(crate) fn into_pull_request(self, owner: &str, repo: &str) -> PullRequest {
+        let is_draft = self.is_draft();
+        PullRequest {
+            number: self.iid.unwrap_or_default(),
+            url: self
+                .web_url
+                .unwrap_or_else(|| format!("https://gitlab.com/{owner}/{repo}")),
+            title: self.title.unwrap_or_default(),
+            owner: owner.to_string(),
+            repo: repo.to_string(),
+            branch: self.source_branch.unwrap_or_default(),
+            base_branch: self.target_branch.unwrap_or_default(),
+            is_draft,
+        }
+    }
+
+    pub(crate) fn is_draft(&self) -> bool {
+        if self.draft.unwrap_or(false) || self.work_in_progress.unwrap_or(false) {
+            return true;
+        }
+        let t = self
+            .title
+            .as_deref()
+            .unwrap_or("")
+            .trim()
+            .to_ascii_lowercase();
+        t.starts_with("draft:") || t.starts_with("wip:")
+    }
+}
+
+pub(crate) fn parse_mr_list(json: &str) -> Result<Vec<MergeRequest>> {
+    serde_json::from_str(json).map_err(|e| bad("parse mr list", e))
+}
+
+pub(crate) fn parse_mr_view(json: &str) -> Result<MergeRequest> {
+    serde_json::from_str(json).map_err(|e| bad("parse mr view", e))
+}
+
+pub(crate) fn map_pr_state(raw: &str) -> PrState {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "merged" => PrState::Merged,
+        "closed" => PrState::Closed,
+        _ => PrState::Open,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// CI (head pipeline)
+// ---------------------------------------------------------------------------
+
+pub(crate) fn extract_ci_checks(mr: &MergeRequest) -> Vec<CheckRun> {
+    let Some(p) = mr.head_pipeline.as_ref() else {
+        return Vec::new();
+    };
+    let status_raw = p.status.as_deref().unwrap_or("").to_string();
+    let status = map_pipeline_status(&status_raw);
+    let url = p.web_url.clone().filter(|s| !s.is_empty());
+    let conclusion = if status_raw.trim().is_empty() {
+        None
+    } else {
+        Some(status_raw)
+    };
+    vec![CheckRun {
+        name: "pipeline".into(),
+        status,
+        url,
+        conclusion,
+    }]
+}
+
+fn map_pipeline_status(raw: &str) -> CheckStatus {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "running" => CheckStatus::Running,
+        "pending" => CheckStatus::Pending,
+        "created" => CheckStatus::Pending,
+        "waiting_for_resource" => CheckStatus::Pending,
+        "preparing" => CheckStatus::Pending,
+        "manual" => CheckStatus::Pending,
+        "scheduled" => CheckStatus::Pending,
+        "success" => CheckStatus::Passed,
+        "failed" | "canceled" | "cancelled" => CheckStatus::Failed,
+        "skipped" => CheckStatus::Skipped,
+        _ => CheckStatus::Skipped,
+    }
+}
+
+pub(crate) fn summarize_ci(checks: &[CheckRun]) -> CiStatus {
+    if checks.is_empty() {
+        return CiStatus::None;
+    }
+    if checks.iter().any(|c| c.status == CheckStatus::Failed) {
+        return CiStatus::Failing;
+    }
+    if checks
+        .iter()
+        .any(|c| matches!(c.status, CheckStatus::Pending | CheckStatus::Running))
+    {
+        return CiStatus::Pending;
+    }
+    if checks.iter().any(|c| c.status == CheckStatus::Passed) {
+        return CiStatus::Passing;
+    }
+    CiStatus::None
+}
+
+// ---------------------------------------------------------------------------
+// Approvals → reviews + decision
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Approvals {
+    #[serde(default)]
+    pub approvals_required: Option<u32>,
+    #[serde(default)]
+    pub approvals_left: Option<u32>,
+    #[serde(default)]
+    pub approved_by: Vec<ApprovedBy>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct ApprovedBy {
+    #[serde(default)]
+    pub user: Option<User>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct User {
+    #[serde(default)]
+    pub username: Option<String>,
+    #[serde(default)]
+    pub name: Option<String>,
+}
+
+pub(crate) fn parse_approvals(json: &str) -> Result<Approvals> {
+    serde_json::from_str(json).map_err(|e| bad("parse approvals", e))
+}
+
+pub(crate) fn approvals_into_reviews(a: Approvals) -> Vec<Review> {
+    a.approved_by
+        .into_iter()
+        .map(|ab| {
+            let author = ab
+                .user
+                .and_then(|u| u.username.or(u.name))
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "unknown".to_string());
+            Review {
+                author,
+                state: ReviewState::Approved,
+                body: None,
+            }
+        })
+        .collect()
+}
+
+pub(crate) fn review_decision_from_approvals(a: &Approvals) -> ReviewDecision {
+    let required = a.approvals_required.unwrap_or(0);
+    if required == 0 {
+        return ReviewDecision::None;
+    }
+    let left = a.approvals_left.unwrap_or(required);
+    if left == 0 {
+        ReviewDecision::Approved
+    } else {
+        ReviewDecision::Pending
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Discussions → pending comments
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Discussion {
+    #[serde(default)]
+    pub notes: Vec<Note>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Note {
+    #[serde(default)]
+    pub id: u64,
+    #[serde(default)]
+    pub body: String,
+    #[serde(default)]
+    pub resolvable: bool,
+    #[serde(default)]
+    pub resolved: bool,
+    #[serde(default)]
+    pub author: Option<User>,
+    #[serde(default)]
+    pub position: Option<Position>,
+    #[serde(default)]
+    pub web_url: Option<String>,
+}
+
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Position {
+    #[serde(default)]
+    pub new_path: Option<String>,
+    #[serde(default)]
+    pub old_path: Option<String>,
+    #[serde(default)]
+    pub new_line: Option<u32>,
+    #[serde(default)]
+    pub old_line: Option<u32>,
+}
+
+pub(crate) fn parse_discussions(json: &str) -> Result<Vec<Discussion>> {
+    serde_json::from_str(json).map_err(|e| bad("parse discussions", e))
+}
+
+pub(crate) fn extract_pending_comments(
+    discussions: &[Discussion],
+    default_url: &str,
+) -> Vec<ReviewComment> {
+    let mut out = Vec::new();
+    for d in discussions {
+        for n in &d.notes {
+            if !n.resolvable || n.resolved {
+                continue;
+            }
+            let author = n
+                .author
+                .as_ref()
+                .and_then(|u| u.username.clone().or_else(|| u.name.clone()))
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "unknown".to_string());
+            let (path, line) = n
+                .position
+                .as_ref()
+                .map(|p| {
+                    let path = p.new_path.clone().or_else(|| p.old_path.clone());
+                    let line = p.new_line.or(p.old_line);
+                    (path.filter(|s| !s.is_empty()), line)
+                })
+                .unwrap_or((None, None));
+            out.push(ReviewComment {
+                id: n.id.to_string(),
+                author,
+                body: n.body.clone(),
+                path,
+                line,
+                is_resolved: false,
+                url: n.web_url.clone().unwrap_or_else(|| default_url.to_string()),
+            });
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn merge_request_is_draft_detects_title_prefix() {
+        let mr = MergeRequest {
+            iid: Some(1),
+            web_url: None,
+            title: Some("WIP: test".into()),
+            source_branch: None,
+            target_branch: None,
+            state: None,
+            draft: None,
+            work_in_progress: None,
+            merge_status: None,
+            has_conflicts: None,
+            head_pipeline: None,
+        };
+        assert!(mr.is_draft());
+    }
+
+    #[test]
+    fn summarize_ci_empty_is_none() {
+        assert_eq!(summarize_ci(&[]), CiStatus::None);
+    }
+
+    #[test]
+    fn review_decision_required_zero_is_none() {
+        let a = Approvals {
+            approvals_required: Some(0),
+            approvals_left: Some(0),
+            approved_by: vec![],
+        };
+        assert_eq!(review_decision_from_approvals(&a), ReviewDecision::None);
+    }
+}

--- a/crates/plugins/scm-gitlab/tests/fixtures/mr_list_open.json
+++ b/crates/plugins/scm-gitlab/tests/fixtures/mr_list_open.json
@@ -1,0 +1,13 @@
+[
+  {
+    "iid": 7,
+    "web_url": "https://gitlab.example.com/acme/widgets/-/merge_requests/7",
+    "title": "Draft: fix things",
+    "source_branch": "ao-abc",
+    "target_branch": "main",
+    "draft": true,
+    "has_conflicts": false,
+    "merge_status": "can_be_merged"
+  }
+]
+


### PR DESCRIPTION
## Summary
- Add `ao-plugin-scm-gitlab` implementing `ao_core::Scm` via the GitLab REST API (MR detection, CI status, approvals/review decision, mergeability, merge, pending comments).
- Add fixture-based tests using a mocked HTTP server (no real network).
- Wire `ao-cli` to auto-route SCM calls between GitHub and GitLab based on detected PR/MR URL shape.

## Notes
- Auth via `GITLAB_TOKEN` (also accepts `GITLAB_PRIVATE_TOKEN`).

Fixes #17

Made with [Cursor](https://cursor.com)