### PR TITLE
fix(core): restore edge cases + safe worktree cleanup

### DIFF
--- a/crates/ao-core/src/restore.rs
+++ b/crates/ao-core/src/restore.rs
@@ -303,6 +303,43 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn restore_missing_runtime_handle_creates_new_handle_without_destroy() {
+        let base = unique_temp_dir("no-handle");
+        let ws = base.join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let manager = SessionManager::new(base.clone());
+        // Persist a terminal session that somehow lost its runtime_handle.
+        let mut s = persist_session(&manager, "sess-nohandle", SessionStatus::Terminated, &ws).await;
+        s.runtime_handle = None;
+        manager.save(&s).await.unwrap();
+
+        let rt = RecorderRuntime::new(false);
+        let out = restore_session("sess-nohandle", &manager, &rt, &StubAgent)
+            .await
+            .unwrap();
+
+        // No prior handle → no destroy call.
+        let calls = rt.calls();
+        assert!(
+            !calls.iter().any(|c| c.starts_with("destroy:")),
+            "unexpected destroy call(s): {calls:?}"
+        );
+        // The name used should fall back to first 8 chars of the uuid.
+        assert!(
+            calls.iter().any(|c| c == "create:sess-noh"),
+            "expected create with short id (sess-noh), got calls: {calls:?}"
+        );
+        assert_eq!(out.runtime_handle, "sess-noh");
+        assert_eq!(out.session.status, SessionStatus::Spawning);
+
+        let reread = manager.find_by_prefix("sess-nohandle").await.unwrap();
+        assert_eq!(reread.runtime_handle.as_deref(), Some("sess-noh"));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
     async fn crashed_working_session_is_enriched_to_terminated_then_restored() {
         // Session on disk says `working` but the runtime probe reports dead
         // — exactly the TS `enrichSessionWithRuntimeState` case.

--- a/crates/ao-core/src/session_manager.rs
+++ b/crates/ao-core/src/session_manager.rs
@@ -469,4 +469,26 @@ mod tests {
 
         let _ = std::fs::remove_dir_all(&base);
     }
+
+    #[tokio::test]
+    async fn list_skips_corrupted_yaml_among_many() {
+        let base = unique_temp_dir("corrupt");
+        let manager = SessionManager::new(base.clone());
+
+        // One valid session.
+        let ok = fake_session("uuid-ok", "demo", "good");
+        manager.save(&ok).await.unwrap();
+
+        // One corrupted YAML file in the same project dir.
+        let project_dir = base.join("demo");
+        std::fs::create_dir_all(&project_dir).unwrap();
+        let bad_path = project_dir.join("uuid-bad.yaml");
+        std::fs::write(&bad_path, "this: is: not: valid: yaml: [").unwrap();
+
+        let all = manager.list().await.unwrap();
+        assert_eq!(all.len(), 1, "expected only the valid session to load");
+        assert_eq!(all[0].id.0, "uuid-ok");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
 }

--- a/crates/plugins/workspace-worktree/src/lib.rs
+++ b/crates/plugins/workspace-worktree/src/lib.rs
@@ -27,6 +27,27 @@ impl WorktreeWorkspace {
     pub fn with_base_dir(base_dir: PathBuf) -> Self {
         Self { base_dir }
     }
+
+    fn assert_under_base_dir(&self, workspace_path: &Path) -> Result<()> {
+        // `destroy()` may be called with a path loaded from disk (session YAML).
+        // Treat the configured base dir as an allowlist: never delete anything
+        // outside it, even on fallback cleanup.
+        //
+        // Canonicalize when possible to defend against `..` segments and symlinks.
+        // If canonicalization fails (e.g. path doesn't exist yet), fall back to a
+        // lexical check.
+        let base = canonical_or_clean(&self.base_dir);
+        let ws = canonical_or_clean(workspace_path);
+
+        if !path_is_within(&ws, &base) {
+            return Err(AoError::Workspace(format!(
+                "refusing to destroy workspace outside base dir: base={} workspace={}",
+                base.display(),
+                ws.display()
+            )));
+        }
+        Ok(())
+    }
 }
 
 impl Default for WorktreeWorkspace {
@@ -96,6 +117,7 @@ impl Workspace for WorktreeWorkspace {
     }
 
     async fn destroy(&self, workspace_path: &Path) -> Result<()> {
+        self.assert_under_base_dir(workspace_path)?;
         let worktree_str = path_to_str(workspace_path)?;
 
         // Try to find the parent repo via git itself.
@@ -129,6 +151,28 @@ impl Workspace for WorktreeWorkspace {
 }
 
 // ---------- helpers ----------
+
+fn canonical_or_clean(p: &Path) -> PathBuf {
+    std::fs::canonicalize(p).unwrap_or_else(|_| {
+        // Best-effort lexical normalization: strip trailing separators and
+        // remove `.` segments. We do *not* try to resolve `..` here.
+        let mut out = PathBuf::new();
+        for part in p.components() {
+            use std::path::Component;
+            match part {
+                Component::CurDir => {}
+                other => out.push(other.as_os_str()),
+            }
+        }
+        out
+    })
+}
+
+fn path_is_within(child: &Path, base: &Path) -> bool {
+    // `starts_with` is path-component aware; with canonical paths it provides
+    // the containment guarantee we want.
+    child.starts_with(base)
+}
 
 /// Run `git <args>` in `cwd`, return trimmed stdout or a structured error.
 async fn git(cwd: &Path, args: &[&str]) -> Result<String> {

--- a/crates/plugins/workspace-worktree/tests/integration.rs
+++ b/crates/plugins/workspace-worktree/tests/integration.rs
@@ -98,3 +98,26 @@ async fn rejects_unsafe_session_id() {
     let _ = std::fs::remove_dir_all(&repo);
     let _ = std::fs::remove_dir_all(&base);
 }
+
+#[tokio::test]
+async fn destroy_refuses_paths_outside_base_dir() {
+    let base = unique_dir("worktrees-safety-base");
+    let workspace = WorktreeWorkspace::with_base_dir(base.clone());
+
+    let victim_parent = unique_dir("worktrees-safety-victim");
+    let victim = victim_parent.join("do-not-delete");
+    std::fs::create_dir_all(&victim).unwrap();
+    std::fs::write(victim.join("sentinel.txt"), "keep\n").unwrap();
+
+    let err = workspace.destroy(&victim).await.unwrap_err();
+    let msg = format!("{err}");
+    assert!(
+        msg.contains("refusing to destroy workspace outside base dir"),
+        "unexpected error: {msg}"
+    );
+    assert!(victim.exists(), "victim directory was deleted");
+    assert!(victim.join("sentinel.txt").exists(), "victim contents were deleted");
+
+    let _ = std::fs::remove_dir_all(&victim_parent);
+    let _ = std::fs::remove_dir_all(&base);
+}


### PR DESCRIPTION
Closes #25 (Phase 1).

## Summary
- Restore supports sessions with missing `runtime_handle` (no `destroy`, creates new handle from short id).
- Session listing (`status`) skips corrupted YAML entries instead of failing the whole command.
- `workspace-worktree` refuses to destroy any path outside its configured base dir to avoid deleting unrelated worktrees.

## Test plan
- `cargo test -p ao-core -p ao-cli`

## Notes
- Missing worktree on restore remains a hard error (no auto-recreate); this matches the existing `ao_core::restore_session` contract.

Made with [Cursor](https://cursor.com)