### PR TITLE
feat: show linked issue in session titles

### DIFF
--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -1602,7 +1602,8 @@ async fn status(
 
     for s in sessions {
         let short_id: String = s.id.0.chars().take(8).collect();
-        let task = truncate(&s.task, 60);
+        let title = session_display_title(&s);
+        let task = truncate(&title, 60);
         let activity = s
             .activity
             .map(|a| a.as_str().to_string())
@@ -2730,6 +2731,13 @@ fn print_event(event: &OrchestratorEvent) {
     }
 }
 
+fn session_display_title(s: &Session) -> String {
+    if let Some(issue_id) = s.issue_id.as_deref() {
+        return format!("#{issue_id} {}", s.task);
+    }
+    s.task.clone()
+}
+
 /// Truncate a string to at most `max` characters, appending `…` if cut.
 fn truncate(s: &str, max: usize) -> String {
     if s.chars().count() <= max {
@@ -2755,6 +2763,37 @@ mod tests {
             .as_nanos();
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("ao-rs-cli-{label}-{nanos}-{n}"))
+    }
+
+    #[test]
+    fn session_display_title_prefixes_issue_sessions() {
+        let mut s = Session {
+            id: SessionId("x".into()),
+            project_id: "p".into(),
+            status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: "br".into(),
+            task: "Phase 2: Port TS package plugins/agent-aider".into(),
+            workspace_path: None,
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: Some("22".into()),
+            issue_url: Some("https://github.com/duonghb53/ao-rs/issues/22".into()),
+        };
+        assert_eq!(
+            session_display_title(&s),
+            "#22 Phase 2: Port TS package plugins/agent-aider"
+        );
+
+        s.issue_id = None;
+        assert_eq!(
+            session_display_title(&s),
+            "Phase 2: Port TS package plugins/agent-aider"
+        );
     }
 
     #[test]

--- a/crates/ao-desktop/ui/src/components/SessionCard.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionCard.tsx
@@ -10,12 +10,18 @@ interface SessionCardProps {
   onOpen?: (session: DashboardSession) => void;
 }
 
+function openIssue(url: string) {
+  window.open(url, "_blank", "noopener,noreferrer");
+}
+
 function SessionCardView({ session, onClick, onOpen }: SessionCardProps) {
   const level = getAttentionLevel(session);
   const title = getSessionTitle(session);
   const secondary =
     session.branch ? session.branch : session.summary && session.summary !== title ? session.summary : null;
   const pr = session.pr;
+  const issueUrl = session.issueUrl;
+  const issueId = session.issueId;
 
   return (
     <button
@@ -56,7 +62,35 @@ function SessionCardView({ session, onClick, onOpen }: SessionCardProps) {
           ) : null}
         </div>
       </div>
-      <div className="session-card__title">{title}</div>
+      <div className="session-card__title">
+        {issueUrl && issueId ? (
+          <>
+            <span
+              role="link"
+              tabIndex={0}
+              title={issueUrl}
+              style={{ cursor: "pointer", userSelect: "none" }}
+              onClick={(e) => {
+                e.preventDefault();
+                e.stopPropagation();
+                openIssue(issueUrl);
+              }}
+              onKeyDown={(e) => {
+                if (e.key === "Enter" || e.key === " ") {
+                  e.preventDefault();
+                  e.stopPropagation();
+                  openIssue(issueUrl);
+                }
+              }}
+            >
+              #{issueId}
+            </span>{" "}
+            <span>{session.issueTitle ?? title}</span>
+          </>
+        ) : (
+          title
+        )}
+      </div>
       {secondary ? <div className="session-card__sub">{secondary}</div> : null}
       {pr ? (
         <div className="session-card__pills">

--- a/crates/ao-desktop/ui/src/components/SessionDetail.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.tsx
@@ -4,6 +4,14 @@ import { getAttentionLevel, TERMINAL_STATUSES } from "../lib/types";
 import { getSessionTitle } from "../lib/format";
 import { ConfirmModal } from "./ConfirmModal";
 
+function IssueLink({ id, url }: { id: string; url: string }) {
+  return (
+    <a href={url} target="_blank" rel="noreferrer" title={url}>
+      #{id}
+    </a>
+  );
+}
+
 export function SessionDetail({
   session,
   onSendMessage,
@@ -115,7 +123,15 @@ export function SessionDetail({
       />
       <section className="detail-hero">
         <div className="detail-hero__top">
-          <div className="detail-hero__title">{title}</div>
+          <div className="detail-hero__title">
+            {session.issueId && session.issueUrl && session.issueTitle ? (
+              <>
+                <IssueLink id={session.issueId} url={session.issueUrl} /> {session.issueTitle}
+              </>
+            ) : (
+              title
+            )}
+          </div>
           <span className="mini-pill detail-hero__status" data-tone={level}>
             {level}
           </span>

--- a/crates/ao-desktop/ui/src/lib/format.ts
+++ b/crates/ao-desktop/ui/src/lib/format.ts
@@ -13,6 +13,7 @@ export function humanizeBranch(branch: string): string {
 
 export function getSessionTitle(session: DashboardSession): string {
   if (session.pr?.title) return session.pr.title;
+  if (session.issueId && session.issueTitle) return `#${session.issueId} ${session.issueTitle}`;
   if (session.issueTitle) return session.issueTitle;
   if (session.userPrompt) return session.userPrompt;
   if (session.branch) return humanizeBranch(session.branch);

--- a/crates/ao-desktop/ui/src/lib/types.ts
+++ b/crates/ao-desktop/ui/src/lib/types.ts
@@ -25,6 +25,8 @@ export type DashboardSession = {
   summary: string | null;
   summaryIsFallback: boolean;
   issueTitle: string | null;
+  issueId: string | null;
+  issueUrl: string | null;
   userPrompt: string | null;
   pr: DashboardPR | null;
   attentionLevel?: AttentionLevel | null;

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -292,7 +292,9 @@ export function App() {
         branch: s.branch ?? null,
         summary: s.task ?? null,
         summaryIsFallback: false,
-        issueTitle: null,
+        issueTitle: s.issue_id ? (s.task ?? null) : null,
+        issueId: s.issue_id ?? null,
+        issueUrl: s.issue_url ?? null,
         userPrompt: null,
         pr: s.pr
           ? {


### PR DESCRIPTION
## Summary
- Prefix issue-backed sessions with `#<issue>` in CLI `status` output.
- Expose `issueId`/`issueUrl` in desktop UI session types and render a clickable issue link in the session list and detail header.

## Test plan
- `cargo test`
- `cd crates/ao-desktop/ui && npm run build`

Closes #40.

Made with [Cursor](https://cursor.com)