### PR TITLE
feat(cursor): parity improvements for activity + rules

### DIFF
--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -244,6 +244,24 @@ fn resolve_agent_config(
     Some(out)
 }
 
+/// Ensure `Session::agent_config` is self-contained for restore.
+///
+/// Older sessions (or sessions created by other tools) may persist `rules_file`
+/// instead of inlining the resolved `rules`. On restore we best-effort inline
+/// rules using the session's worktree path as the base dir.
+fn resolve_agent_config_for_restore(session: &mut Session) {
+    let Some(cfg) = session.agent_config.as_ref() else {
+        return;
+    };
+    if cfg.rules_file.is_none() {
+        return;
+    }
+    let Some(ws) = session.workspace_path.as_deref() else {
+        return;
+    };
+    session.agent_config = resolve_agent_config(Some(cfg), ws);
+}
+
 /// Delegating agent that picks an underlying implementation per session.
 ///
 /// Needed because `ao-rs watch`/`dashboard` manage a fleet of sessions that may
@@ -2730,7 +2748,12 @@ async fn restore(session_id_or_prefix: String) -> Result<(), Box<dyn std::error:
     let sessions = SessionManager::with_default();
     // Resolve the session first so we can reconstruct the correct agent plugin
     // (and its captured config) for the restore call.
-    let session = sessions.find_by_prefix(&session_id_or_prefix).await?;
+    let mut session = sessions.find_by_prefix(&session_id_or_prefix).await?;
+    let before = session.agent_config.clone();
+    resolve_agent_config_for_restore(&mut session);
+    if session.agent_config != before {
+        sessions.save(&session).await?;
+    }
     let runtime = select_runtime(&session.runtime);
     let agent_box = select_agent(&session.agent, session.agent_config.as_ref());
 
@@ -2865,6 +2888,53 @@ mod tests {
             .as_nanos();
         let n = COUNTER.fetch_add(1, Ordering::Relaxed);
         std::env::temp_dir().join(format!("ao-rs-cli-{label}-{nanos}-{n}"))
+    }
+
+    #[test]
+    fn resolve_agent_config_inlines_rules_file_and_clears_path() {
+        let repo_dir = unique_temp_dir("rules-inline");
+        std::fs::create_dir_all(&repo_dir).unwrap();
+        let rules_path = repo_dir.join("rules.md");
+        std::fs::write(&rules_path, "RULES: be nice").unwrap();
+
+        let cfg = AgentConfig {
+            permissions: "permissionless".into(),
+            rules: None,
+            rules_file: Some("rules.md".into()),
+            model: None,
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let resolved = resolve_agent_config(Some(&cfg), &repo_dir).unwrap();
+        assert_eq!(resolved.rules.as_deref(), Some("RULES: be nice"));
+        assert!(resolved.rules_file.is_none());
+
+        let _ = std::fs::remove_dir_all(&repo_dir);
+    }
+
+    #[test]
+    fn resolve_agent_config_for_restore_inlines_rules_file_using_workspace_path() {
+        let ws = unique_temp_dir("rules-restore");
+        std::fs::create_dir_all(&ws).unwrap();
+        std::fs::write(ws.join("rules.txt"), "restored rules").unwrap();
+
+        let mut s = fake_session();
+        s.workspace_path = Some(ws.clone());
+        s.agent_config = Some(AgentConfig {
+            permissions: "permissionless".into(),
+            rules: None,
+            rules_file: Some("rules.txt".into()),
+            model: None,
+            orchestrator_model: None,
+            opencode_session_id: None,
+        });
+
+        resolve_agent_config_for_restore(&mut s);
+        let cfg = s.agent_config.unwrap();
+        assert_eq!(cfg.rules.as_deref(), Some("restored rules"));
+        assert!(cfg.rules_file.is_none());
+
+        let _ = std::fs::remove_dir_all(&ws);
     }
 
     #[test]

--- a/crates/plugins/agent-cursor/src/lib.rs
+++ b/crates/plugins/agent-cursor/src/lib.rs
@@ -17,8 +17,10 @@
 //!
 //! Cursor doesn't write JSONL session logs like Claude Code. Detection uses:
 //! 1. `.cursor/chat.md` file mtime — if recently modified, agent is active.
-//! 2. Recent git commits in the workspace — if any within 60s, agent is active.
-//! 3. Fallback: `ActivityState::Ready` (runtime liveness covers process exit).
+//! 2. Cursor log artifacts (if present) — `.cursor/logs/*` mtime.
+//! 3. Workspace git activity — `.git/index` mtime (captures edits even without commits).
+//! 4. Recent git commits in the workspace — if any within 60s, agent is active.
+//! 5. Fallback: `ActivityState::Ready` (runtime liveness covers process exit).
 //!
 //! ## Cost tracking
 //!
@@ -146,33 +148,125 @@ impl Agent for CursorAgent {
 ///   3. Fallback: `Ready` — runtime liveness covers process exit.
 fn detect_cursor_activity(workspace_path: &Path) -> Result<ActivityState> {
     // 1. Check .cursor/chat.md mtime.
-    let chat_file = workspace_path.join(".cursor").join("chat.md");
-    if let Ok(metadata) = std::fs::metadata(&chat_file) {
-        let Ok(modified) = metadata.modified() else {
-            // Platform doesn't support mtime — fall back to Ready rather
-            // than silently reporting Active with a faked timestamp.
-            return Ok(ActivityState::Ready);
-        };
-        let age = std::time::SystemTime::now()
-            .duration_since(modified)
-            .unwrap_or_default();
-
-        if age.as_secs() <= ACTIVE_WINDOW_SECS {
-            return Ok(ActivityState::Active);
-        }
-        if age.as_secs() <= IDLE_THRESHOLD_SECS {
-            return Ok(ActivityState::Ready);
-        }
-        return Ok(ActivityState::Idle);
+    if let Some(state) = state_from_mtime(workspace_path.join(".cursor").join("chat.md"))? {
+        return Ok(state);
     }
 
-    // 2. Check for recent git commits.
+    // 2. Check Cursor log artifacts (if any).
+    if let Some(state) = detect_cursor_log_activity(workspace_path)? {
+        return Ok(state);
+    }
+
+    // 3. Check git activity via `.git/index` mtime (captures "work happened" even without commits).
+    if let Some(state) = detect_git_index_activity(workspace_path)? {
+        return Ok(state);
+    }
+
+    // 4. Check for recent git commits.
     if has_recent_commits(workspace_path) {
         return Ok(ActivityState::Active);
     }
 
-    // 3. Fallback — no cursor artifacts, agent may have just started.
+    // 5. Fallback — no cursor artifacts, agent may have just started.
     Ok(ActivityState::Ready)
+}
+
+fn age_to_state(age_secs: u64) -> ActivityState {
+    if age_secs <= ACTIVE_WINDOW_SECS {
+        ActivityState::Active
+    } else if age_secs <= IDLE_THRESHOLD_SECS {
+        ActivityState::Ready
+    } else {
+        ActivityState::Idle
+    }
+}
+
+fn state_from_mtime(path: impl AsRef<Path>) -> Result<Option<ActivityState>> {
+    let path = path.as_ref();
+    let Ok(metadata) = std::fs::metadata(path) else {
+        return Ok(None);
+    };
+    let Ok(modified) = metadata.modified() else {
+        // Platform doesn't support mtime — fall back to Ready rather
+        // than silently reporting Active with a faked timestamp.
+        return Ok(Some(ActivityState::Ready));
+    };
+    let age = std::time::SystemTime::now()
+        .duration_since(modified)
+        .unwrap_or_default()
+        .as_secs();
+    Ok(Some(age_to_state(age)))
+}
+
+fn detect_cursor_log_activity(workspace_path: &Path) -> Result<Option<ActivityState>> {
+    let cursor_dir = workspace_path.join(".cursor");
+    let logs_dir = cursor_dir.join("logs");
+    let Ok(entries) = std::fs::read_dir(&logs_dir) else {
+        return Ok(None);
+    };
+
+    let mut newest: Option<std::time::SystemTime> = None;
+    // Bound cost even if logs dir is large.
+    for (i, entry) in entries.flatten().enumerate() {
+        if i >= 200 {
+            break;
+        }
+        let Ok(meta) = entry.metadata() else {
+            continue;
+        };
+        if !meta.is_file() {
+            continue;
+        }
+        let Ok(modified) = meta.modified() else {
+            continue;
+        };
+        newest = Some(match newest {
+            Some(prev) if prev > modified => prev,
+            _ => modified,
+        });
+    }
+
+    let Some(newest) = newest else {
+        return Ok(None);
+    };
+    let age = std::time::SystemTime::now()
+        .duration_since(newest)
+        .unwrap_or_default()
+        .as_secs();
+    Ok(Some(age_to_state(age)))
+}
+
+fn detect_git_index_activity(workspace_path: &Path) -> Result<Option<ActivityState>> {
+    // Fast path: `.git/index` exists directly under worktree.
+    let direct = workspace_path.join(".git").join("index");
+    if let Some(state) = state_from_mtime(&direct)? {
+        return Ok(Some(state));
+    }
+
+    // Worktrees sometimes have `.git` as a file pointing at the real git dir.
+    let output = std::process::Command::new("git")
+        .args(["rev-parse", "--git-dir"])
+        .current_dir(workspace_path)
+        .stdout(std::process::Stdio::piped())
+        .stderr(std::process::Stdio::null())
+        .output();
+    let Ok(o) = output else {
+        return Ok(None);
+    };
+    if !o.status.success() {
+        return Ok(None);
+    }
+    let git_dir = String::from_utf8_lossy(&o.stdout).trim().to_string();
+    if git_dir.is_empty() {
+        return Ok(None);
+    }
+    let git_dir = if Path::new(&git_dir).is_absolute() {
+        std::path::PathBuf::from(git_dir)
+    } else {
+        workspace_path.join(git_dir)
+    };
+    let idx = git_dir.join("index");
+    Ok(state_from_mtime(idx)?)
 }
 
 /// Check if any git commits were made in the workspace within the last 60s.
@@ -332,6 +426,32 @@ mod tests {
         let cursor_dir = ws.join(".cursor");
         std::fs::create_dir_all(&cursor_dir).unwrap();
         std::fs::write(cursor_dir.join("chat.md"), "# Session\nHello").unwrap();
+
+        let result = detect_cursor_activity(&ws).unwrap();
+        assert_eq!(result, ActivityState::Active);
+
+        std::fs::remove_dir_all(&ws).ok();
+    }
+
+    #[test]
+    fn detect_activity_falls_back_to_cursor_logs_when_chat_missing() {
+        let ws = std::env::temp_dir().join("ao-cursor-active-logs");
+        let logs_dir = ws.join(".cursor").join("logs");
+        std::fs::create_dir_all(&logs_dir).unwrap();
+        std::fs::write(logs_dir.join("cursor-agent.log"), "hello").unwrap();
+
+        let result = detect_cursor_activity(&ws).unwrap();
+        assert_eq!(result, ActivityState::Active);
+
+        std::fs::remove_dir_all(&ws).ok();
+    }
+
+    #[test]
+    fn detect_activity_falls_back_to_git_index_mtime_when_no_cursor_artifacts() {
+        let ws = std::env::temp_dir().join("ao-cursor-active-git-index");
+        let git_dir = ws.join(".git");
+        std::fs::create_dir_all(&git_dir).unwrap();
+        std::fs::write(git_dir.join("index"), "fake index").unwrap();
 
         let result = detect_cursor_activity(&ws).unwrap();
         assert_eq!(result, ActivityState::Active);


### PR DESCRIPTION
## Summary
- Improve Cursor session activity detection by adding fallbacks beyond `.cursor/chat.md` (Cursor log artifacts + git index mtime + existing recent-commit fallback).
- Ensure `rules_file` is consistently resolved to inline `rules` on restore so sessions remain self-contained.
- Add unit tests covering the new activity detection fallbacks and rules resolution/persistence.

## Test plan
- `cargo test -p ao-plugin-agent-cursor -p ao-cli`

## Issue
Closes #27

Made with [Cursor](https://cursor.com)