### PR TITLE
feat(scm-github): merge parity (statuses fallback + merge method)

### DIFF
--- a/crates/ao-core/src/config.rs
+++ b/crates/ao-core/src/config.rs
@@ -228,10 +228,18 @@ pub struct AgentConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub model: Option<String>,
     /// Orchestrator model override (TS: `agentConfig.orchestratorModel`).
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "orchestratorModel")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "orchestratorModel"
+    )]
     pub orchestrator_model: Option<String>,
     /// OpenCode session id (TS: `agentConfig.opencodeSessionId`).
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "opencodeSessionId")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "opencodeSessionId"
+    )]
     pub opencode_session_id: Option<String>,
 }
 
@@ -363,9 +371,17 @@ pub struct AoConfig {
     #[serde(default = "default_port")]
     pub port: u16,
     /// Terminal server ports (TS: `terminalPort`, `directTerminalPort`).
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "terminalPort")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "terminalPort"
+    )]
     pub terminal_port: Option<u16>,
-    #[serde(default, skip_serializing_if = "Option::is_none", rename = "directTerminalPort")]
+    #[serde(
+        default,
+        skip_serializing_if = "Option::is_none",
+        rename = "directTerminalPort"
+    )]
     pub direct_terminal_port: Option<u16>,
     /// Power management settings.
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -494,6 +510,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: Some(EscalateAfter::Attempts(2)),
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -510,6 +527,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: Some(EscalateAfter::Duration("30m".into())),
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -526,6 +544,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: Some(EscalateAfter::Duration("15m".into())),
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -539,6 +558,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: None,
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -555,6 +575,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: Some(EscalateAfter::Duration("15m".into())),
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -568,6 +589,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: None,
             threshold: Some("10m".into()),
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -581,6 +603,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: None,
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -594,6 +617,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: None,
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
     m.insert(
@@ -607,6 +631,7 @@ pub fn default_reactions() -> HashMap<String, ReactionConfig> {
             escalate_after: None,
             threshold: None,
             include_summary: true,
+            merge_method: None,
         },
     );
     m

--- a/crates/ao-core/src/reaction_engine.rs
+++ b/crates/ao-core/src/reaction_engine.rs
@@ -809,7 +809,7 @@ impl ReactionEngine {
         &self,
         session: &Session,
         reaction_key: &str,
-        _cfg: &ReactionConfig,
+        cfg: &ReactionConfig,
     ) -> ReactionOutcome {
         // Phase D-compat path: no SCM attached → emit the intent event
         // and return success without merging. Existing Phase D tests and
@@ -935,7 +935,7 @@ impl ReactionEngine {
         });
 
         // Actually merge. `None` = plugin default merge method.
-        match scm.merge(&pr, None).await {
+        match scm.merge(&pr, cfg.merge_method).await {
             Ok(()) => {
                 tracing::info!(
                     reaction = reaction_key,

--- a/crates/ao-core/src/reactions.rs
+++ b/crates/ao-core/src/reactions.rs
@@ -28,6 +28,7 @@
 //!   A deserialization trivial and defers the "what units do we accept"
 //!   question to when we have a concrete use site.
 
+use crate::scm::MergeMethod;
 use serde::{Deserialize, Serialize};
 
 /// What a reaction should actually do when it fires. Matches the TS
@@ -195,6 +196,16 @@ pub struct ReactionConfig {
     /// produce one; Phase D might flip the default.
     #[serde(default, skip_serializing_if = "is_false")]
     pub include_summary: bool,
+
+    /// Merge method to use when `action: auto-merge`. If unset, the SCM
+    /// plugin's default is used.
+    #[serde(
+        default,
+        rename = "merge_method",
+        alias = "merge-method",
+        skip_serializing_if = "Option::is_none"
+    )]
+    pub merge_method: Option<MergeMethod>,
 }
 
 impl ReactionConfig {
@@ -211,6 +222,7 @@ impl ReactionConfig {
             escalate_after: None,
             threshold: None,
             include_summary: false,
+            merge_method: None,
         }
     }
 }

--- a/crates/ao-core/tests/notification_flow.rs
+++ b/crates/ao-core/tests/notification_flow.rs
@@ -326,6 +326,7 @@ async fn lifecycle_tick_triggers_notify_through_to_plugin() {
             escalate_after: None,
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
 
@@ -396,6 +397,7 @@ async fn escalation_reaches_notifier_with_escalated_flag() {
             escalate_after: Some(ao_core::reactions::EscalateAfter::Attempts(0)),
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
 
@@ -450,6 +452,7 @@ async fn partial_failure_one_plugin_fails_others_succeed() {
             escalate_after: None,
             threshold: None,
             include_summary: false,
+            merge_method: None,
         },
     );
 

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -56,6 +56,11 @@ fn is_no_checks_reported_error(msg: &str) -> bool {
     msg.to_lowercase().contains("no checks reported")
 }
 
+fn is_not_found_error(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("not found") || m.contains("404")
+}
+
 /// Per-subprocess timeout. Mirrors `DEFAULT_TIMEOUT_MS = 30_000` in the
 /// TS reference's `execCli` helper. `gh pr checks` on a large monorepo can
 /// easily take 5–10s; 30s is the "the network is wedged, kill it" bound,
@@ -146,7 +151,7 @@ impl Scm for GitHubScm {
     }
 
     async fn ci_checks(&self, pr: &PullRequest) -> Result<Vec<CheckRun>> {
-        let json = gh(&[
+        match gh(&[
             "pr",
             "checks",
             &pr.number.to_string(),
@@ -155,8 +160,19 @@ impl Scm for GitHubScm {
             "--json",
             "name,state,link,startedAt,completedAt",
         ])
-        .await?;
-        parse::parse_ci_checks(&json)
+        .await
+        {
+            Ok(json) => parse::parse_ci_checks(&json),
+            Err(e) => {
+                // Fallback for repos that publish commit statuses but not
+                // check runs. `gh pr checks` reports "no checks reported"
+                // for those repos, but CI *does* exist (as statuses).
+                if is_no_checks_reported_error(&e.to_string()) {
+                    return self.commit_status_checks(pr).await;
+                }
+                Err(e)
+            }
+        }
     }
 
     async fn ci_status(&self, pr: &PullRequest) -> Result<CiStatus> {
@@ -178,15 +194,11 @@ impl Scm for GitHubScm {
                         return Ok(CiStatus::None);
                     }
                 }
-                // `gh pr checks` returns a non-zero exit with an error like:
-                // "no checks reported on the '<branch>' branch"
-                // This is not "CI pending" — it usually means the repo has no checks
-                // configured (or GitHub isn't reporting them as check runs).
-                // Treat as `None` so the dashboard doesn't incorrectly move the session
-                // into Backlog ("pending").
-                if is_no_checks_reported_error(&e.to_string()) {
-                    return Ok(CiStatus::None);
-                }
+                // If `gh pr checks` failed with "no checks reported", we may
+                // still have commit statuses. `ci_checks()` already tries
+                // the fallback, so reaching this branch means either:
+                // - the fallback also failed, or
+                // - a different error occurred.
                 tracing::warn!(
                     "ci_status: gh checks failed for PR #{} (reporting pending): {e}",
                     pr.number
@@ -304,7 +316,7 @@ impl Scm for GitHubScm {
             MergeMethod::Squash => "--squash",
             MergeMethod::Rebase => "--rebase",
         };
-        gh(&[
+        let res = gh(&[
             "pr",
             "merge",
             &pr.number.to_string(),
@@ -313,8 +325,44 @@ impl Scm for GitHubScm {
             flag,
             "--delete-branch",
         ])
-        .await?;
+        .await;
+        if let Err(e) = res {
+            return Err(normalize_merge_error(e));
+        }
         Ok(())
+    }
+}
+
+impl GitHubScm {
+    async fn pr_head_sha(&self, pr: &PullRequest) -> Result<String> {
+        let json = gh(&[
+            "pr",
+            "view",
+            &pr.number.to_string(),
+            "--repo",
+            &repo_flag(pr),
+            "--json",
+            "headRefOid",
+        ])
+        .await?;
+        parse::parse_head_ref_oid(&json)
+    }
+
+    async fn commit_status_checks(&self, pr: &PullRequest) -> Result<Vec<CheckRun>> {
+        let sha = self.pr_head_sha(pr).await?;
+        let endpoint = format!("repos/{}/{}/commits/{}/status", pr.owner, pr.repo, sha);
+        match gh(&["api", "--method", "GET", &endpoint]).await {
+            Ok(json) => parse::parse_commit_statuses(&json),
+            Err(e) => {
+                // Some repos (or permissions) may not expose the statuses
+                // endpoint; treat as "no CI signal" rather than hard-erroring
+                // into a perpetual Pending state.
+                if is_not_found_error(&e.to_string()) {
+                    return Ok(Vec::new());
+                }
+                Err(e)
+            }
+        }
     }
 }
 
@@ -368,8 +416,13 @@ pub(crate) fn compose_merge_readiness(
     let merge_state = raw.merge_state_status.to_ascii_uppercase();
     match merge_state.as_str() {
         "BEHIND" => blockers.push("Branch is behind base branch".into()),
-        "BLOCKED" => blockers.push("Merge is blocked by branch protection".into()),
+        "BLOCKED" => blockers.push("Branch protection requirements not satisfied".into()),
         "UNSTABLE" => blockers.push("Required checks are failing".into()),
+        "DIRTY" => {
+            // This can overlap with `mergeable: CONFLICTING`, but some repos
+            // report only mergeStateStatus. Provide an actionable umbrella.
+            blockers.push("Merge is blocked (conflicts or failing requirements)".into())
+        }
         _ => {}
     }
 
@@ -393,6 +446,28 @@ fn ci_status_label(s: CiStatus) -> &'static str {
         CiStatus::Failing => "failing",
         CiStatus::None => "none",
     }
+}
+
+fn normalize_merge_error(e: AoError) -> AoError {
+    let msg = e.to_string();
+    let lower = msg.to_lowercase();
+
+    // Keep the original detail but make the prefix actionable.
+    if lower.contains("protected branch")
+        || lower.contains("branch protection")
+        || lower.contains("base branch policy")
+    {
+        return AoError::Scm(format!("merge blocked by branch protection: {msg}"));
+    }
+    if lower.contains("not mergeable") || lower.contains("cannot be merged") {
+        return AoError::Scm(format!("merge blocked (PR not mergeable yet): {msg}"));
+    }
+    if lower.contains("merge method")
+        && (lower.contains("not allowed") || lower.contains("disabled"))
+    {
+        return AoError::Scm(format!("merge method not allowed for this repo: {msg}"));
+    }
+    AoError::Scm(format!("merge failed: {msg}"))
 }
 
 // ---------------------------------------------------------------------------
@@ -527,6 +602,43 @@ mod tests {
         let msg =
             "gh pr checks 26 --repo x/y --json name,state failed: no checks reported on the 'ao-abc' branch";
         assert!(is_no_checks_reported_error(msg));
+    }
+
+    #[test]
+    fn is_not_found_error_matches_common_gh_api_failures() {
+        assert!(is_not_found_error(
+            "gh api ... failed: Not Found (HTTP 404)"
+        ));
+        assert!(is_not_found_error("HTTP 404: Not Found"));
+        assert!(!is_not_found_error("HTTP 401: Bad credentials"));
+    }
+
+    #[test]
+    fn normalize_merge_error_adds_actionable_prefixes() {
+        let fixture = include_str!("../tests/fixtures/merge_error_branch_protection.txt");
+        let e = AoError::Scm(fixture.trim().to_string());
+        let n = normalize_merge_error(e).to_string();
+        assert!(n.to_lowercase().contains("branch protection"));
+
+        let e = AoError::Scm("gh pr merge failed: Pull request is not mergeable".into());
+        let n = normalize_merge_error(e).to_string();
+        assert!(n.to_lowercase().contains("not mergeable"));
+
+        let e = AoError::Scm("gh pr merge failed: Merge method 'rebase' is disabled".into());
+        let n = normalize_merge_error(e).to_string();
+        assert!(n.to_lowercase().contains("merge method"));
+    }
+
+    #[test]
+    fn mergeability_blocked_fixture_formats_actionable_blocker() {
+        let json = include_str!("../tests/fixtures/mergeability_blocked.json");
+        let raw = parse::parse_raw_mergeability(json).unwrap();
+        let r = compose_merge_readiness(raw, CiStatus::Passing);
+        assert!(!r.is_ready());
+        assert!(r
+            .blockers
+            .iter()
+            .any(|b| b.to_lowercase().contains("branch protection")));
     }
 
     #[test]

--- a/crates/plugins/scm-github/src/parse.rs
+++ b/crates/plugins/scm-github/src/parse.rs
@@ -111,6 +111,20 @@ pub(crate) fn map_check_state(raw: &str) -> CheckStatus {
     }
 }
 
+/// Map GitHub "commit status" states (Statuses API) onto our normalized
+/// `CheckStatus`.
+///
+/// GitHub's combined status uses lower-case strings: `success`, `failure`,
+/// `pending`, `error`. Treat unknowns as `Skipped` (defensive).
+pub(crate) fn map_commit_status_state(raw: &str) -> CheckStatus {
+    match raw.trim().to_ascii_lowercase().as_str() {
+        "pending" => CheckStatus::Pending,
+        "success" => CheckStatus::Passed,
+        "failure" | "error" => CheckStatus::Failed,
+        _ => CheckStatus::Skipped,
+    }
+}
+
 #[derive(Debug, Deserialize)]
 struct RawCheck {
     name: String,
@@ -176,6 +190,58 @@ pub(crate) fn summarize_ci(checks: &[CheckRun]) -> CiStatus {
         return CiStatus::Passing;
     }
     CiStatus::None
+}
+
+// ---------------------------------------------------------------------------
+// Commit statuses (Statuses API) — fallback for statuses-only repos
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct RawCombinedStatus {
+    #[serde(default)]
+    statuses: Vec<RawCommitStatus>,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawCommitStatus {
+    #[serde(default)]
+    context: String,
+    #[serde(default)]
+    state: String,
+    #[serde(default)]
+    target_url: Option<String>,
+    // `description` exists but is not needed for core signals.
+}
+
+/// Parse `gh api repos/{owner}/{repo}/commits/{sha}/status`.
+///
+/// This endpoint is commonly used by older CI systems that publish only
+/// commit statuses (not check runs). We map each status row into a
+/// `CheckRun` so the rest of the pipeline (summarization + reactions) can
+/// stay uniform.
+pub(crate) fn parse_commit_statuses(json: &str) -> Result<Vec<CheckRun>> {
+    let raw: RawCombinedStatus =
+        serde_json::from_str(json).map_err(|e| bad("parse commit statuses", e))?;
+    Ok(raw
+        .statuses
+        .into_iter()
+        .filter(|s| !s.context.trim().is_empty())
+        .map(|s| {
+            let status = map_commit_status_state(&s.state);
+            let conclusion = if s.state.trim().is_empty() {
+                None
+            } else {
+                Some(s.state)
+            };
+            let url = s.target_url.filter(|u| !u.trim().is_empty());
+            CheckRun {
+                name: s.context,
+                status,
+                url,
+                conclusion,
+            }
+        })
+        .collect())
 }
 
 // ---------------------------------------------------------------------------
@@ -334,6 +400,21 @@ pub(crate) fn parse_raw_mergeability(json: &str) -> Result<RawMergeability> {
 }
 
 // ---------------------------------------------------------------------------
+// Misc helpers (PR head sha)
+// ---------------------------------------------------------------------------
+
+/// Parse `gh pr view <num> --json headRefOid`.
+pub(crate) fn parse_head_ref_oid(json: &str) -> Result<String> {
+    #[derive(Deserialize)]
+    struct Wrap {
+        #[serde(default, rename = "headRefOid")]
+        head_ref_oid: String,
+    }
+    let w: Wrap = serde_json::from_str(json).map_err(|e| bad("parse headRefOid", e))?;
+    Ok(w.head_ref_oid)
+}
+
+// ---------------------------------------------------------------------------
 // Tests
 // ---------------------------------------------------------------------------
 
@@ -436,6 +517,16 @@ mod tests {
     fn map_check_state_is_case_insensitive_and_trims() {
         assert_eq!(map_check_state("  success  "), CheckStatus::Passed);
         assert_eq!(map_check_state("In_Progress"), CheckStatus::Running);
+    }
+
+    #[test]
+    fn map_commit_status_state_covers_github_values() {
+        assert_eq!(map_commit_status_state("pending"), CheckStatus::Pending);
+        assert_eq!(map_commit_status_state("success"), CheckStatus::Passed);
+        assert_eq!(map_commit_status_state("failure"), CheckStatus::Failed);
+        assert_eq!(map_commit_status_state("error"), CheckStatus::Failed);
+        assert_eq!(map_commit_status_state("WEIRD"), CheckStatus::Skipped);
+        assert_eq!(map_commit_status_state(""), CheckStatus::Skipped);
     }
 
     #[test]
@@ -561,6 +652,30 @@ mod tests {
             },
         ];
         assert_eq!(summarize_ci(&checks), CiStatus::Passing);
+    }
+
+    #[test]
+    fn parse_commit_statuses_maps_context_state_and_url() {
+        let json = include_str!("../tests/fixtures/commit_statuses_only.json");
+        let statuses = parse_commit_statuses(json).unwrap();
+        assert_eq!(statuses.len(), 3);
+        assert_eq!(statuses[0].name, "ci/build");
+        assert_eq!(statuses[0].status, CheckStatus::Passed);
+        assert_eq!(
+            statuses[0].url.as_deref(),
+            Some("https://ci.example/build/1")
+        );
+        assert_eq!(statuses[0].conclusion.as_deref(), Some("success"));
+        assert_eq!(statuses[1].status, CheckStatus::Pending);
+        assert_eq!(statuses[1].url, None);
+        assert_eq!(statuses[2].status, CheckStatus::Failed);
+        assert_eq!(statuses[2].url, None);
+    }
+
+    #[test]
+    fn parse_head_ref_oid_pulls_value() {
+        let sha = parse_head_ref_oid(r#"{"headRefOid":"abc123"}"#).unwrap();
+        assert_eq!(sha, "abc123");
     }
 
     #[test]

--- a/crates/plugins/scm-github/tests/fixtures/commit_statuses_only.json
+++ b/crates/plugins/scm-github/tests/fixtures/commit_statuses_only.json
@@ -1,0 +1,25 @@
+{
+  "state": "pending",
+  "statuses": [
+    {
+      "context": "ci/build",
+      "state": "success",
+      "target_url": "https://ci.example/build/1",
+      "description": "build ok"
+    },
+    {
+      "context": "ci/test",
+      "state": "pending",
+      "target_url": null,
+      "description": "tests running"
+    },
+    {
+      "context": "ci/lint",
+      "state": "failure",
+      "target_url": "",
+      "description": "lint failed"
+    }
+  ],
+  "sha": "abc123",
+  "total_count": 3
+}

--- a/crates/plugins/scm-github/tests/fixtures/merge_error_branch_protection.txt
+++ b/crates/plugins/scm-github/tests/fixtures/merge_error_branch_protection.txt
@@ -1,0 +1,1 @@
+gh pr merge 42 --repo acme/widgets --merge --delete-branch failed: GraphQL: Protected branch update failed for refs/heads/main. (base branch policy)

--- a/crates/plugins/scm-github/tests/fixtures/mergeability_blocked.json
+++ b/crates/plugins/scm-github/tests/fixtures/mergeability_blocked.json
@@ -1,0 +1,6 @@
+{
+  "mergeable": "MERGEABLE",
+  "reviewDecision": "APPROVED",
+  "mergeStateStatus": "BLOCKED",
+  "isDraft": false
+}


### PR DESCRIPTION
## Summary
- Improve PR readiness by falling back to GitHub commit statuses when `gh pr checks` reports no check runs.
- Make auto-merge honor a per-reaction `merge_method` override (merge/squash/rebase) instead of always using the plugin default.
- Provide more actionable merge blockers and normalize common branch-protection / merge-method failure messages.

## Tests
- `cargo test -p ao-plugin-scm-github`

## Notes
- Added fixture-based unit tests covering statuses-only repos, branch-protection blockers formatting, and merge failure reason normalization.

Closes #28

Made with [Cursor](https://cursor.com)