### PR TITLE
feat(config): validate ao-rs.yaml (issue #26)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,6 +133,7 @@ dependencies = [
  "async-trait",
  "libc",
  "serde",
+ "serde_ignored",
  "serde_json",
  "serde_yaml",
  "thiserror 1.0.69",
@@ -4058,6 +4059,16 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 2.0.117",
+]
+
+[[package]]
+name = "serde_ignored"
+version = "0.1.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115dffd5f3853e06e746965a20dcbae6ee747ae30b543d91b0e089668bb07798"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,6 +40,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"
+serde_ignored = "0.1"
 thiserror = "1"
 async-trait = "0.1"
 tracing = "0.1"

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -16,12 +16,12 @@
 //! it twice concurrently fails fast instead of racing two polling loops.
 
 use ao_core::{
-    build_prompt, default_agent_rules, default_orchestrator_rules, detect_git_repo, generate_config,
-    install_skills, now_ms, paths, restore_session, ActivityState, Agent, AgentConfig, AoConfig,
-    CiStatus, RoleAgentConfig,
-    LifecycleManager, LockError, MergeReadiness, NotificationRouting, NotifierRegistry,
-    OrchestratorEvent, PidFile, PrState, PullRequest, ReactionEngine, ReviewDecision, Runtime, Scm,
-    Session, SessionId, SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
+    build_prompt, default_agent_rules, default_orchestrator_rules, detect_git_repo,
+    generate_config, install_skills, now_ms, paths, restore_session, ActivityState, Agent,
+    AgentConfig, AoConfig, CiStatus, ConfigWarning, LifecycleManager, LoadedConfig, LockError,
+    MergeReadiness, NotificationRouting, NotifierRegistry, OrchestratorEvent, PidFile, PrState,
+    PullRequest, ReactionEngine, ReviewDecision, RoleAgentConfig, Runtime, Scm, Session, SessionId,
+    SessionManager, SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
 use ao_plugin_agent_aider::AiderAgent;
 use ao_plugin_agent_claude_code::ClaudeCodeAgent;
@@ -760,8 +760,12 @@ async fn start(
 
     if config_path.exists() {
         // Load existing config and print summary.
-        let mut config = AoConfig::load_from(&config_path)
+        let LoadedConfig {
+            mut config,
+            warnings,
+        } = AoConfig::load_from_with_warnings(&config_path)
             .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+        print_config_warnings(&config_path, &warnings);
 
         // Backfill newly-added orchestrator fields so `ao-rs start` upgrades older configs.
         let mut changed = false;
@@ -806,8 +810,12 @@ async fn start(
             // the standard cursor setup. After migration we keep project-level overrides only
             // when they are truly custom.
             if let Some(defaults) = config.defaults.as_ref() {
-                let default_orch_agent = defaults.orchestrator.as_ref().and_then(|o| o.agent.as_deref());
-                let default_worker_agent = defaults.worker.as_ref().and_then(|w| w.agent.as_deref());
+                let default_orch_agent = defaults
+                    .orchestrator
+                    .as_ref()
+                    .and_then(|o| o.agent.as_deref());
+                let default_worker_agent =
+                    defaults.worker.as_ref().and_then(|w| w.agent.as_deref());
 
                 let is_default_orch = project
                     .orchestrator
@@ -1302,6 +1310,24 @@ fn shell_escape_single_quotes(s: &str) -> String {
     format!("'{escaped}'")
 }
 
+fn print_config_warnings(config_path: &std::path::Path, warnings: &[ConfigWarning]) {
+    if warnings.is_empty() {
+        return;
+    }
+    eprintln!(
+        "warning: {}: {} unsupported field(s) found (they will be ignored):",
+        config_path.display(),
+        warnings.len()
+    );
+    for w in warnings {
+        if w.field.is_empty() {
+            eprintln!("  - {}", w.message);
+        } else {
+            eprintln!("  - {}: {}", w.field, w.message);
+        }
+    }
+}
+
 async fn tmux_send_keys_literal_no_enter(handle: &str, text: &str) {
     // Best-effort: used for UI keystrokes (Cursor trust prompt) where sending
     // Enter can be harmful. Ignore failures so spawn doesn't fail just because
@@ -1334,8 +1360,12 @@ async fn spawn(
     //
     // Missing config is silently empty; a broken YAML is a loud error.
     let config_path = AoConfig::path_in(&repo_path);
-    let ao_config = AoConfig::load_from_or_default(&config_path)
+    let LoadedConfig {
+        config: ao_config,
+        warnings,
+    } = AoConfig::load_from_or_default_with_warnings(&config_path)
         .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    print_config_warnings(&config_path, &warnings);
 
     // Resolve project id:
     // - explicit `--project` wins
@@ -2009,8 +2039,10 @@ async fn watch(interval: Duration) -> Result<(), Box<dyn std::error::Error>> {
     // Load config from the local project directory (ao-rs.yaml).
     // Missing config is silently empty; a broken YAML is a loud error.
     let config_path = AoConfig::local_path();
-    let config = AoConfig::load_from_or_default(&config_path)
-        .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    let LoadedConfig { config, warnings } =
+        AoConfig::load_from_or_default_with_warnings(&config_path)
+            .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    print_config_warnings(&config_path, &warnings);
     if !config.reactions.is_empty() {
         println!(
             "→ loaded {} reaction(s) from {}",
@@ -2193,8 +2225,10 @@ async fn dashboard(port: u16, interval: Duration) -> Result<(), Box<dyn std::err
     let scm: Arc<dyn Scm> = Arc::new(AutoScm::new());
 
     let config_path = AoConfig::local_path();
-    let config = AoConfig::load_from_or_default(&config_path)
-        .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    let LoadedConfig { config, warnings } =
+        AoConfig::load_from_or_default_with_warnings(&config_path)
+            .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    print_config_warnings(&config_path, &warnings);
     let runtime_name = config
         .defaults
         .as_ref()
@@ -2500,8 +2534,11 @@ async fn doctor() -> Result<(), Box<dyn std::error::Error>> {
 
     // 3. Config file loads without error.
     let config_path = AoConfig::local_path();
-    match AoConfig::load_from_or_default(&config_path) {
-        Ok(cfg) => {
+    match AoConfig::load_from_or_default_with_warnings(&config_path) {
+        Ok(LoadedConfig {
+            config: cfg,
+            warnings,
+        }) => {
             let projects = cfg.projects.len();
             let reactions = cfg.reactions.len();
             if config_path.exists() {
@@ -2510,6 +2547,7 @@ async fn doctor() -> Result<(), Box<dyn std::error::Error>> {
                     "config",
                     config_path.display()
                 );
+                print_config_warnings(&config_path, &warnings);
             } else {
                 println!(
                     "  WARN  {:<10} no config file (run `ao-rs start`)",
@@ -3092,7 +3130,9 @@ mod tests {
         let config_path = AoConfig::path_in(&repo_dir);
         cfg.save_to(&config_path).unwrap();
 
-        let loaded = AoConfig::load_from_or_default(&config_path).unwrap();
+        let loaded = AoConfig::load_from_or_default_with_warnings(&config_path)
+            .unwrap()
+            .config;
         let project_id = resolve_project_id(&repo_dir, &loaded, None);
         assert_eq!(project_id, "ao-rs");
 

--- a/crates/ao-core/Cargo.toml
+++ b/crates/ao-core/Cargo.toml
@@ -10,6 +10,7 @@ tokio = { workspace = true }
 serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
+serde_ignored = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ao-core/src/activity_log.rs
+++ b/crates/ao-core/src/activity_log.rs
@@ -5,8 +5,8 @@
 
 use crate::types::ActivityState;
 use serde::{Deserialize, Serialize};
-use std::path::{Path, PathBuf};
 use std::io::Write;
+use std::path::{Path, PathBuf};
 
 pub const ACTIVITY_INPUT_STALENESS_SECS: u64 = 5 * 60;
 
@@ -71,7 +71,7 @@ pub fn read_last_activity_entry(
     }
 
     let mut last_ok: Option<ActivityLogEntry> = None;
-    for line in r.lines().flatten() {
+    for line in r.lines().map_while(std::result::Result::ok) {
         if line.trim().is_empty() {
             continue;
         }
@@ -88,7 +88,10 @@ pub fn check_actionable_state(
     now: std::time::SystemTime,
 ) -> Option<ActivityState> {
     let e = entry?;
-    if !matches!(e.state, ActivityState::WaitingInput | ActivityState::Blocked) {
+    if !matches!(
+        e.state,
+        ActivityState::WaitingInput | ActivityState::Blocked
+    ) {
         return None;
     }
     let ts = chrono_like_parse(&e.ts)?;
@@ -118,7 +121,10 @@ mod tests {
             source: "terminal".into(),
             trigger: Some("prompt".into()),
         };
-        assert_eq!(check_actionable_state(Some(&fresh), now), Some(ActivityState::WaitingInput));
+        assert_eq!(
+            check_actionable_state(Some(&fresh), now),
+            Some(ActivityState::WaitingInput)
+        );
 
         let stale = ActivityLogEntry {
             ts: ((1_000_000u64 - (ACTIVITY_INPUT_STALENESS_SECS + 1)) * 1000).to_string(),
@@ -129,4 +135,3 @@ mod tests {
         assert_eq!(check_actionable_state(Some(&stale), now), None);
     }
 }
-

--- a/crates/ao-core/src/config.rs
+++ b/crates/ao-core/src/config.rs
@@ -13,10 +13,191 @@
 use crate::{
     error::{AoError, Result},
     notifier::NotificationRouting,
+    reaction_engine::parse_duration,
     reactions::{EscalateAfter, EventPriority, ReactionAction, ReactionConfig},
 };
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path};
+
+// ---------------------------------------------------------------------------
+// Diagnostics + validation
+// ---------------------------------------------------------------------------
+
+/// Non-fatal config issues (unknown fields, questionable values).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConfigWarning {
+    /// Human-readable field path (e.g. `"projects.my-app.defaultBranch"`).
+    pub field: String,
+    /// Actionable message.
+    pub message: String,
+}
+
+/// Result of loading a config file: parsed config + any warnings.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct LoadedConfig {
+    pub config: AoConfig,
+    pub warnings: Vec<ConfigWarning>,
+}
+
+fn yaml_field_path(path: &serde_ignored::Path) -> String {
+    // serde_ignored uses segments like `.field`, `[0]`, etc.
+    // We prefer a dot-separated path for CLI output.
+    let s = path.to_string();
+    s.trim_start_matches('.').to_string()
+}
+
+fn supported_reaction_keys() -> [&'static str; 9] {
+    [
+        "ci-failed",
+        "changes-requested",
+        "merge-conflicts",
+        "approved-and-green",
+        "agent-idle",
+        "agent-stuck",
+        "agent-needs-input",
+        "agent-exited",
+        "all-complete",
+    ]
+}
+
+fn supported_notifier_names() -> [&'static str; 5] {
+    // These are the notifier plugin names ao-cli may register.
+    // Some are conditional on env vars (ntfy/discord/slack), but the *names*
+    // are still supported; validation should catch typos.
+    ["stdout", "desktop", "ntfy", "discord", "slack"]
+}
+
+impl AoConfig {
+    /// Validate config semantics (beyond YAML parsing).
+    ///
+    /// Returns `Ok(())` when valid, otherwise a `AoError::Config` with an
+    /// actionable, field-scoped message including the config file path.
+    pub fn validate(&self, config_path: &Path) -> Result<()> {
+        // ---- reactions.* keys ----
+        let known: std::collections::HashSet<&'static str> =
+            supported_reaction_keys().into_iter().collect();
+        for key in self.reactions.keys() {
+            if !known.contains(key.as_str()) {
+                let mut keys: Vec<&str> = known.iter().copied().collect();
+                keys.sort();
+                return Err(AoError::Config(format!(
+                    "{}: unknown reaction key `reactions.{}` (supported: {})",
+                    config_path.display(),
+                    key,
+                    keys.join(", ")
+                )));
+            }
+        }
+
+        // ---- duration parsing (reactions.*.threshold, reactions.*.escalate_after) ----
+        for (reaction_key, cfg) in &self.reactions {
+            if let Some(raw) = cfg.threshold.as_deref() {
+                if parse_duration(raw).is_none() {
+                    return Err(AoError::Config(format!(
+                        "{}: invalid duration at `reactions.{}.threshold`: {:?} (expected like \"10s\", \"5m\", \"2h\")",
+                        config_path.display(),
+                        reaction_key,
+                        raw
+                    )));
+                }
+            }
+            if let Some(EscalateAfter::Duration(raw)) = cfg.escalate_after.as_ref() {
+                if parse_duration(raw).is_none() {
+                    return Err(AoError::Config(format!(
+                        "{}: invalid duration at `reactions.{}.escalate_after`: {:?} (expected like \"10s\", \"5m\", \"2h\")",
+                        config_path.display(),
+                        reaction_key,
+                        raw
+                    )));
+                }
+            }
+        }
+
+        // ---- notifier names (defaults.notifiers, notification_routing) ----
+        let supported_notifiers: std::collections::HashSet<&'static str> =
+            supported_notifier_names().into_iter().collect();
+
+        if let Some(defaults) = self.defaults.as_ref() {
+            for name in &defaults.notifiers {
+                if !supported_notifiers.contains(name.as_str()) {
+                    return Err(AoError::Config(format!(
+                        "{}: unknown notifier name at `defaults.notifiers`: {:?} (supported: {})",
+                        config_path.display(),
+                        name,
+                        supported_notifier_names().join(", ")
+                    )));
+                }
+            }
+        }
+
+        // NotificationRouting parsing is already strict for priority keys
+        // (serde rejects unknown priorities). Here we validate notifier names.
+        for &priority in &[
+            EventPriority::Urgent,
+            EventPriority::Action,
+            EventPriority::Warning,
+            EventPriority::Info,
+        ] {
+            if let Some(names) = self.notification_routing.names_for(priority) {
+                for name in names {
+                    if !supported_notifiers.contains(name.as_str()) {
+                        return Err(AoError::Config(format!(
+                            "{}: unknown notifier name at `notification_routing.{}[]`: {:?} (supported: {})",
+                            config_path.display(),
+                            priority.as_str(),
+                            name,
+                            supported_notifier_names().join(", ")
+                        )));
+                    }
+                }
+            }
+        }
+
+        // ---- projects.* repo/path constraints ----
+        for (project_id, project) in &self.projects {
+            // repo must be owner/repo (one slash, neither side empty).
+            let parts: Vec<&str> = project.repo.split('/').collect();
+            let ok = parts.len() == 2 && !parts[0].trim().is_empty() && !parts[1].trim().is_empty();
+            if !ok {
+                return Err(AoError::Config(format!(
+                    "{}: invalid repo slug at `projects.{}.repo`: {:?} (expected \"owner/repo\")",
+                    config_path.display(),
+                    project_id,
+                    project.repo
+                )));
+            }
+
+            // path must be absolute; we intentionally reject `~` because it
+            // won't canonicalize reliably in non-shell contexts.
+            let p = project.path.trim();
+            if p.is_empty() {
+                return Err(AoError::Config(format!(
+                    "{}: empty path at `projects.{}.path`",
+                    config_path.display(),
+                    project_id
+                )));
+            }
+            if p.starts_with('~') {
+                return Err(AoError::Config(format!(
+                    "{}: `projects.{}.path` must be an absolute path (found {:?}; `~` is not supported here)",
+                    config_path.display(),
+                    project_id,
+                    project.path
+                )));
+            }
+            if !p.starts_with('/') {
+                return Err(AoError::Config(format!(
+                    "{}: `projects.{}.path` must be an absolute path (found {:?})",
+                    config_path.display(),
+                    project_id,
+                    project.path
+                )));
+            }
+        }
+
+        Ok(())
+    }
+}
 
 // --- Serde default helpers ---
 
@@ -417,6 +598,41 @@ pub struct AoConfig {
 }
 
 impl AoConfig {
+    /// Read and parse a config file at an explicit path, collecting warnings
+    /// for unknown fields and validating the supported subset.
+    pub fn load_from_with_warnings(path: &Path) -> Result<LoadedConfig> {
+        let text = std::fs::read_to_string(path)?;
+
+        let mut warnings: Vec<ConfigWarning> = Vec::new();
+        let deserializer = serde_yaml::Deserializer::from_str(&text);
+        let cfg: AoConfig = serde_ignored::deserialize(deserializer, |p| {
+            warnings.push(ConfigWarning {
+                field: yaml_field_path(&p),
+                message: "unknown field; this key is not supported and will be ignored".into(),
+            });
+        })
+        .map_err(|e| AoError::Yaml(e.to_string()))?;
+
+        cfg.validate(path)?;
+        Ok(LoadedConfig {
+            config: cfg,
+            warnings,
+        })
+    }
+
+    /// Read a config file at an explicit path, or return an empty config
+    /// if the file doesn't exist, collecting warnings and validating.
+    pub fn load_from_or_default_with_warnings(path: &Path) -> Result<LoadedConfig> {
+        match std::fs::read_to_string(path) {
+            Ok(_) => Self::load_from_with_warnings(path),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => Ok(LoadedConfig {
+                config: Self::default(),
+                warnings: Vec::new(),
+            }),
+            Err(e) => Err(AoError::Io(e)),
+        }
+    }
+
     /// Read and parse a config file at an explicit path.
     ///
     /// Distinct from `load_default` because tests should never touch
@@ -949,6 +1165,103 @@ reactions:
         let path = unique_temp_file("invalid");
         std::fs::write(&path, "reactions: [not-a-map]\n").unwrap();
         assert!(AoConfig::load_from(&path).is_err());
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn load_from_with_warnings_reports_unknown_fields() {
+        let path = unique_temp_file("unknown-fields");
+        std::fs::write(
+            &path,
+            r#"
+port: 3000
+unknownTopLevel: 123
+defaults:
+  runtime: tmux
+  unknownDefaultsKey: true
+"#,
+        )
+        .unwrap();
+        let loaded = AoConfig::load_from_with_warnings(&path).unwrap();
+        assert_eq!(loaded.config.port, 3000);
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .any(|w| w.field.contains("unknownTopLevel")),
+            "expected unknownTopLevel warning, got {:?}",
+            loaded.warnings
+        );
+        assert!(
+            loaded
+                .warnings
+                .iter()
+                .any(|w| w.field.contains("defaults") && w.field.contains("unknownDefaultsKey")),
+            "expected defaults.unknownDefaultsKey warning, got {:?}",
+            loaded.warnings
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn validate_rejects_unknown_reaction_key() {
+        let path = unique_temp_file("bad-reaction-key");
+        std::fs::write(
+            &path,
+            r#"
+reactions:
+  ci-failed:
+    action: notify
+  ci-broke:
+    action: notify
+"#,
+        )
+        .unwrap();
+        let err = AoConfig::load_from_with_warnings(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown reaction key"), "got: {msg}");
+        assert!(msg.contains("reactions.ci-broke"), "got: {msg}");
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn validate_rejects_bad_duration() {
+        let path = unique_temp_file("bad-duration");
+        std::fs::write(
+            &path,
+            r#"
+reactions:
+  agent-stuck:
+    action: notify
+    threshold: "1m30s"
+"#,
+        )
+        .unwrap();
+        let err = AoConfig::load_from_with_warnings(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("invalid duration"), "got: {msg}");
+        assert!(
+            msg.contains("reactions.agent-stuck.threshold"),
+            "got: {msg}"
+        );
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn validate_rejects_unknown_notifier_name_in_routing() {
+        let path = unique_temp_file("bad-notifier");
+        std::fs::write(
+            &path,
+            r#"
+notification-routing:
+  urgent: [stdout, slackk]
+"#,
+        )
+        .unwrap();
+        let err = AoConfig::load_from_with_warnings(&path).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("unknown notifier name"), "got: {msg}");
+        assert!(msg.contains("slackk"), "got: {msg}");
         let _ = std::fs::remove_file(&path);
     }
 

--- a/crates/ao-core/src/error.rs
+++ b/crates/ao-core/src/error.rs
@@ -25,6 +25,9 @@ pub enum AoError {
     #[error("yaml: {0}")]
     Yaml(String),
 
+    #[error("config: {0}")]
+    Config(String),
+
     #[error("{0}")]
     Other(String),
 }

--- a/crates/ao-core/src/lib.rs
+++ b/crates/ao-core/src/lib.rs
@@ -8,6 +8,7 @@ pub mod lockfile;
 pub mod notifier;
 pub mod notifier_resolution;
 pub mod opencode_session_id;
+pub mod orchestrator_prompt;
 pub mod parity_config_validation;
 pub mod parity_feedback_tools;
 pub mod parity_metadata;
@@ -15,7 +16,6 @@ pub mod parity_observability;
 pub mod parity_plugin_registry;
 pub mod parity_session_strategy;
 pub mod parity_utils;
-pub mod orchestrator_prompt;
 pub mod paths;
 pub mod prompt_builder;
 pub mod reaction_engine;
@@ -29,8 +29,8 @@ pub mod types;
 
 pub use config::{
     default_agent_rules, default_orchestrator_rules, default_reactions, default_routing,
-    detect_git_repo, generate_config, install_skills, AgentConfig, AoConfig, DefaultsConfig,
-    ProjectConfig, RoleAgentConfig,
+    detect_git_repo, generate_config, install_skills, AgentConfig, AoConfig, ConfigWarning,
+    DefaultsConfig, LoadedConfig, ProjectConfig, RoleAgentConfig,
 };
 pub use error::{AoError, Result};
 pub use events::{OrchestratorEvent, TerminationReason};

--- a/crates/ao-core/src/notifier_resolution.rs
+++ b/crates/ao-core/src/notifier_resolution.rs
@@ -25,4 +25,3 @@ pub fn resolve_notifier_target(
         plugin_name,
     }
 }
-

--- a/crates/ao-core/src/opencode_session_id.rs
+++ b/crates/ao-core/src/opencode_session_id.rs
@@ -16,4 +16,3 @@ pub fn as_valid_opencode_session_id(value: impl AsRef<str>) -> Option<String> {
         None
     }
 }
-

--- a/crates/ao-core/src/orchestrator_prompt.rs
+++ b/crates/ao-core/src/orchestrator_prompt.rs
@@ -147,4 +147,3 @@ mod tests {
         assert!(prompt.contains("tmux send-keys"));
     }
 }
-

--- a/crates/ao-core/src/parity_config_validation.rs
+++ b/crates/ao-core/src/parity_config_validation.rs
@@ -19,7 +19,10 @@ pub fn generate_session_prefix(project_id: &str) -> String {
         return project_id.to_lowercase();
     }
 
-    let uppercase: Vec<char> = project_id.chars().filter(|c| c.is_ascii_uppercase()).collect();
+    let uppercase: Vec<char> = project_id
+        .chars()
+        .filter(|c| c.is_ascii_uppercase())
+        .collect();
     if uppercase.len() > 1 {
         return uppercase.into_iter().collect::<String>().to_lowercase();
     }
@@ -34,7 +37,11 @@ pub fn generate_session_prefix(project_id: &str) -> String {
             .to_lowercase();
     }
 
-    project_id.chars().take(3).collect::<String>().to_lowercase()
+    project_id
+        .chars()
+        .take(3)
+        .collect::<String>()
+        .to_lowercase()
 }
 
 pub fn validate_project_uniqueness(config: &TsOrchestratorConfig) -> Result<(), String> {
@@ -81,7 +88,10 @@ pub fn validate_project_uniqueness(config: &TsOrchestratorConfig) -> Result<(), 
             .unwrap_or_else(|| generate_session_prefix(&basename));
 
         if prefixes.contains(&prefix) {
-            let first = prefix_to_project_key.get(&prefix).cloned().unwrap_or_default();
+            let first = prefix_to_project_key
+                .get(&prefix)
+                .cloned()
+                .unwrap_or_default();
             let first_path = config
                 .projects
                 .get(&first)
@@ -99,4 +109,3 @@ pub fn validate_project_uniqueness(config: &TsOrchestratorConfig) -> Result<(), 
 
     Ok(())
 }
-

--- a/crates/ao-core/src/parity_feedback_tools.rs
+++ b/crates/ao-core/src/parity_feedback_tools.rs
@@ -115,7 +115,11 @@ impl FeedbackReportStore {
         validate_feedback_tool_input(tool, &input)?;
         let created_at = iso_now();
         let dedupe_key = generate_feedback_dedupe_key(tool, &input);
-        let id = format!("report_{}_{}", created_at.replace([':', '.'], "-"), short_id());
+        let id = format!(
+            "report_{}_{}",
+            created_at.replace([':', '.'], "-"),
+            short_id()
+        );
         let report = PersistedFeedbackReport {
             id: id.clone(),
             tool: tool.to_string(),
@@ -161,11 +165,8 @@ fn parse_report_file(content: &str) -> Result<PersistedFeedbackReport, String> {
     let mut evidence: Vec<(usize, String)> = raw
         .iter()
         .filter_map(|(k, v)| {
-            if let Some(idx) = k.strip_prefix("evidence.") {
-                Some((idx.parse::<usize>().unwrap_or(0), v.clone()))
-            } else {
-                None
-            }
+            k.strip_prefix("evidence.")
+                .map(|idx| (idx.parse::<usize>().unwrap_or(0), v.clone()))
         })
         .collect();
     evidence.sort_by_key(|(i, _)| *i);
@@ -208,4 +209,3 @@ fn short_id() -> String {
         .subsec_nanos();
     format!("{:08x}", n)
 }
-

--- a/crates/ao-core/src/parity_metadata.rs
+++ b/crates/ao-core/src/parity_metadata.rs
@@ -27,7 +27,9 @@ pub fn parse_key_value_content(content: &str) -> HashMap<String, String> {
         if trimmed.is_empty() || trimmed.starts_with('#') {
             continue;
         }
-        let Some(eq) = trimmed.find('=') else { continue };
+        let Some(eq) = trimmed.find('=') else {
+            continue;
+        };
         let key = trimmed[..eq].trim();
         let val = trimmed[eq + 1..].trim();
         if !key.is_empty() {
@@ -145,7 +147,10 @@ pub fn read_metadata(
     Ok(Some(TsSessionMetadata {
         worktree: raw.get("worktree").cloned().unwrap_or_default(),
         branch: raw.get("branch").cloned().unwrap_or_default(),
-        status: raw.get("status").cloned().unwrap_or_else(|| "unknown".into()),
+        status: raw
+            .get("status")
+            .cloned()
+            .unwrap_or_else(|| "unknown".into()),
         issue: raw.get("issue").cloned(),
         pr: raw.get("pr").cloned(),
         pr_auto_detect: raw.get("prAutoDetect").cloned(),
@@ -188,8 +193,11 @@ pub fn delete_metadata(data_dir: &Path, session_id: &str, archive: bool) -> Resu
         fs::create_dir_all(&archive_dir).map_err(|e| e.to_string())?;
         let ts = chrono_like_ts();
         let archive_path = archive_dir.join(format!("{session_id}_{ts}"));
-        fs::write(&archive_path, fs::read_to_string(&path).map_err(|e| e.to_string())?)
-            .map_err(|e| e.to_string())?;
+        fs::write(
+            &archive_path,
+            fs::read_to_string(&path).map_err(|e| e.to_string())?,
+        )
+        .map_err(|e| e.to_string())?;
     }
     fs::remove_file(&path).map_err(|e| e.to_string())
 }
@@ -260,4 +268,3 @@ pub fn list_metadata(data_dir: &Path) -> Result<Vec<String>, String> {
     out.sort();
     Ok(out)
 }
-

--- a/crates/ao-core/src/parity_observability.rs
+++ b/crates/ao-core/src/parity_observability.rs
@@ -163,7 +163,11 @@ impl ProjectObserver {
             .join(".ao-observability")
             .join("processes");
         let _ = std::fs::create_dir_all(&base);
-        base.join(format!("{}-{}.json", sanitize_component(&self.component), std::process::id()))
+        base.join(format!(
+            "{}-{}.json",
+            sanitize_component(&self.component),
+            std::process::id()
+        ))
     }
 
     fn read_snapshot(&self) -> ProcessSnapshot {
@@ -196,8 +200,10 @@ pub fn read_observability_summary(config: TsObservabilityConfig) -> Observabilit
         .unwrap_or(Path::new("."))
         .join(".ao-observability")
         .join("processes");
-    let mut summary = ObservabilitySummary::default();
-    summary.overall_status = "ok".into();
+    let mut summary = ObservabilitySummary {
+        overall_status: "ok".into(),
+        ..Default::default()
+    };
     let Ok(rd) = std::fs::read_dir(processes_dir) else {
         return summary;
     };
@@ -275,8 +281,13 @@ fn status_priority(s: &str) -> u8 {
 fn sanitize_component(component: &str) -> String {
     let cleaned = component
         .chars()
-        .map(|c| if c.is_ascii_alphanumeric() || c == '_' || c == '-' { c } else { '-' })
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '_' || c == '-' {
+                c
+            } else {
+                '-'
+            }
+        })
         .collect::<String>();
     cleaned.trim_matches('-').to_string()
 }
-

--- a/crates/ao-core/src/parity_plugin_registry.rs
+++ b/crates/ao-core/src/parity_plugin_registry.rs
@@ -58,4 +58,3 @@ impl PluginRegistry {
             .unwrap_or_default()
     }
 }
-

--- a/crates/ao-core/src/parity_session_strategy.rs
+++ b/crates/ao-core/src/parity_session_strategy.rs
@@ -33,7 +33,8 @@ pub fn decide_existing_session_action(
         OrchestratorSessionStrategy::Ignore => ExistingSessionAction::Abort,
         OrchestratorSessionStrategy::DeleteNew => ExistingSessionAction::Abort,
         OrchestratorSessionStrategy::IgnoreNew => ExistingSessionAction::Abort,
-        OrchestratorSessionStrategy::KillPrevious => ExistingSessionAction::DeleteExistingAndReuseName,
+        OrchestratorSessionStrategy::KillPrevious => {
+            ExistingSessionAction::DeleteExistingAndReuseName
+        }
     }
 }
-

--- a/crates/ao-core/src/parity_utils.rs
+++ b/crates/ao-core/src/parity_utils.rs
@@ -140,4 +140,3 @@ pub fn read_last_jsonl_entry(path: &Path) -> Option<LastJsonlEntry> {
     }
     None
 }
-

--- a/crates/ao-core/src/restore.rs
+++ b/crates/ao-core/src/restore.rs
@@ -310,7 +310,8 @@ mod tests {
 
         let manager = SessionManager::new(base.clone());
         // Persist a terminal session that somehow lost its runtime_handle.
-        let mut s = persist_session(&manager, "sess-nohandle", SessionStatus::Terminated, &ws).await;
+        let mut s =
+            persist_session(&manager, "sess-nohandle", SessionStatus::Terminated, &ws).await;
         s.runtime_handle = None;
         manager.save(&s).await.unwrap();
 

--- a/crates/ao-core/tests/parity_config_validation_parity_test.rs
+++ b/crates/ao-core/tests/parity_config_validation_parity_test.rs
@@ -43,7 +43,10 @@ fn error_message_shows_conflicting_paths() {
 
 #[test]
 fn accepts_unique_basenames() {
-    let c = cfg(vec![("proj1", "/repos/integrator", None), ("proj2", "/repos/backend", None)]);
+    let c = cfg(vec![
+        ("proj1", "/repos/integrator", None),
+        ("proj2", "/repos/backend", None),
+    ]);
     validate_project_uniqueness(&c).unwrap();
 }
 
@@ -69,4 +72,3 @@ fn rejects_duplicate_auto_generated_prefixes() {
     assert!(err.contains("Duplicate session prefix"));
     assert!(err.contains("\"int\""));
 }
-

--- a/crates/ao-core/tests/parity_metadata_parity_test.rs
+++ b/crates/ao-core/tests/parity_metadata_parity_test.rs
@@ -80,7 +80,10 @@ fn read_metadata_raw_reads_arbitrary_pairs() {
     )
     .unwrap();
     let raw = read_metadata_raw(&dir, "raw-1").unwrap().unwrap();
-    assert_eq!(raw.get("custom_key").map(|s| s.as_str()), Some("custom_value"));
+    assert_eq!(
+        raw.get("custom_key").map(|s| s.as_str()),
+        Some("custom_value")
+    );
 }
 
 #[test]
@@ -127,4 +130,3 @@ fn list_metadata_lists_only_session_files() {
     let list = list_metadata(&dir).unwrap();
     assert_eq!(list, vec!["a-1".to_string(), "b-2".to_string()]);
 }
-

--- a/crates/ao-core/tests/parity_observability_feedback_parity_test.rs
+++ b/crates/ao-core/tests/parity_observability_feedback_parity_test.rs
@@ -14,7 +14,10 @@ fn feedback_dedupe_key_is_stable_for_whitespace_case_and_evidence_order() {
     let payload = FeedbackInput {
         title: "Login failure for SSO users".into(),
         body: "Users with Google SSO are looped back to login.".into(),
-        evidence: vec!["trace_id=abc123".into(), "Video capture from session".into()],
+        evidence: vec![
+            "trace_id=abc123".into(),
+            "Video capture from session".into(),
+        ],
         session: "ao-22".into(),
         source: "agent".into(),
         confidence: 0.82,
@@ -24,7 +27,10 @@ fn feedback_dedupe_key_is_stable_for_whitespace_case_and_evidence_order() {
         &FeedbackInput {
             title: " Login   failure FOR SSO users ".into(),
             body: payload.body.clone(),
-            evidence: vec!["Video capture from session".into(), "trace_id=abc123".into()],
+            evidence: vec![
+                "Video capture from session".into(),
+                "trace_id=abc123".into(),
+            ],
             session: payload.session.clone(),
             source: "Agent".into(),
             confidence: payload.confidence,
@@ -109,7 +115,10 @@ fn observability_records_counters_traces_sessions_and_health() {
     assert_eq!(project.metrics.get("spawn").unwrap().total, 1);
     assert_eq!(project.metrics.get("spawn").unwrap().success, 1);
     assert_eq!(project.metrics.get("send").unwrap().failure, 1);
-    assert_eq!(project.sessions.get("app-1").unwrap().operation, "session.send");
+    assert_eq!(
+        project.sessions.get("app-1").unwrap().operation,
+        "session.send"
+    );
     assert!(project
         .recent_traces
         .iter()
@@ -120,4 +129,3 @@ fn observability_records_counters_traces_sessions_and_health() {
     );
     assert_eq!(summary.overall_status, "warn");
 }
-

--- a/crates/ao-core/tests/parity_plugin_registry_parity_test.rs
+++ b/crates/ao-core/tests/parity_plugin_registry_parity_test.rs
@@ -31,7 +31,9 @@ fn register_and_get() {
 #[test]
 fn get_returns_none_for_unregistered() {
     let r = PluginRegistry::new();
-    assert!(r.get(&PluginSlot("runtime".into()), "nonexistent").is_none());
+    assert!(r
+        .get(&PluginSlot("runtime".into()), "nonexistent")
+        .is_none());
 }
 
 #[test]
@@ -49,7 +51,10 @@ fn passes_config_to_create() {
 fn overwrites_previously_registered() {
     let mut r = PluginRegistry::new();
     r.register(make_plugin("runtime", "tmux"), None);
-    r.register(make_plugin("runtime", "tmux"), Some(serde_json::json!({"x": 1})));
+    r.register(
+        make_plugin("runtime", "tmux"),
+        Some(serde_json::json!({"x": 1})),
+    );
     let inst = r.get(&PluginSlot("runtime".into()), "tmux").unwrap();
     assert_eq!(inst.instance["_config"]["x"], 1);
 }
@@ -74,4 +79,3 @@ fn list_plugins_in_slot() {
     runtimes.sort();
     assert_eq!(runtimes, vec!["process".to_string(), "tmux".to_string()]);
 }
-

--- a/crates/ao-core/tests/parity_session_strategy_parity_test.rs
+++ b/crates/ao-core/tests/parity_session_strategy_parity_test.rs
@@ -21,4 +21,3 @@ fn decide_session_action_basic() {
         ExistingSessionAction::IgnoreExistingAndSpawnNew
     );
 }
-

--- a/crates/ao-core/tests/parity_test_utils.rs
+++ b/crates/ao-core/tests/parity_test_utils.rs
@@ -33,4 +33,3 @@ pub fn fake_session(id: &str) -> Session {
         issue_url: None,
     }
 }
-

--- a/crates/ao-core/tests/parity_utils_parity_test.rs
+++ b/crates/ao-core/tests/parity_utils_parity_test.rs
@@ -1,8 +1,8 @@
 use ao_core::notifier_resolution::{resolve_notifier_target, NotifierConfig};
 use ao_core::opencode_session_id::as_valid_opencode_session_id;
 use ao_core::parity_utils::{
-    is_git_branch_name_safe, is_retryable_http_status, normalize_retry_config, read_last_jsonl_entry,
-    RetryConfig,
+    is_git_branch_name_safe, is_retryable_http_status, normalize_retry_config,
+    read_last_jsonl_entry, RetryConfig,
 };
 use std::collections::HashMap;
 
@@ -134,4 +134,3 @@ fn notifier_resolution_alias_or_passthrough() {
     let got = resolve_notifier_target(Some(&map), "desktop");
     assert_eq!(got.plugin_name, "desktop");
 }
-

--- a/crates/ao-core/tests/reaction_engine_issue24_retry_escalation.rs
+++ b/crates/ao-core/tests/reaction_engine_issue24_retry_escalation.rs
@@ -10,7 +10,10 @@ use ao_core::{
     lifecycle::LifecycleManager,
     reaction_engine::ReactionEngine,
     reactions::{EscalateAfter, ReactionAction, ReactionConfig},
-    scm::{CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest, Review, ReviewComment, ReviewDecision},
+    scm::{
+        CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest, Review,
+        ReviewComment, ReviewDecision,
+    },
     session_manager::SessionManager,
     traits::{Agent, Runtime, Scm},
     types::{ActivityState, Session, SessionId, SessionStatus},
@@ -255,8 +258,8 @@ async fn merge_failed_parking_loop_preserves_approved_and_green_tracker() -> Res
     let scm = Arc::new(MergeableButMergeFailsScm::default());
     let agent = Arc::new(ReadyAgent);
 
-    let lifecycle = LifecycleManager::new(sessions.clone(), runtime.clone(), agent)
-        .with_scm(scm.clone());
+    let lifecycle =
+        LifecycleManager::new(sessions.clone(), runtime.clone(), agent).with_scm(scm.clone());
 
     let mut events_rx = lifecycle.subscribe();
 
@@ -294,4 +297,3 @@ async fn merge_failed_parking_loop_preserves_approved_and_green_tracker() -> Res
     let _ = tokio::fs::remove_dir_all(base).await;
     Ok(())
 }
-

--- a/crates/plugins/notifier-slack/src/lib.rs
+++ b/crates/plugins/notifier-slack/src/lib.rs
@@ -230,7 +230,10 @@ mod tests {
     fn color_mapping_covers_all_variants() {
         assert_eq!(attachment_color(EventPriority::Urgent, false), COLOR_RED);
         assert_eq!(attachment_color(EventPriority::Action, false), COLOR_ORANGE);
-        assert_eq!(attachment_color(EventPriority::Warning, false), COLOR_YELLOW);
+        assert_eq!(
+            attachment_color(EventPriority::Warning, false),
+            COLOR_YELLOW
+        );
         assert_eq!(attachment_color(EventPriority::Info, false), COLOR_GREEN);
     }
 
@@ -257,7 +260,10 @@ mod tests {
             json["attachments"][0]["blocks"][0]["text"]["type"],
             "plain_text"
         );
-        assert_eq!(json["attachments"][0]["blocks"][0]["text"]["text"], "CI failed");
+        assert_eq!(
+            json["attachments"][0]["blocks"][0]["text"]["text"],
+            "CI failed"
+        );
 
         assert_eq!(json["attachments"][0]["blocks"][1]["type"], "section");
         assert_eq!(
@@ -285,4 +291,3 @@ mod tests {
         assert_eq!(json["attachments"][0]["color"], COLOR_RED);
     }
 }
-

--- a/crates/plugins/workspace-worktree/tests/integration.rs
+++ b/crates/plugins/workspace-worktree/tests/integration.rs
@@ -116,7 +116,10 @@ async fn destroy_refuses_paths_outside_base_dir() {
         "unexpected error: {msg}"
     );
     assert!(victim.exists(), "victim directory was deleted");
-    assert!(victim.join("sentinel.txt").exists(), "victim contents were deleted");
+    assert!(
+        victim.join("sentinel.txt").exists(),
+        "victim contents were deleted"
+    );
 
     let _ = std::fs::remove_dir_all(&victim_parent);
     let _ = std::fs::remove_dir_all(&base);

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -16,7 +16,7 @@ Not ported, not planned:
 - Web dashboard (Next.js)
 - Plugin marketplace / registry install flow
 - `~/.agent-orchestrator/plugins/` external install store
-- Zod config validation (using `serde_yaml` + `#[serde(default)]`)
+- TS-style Zod config validation (ao-rs uses `serde_yaml` + a supported-subset validator; see `docs/config.md`)
 - Feedback tool contracts (`bug_report`, `improvement_suggestion`)
 - GraphQL batch PR enrichment (uses `gh` CLI per session — fine at N≤30)
 - Terminal plugin slot

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -275,7 +275,7 @@ Scans terminal sessions (killed, terminated, errored, merged, etc.), removes any
 ao-rs doctor
 ```
 
-Checks required tools on PATH (`git`, `gh`, `tmux`, `claude`), GitHub auth (`gh auth status`), config loadability, and sessions dir presence.
+Checks required tools on PATH (`git`, `gh`, `tmux`, `claude`), GitHub auth (`gh auth status`), config loadability + validation (unknown/unsupported fields are warned and ignored), and sessions dir presence.
 
 ## `ao-rs review-check` — forward new PR comments to agents
 

--- a/docs/config.md
+++ b/docs/config.md
@@ -1,0 +1,73 @@
+# ao-rs config (`ao-rs.yaml`)
+
+`ao-rs.yaml` lives in a project directory (discovered by walking up from the current working directory). It controls **defaults**, **projects**, **reactions**, and **notification routing**.
+
+This document defines the **supported subset** and the **validation strategy** for Rust (`ao-rs`). The loader is intentionally strict about *meaningful* mistakes while remaining migration-friendly for TS configs.
+
+## Supported top-level keys
+
+- `port` (number): dashboard port.
+- `terminalPort` / `directTerminalPort` (number, optional)
+- `power.preventIdleSleep` (bool, optional)
+- `defaults` (optional)
+  - `runtime` (string)
+  - `agent` (string)
+  - `workspace` (string)
+  - `tracker` (string)
+  - `notifiers` (list of notifier names; see below)
+  - `orchestrator` / `worker` (optional)
+    - `agent` (string, optional)
+    - `agentConfig` / `agent_config` (optional)
+      - `permissions` (string)
+      - `rules` (string, optional)
+      - `rulesFile` / `rules_file` (string, optional)
+      - `model` (string, optional)
+      - `orchestratorModel` (string, optional)
+      - `opencodeSessionId` (string, optional)
+- `projects` (map, optional)
+  - `<projectId>.repo` (**required**): `"owner/repo"`
+  - `<projectId>.path` (**required**): absolute path (must start with `/`; `~` is rejected)
+  - `<projectId>.defaultBranch` / `default_branch` (string, optional; defaults to `"main"`)
+  - plus the fields present in `ao-rs.yaml.example`
+- `reactions` (map, optional): keyed by reaction key (see below)
+- `notificationRouting` / `notification_routing` / `notification-routing` (map, optional)
+- `notifiers` (map, optional): stored for parity (plugin configs); not all entries are consumed yet.
+- `plugins` (list, optional): stored for parity only.
+
+## Unknown-field policy
+
+- **Unknown fields are warned and ignored.**
+- The warning includes a best-effort **field path** so you can fix typos quickly.
+
+## Validation (errors)
+
+Misconfigurations that can break behavior are rejected with clear errors that include the **file path** and the **field**:
+
+### Reactions
+
+- **Reaction keys** must be from the supported set:
+  - `ci-failed`
+  - `changes-requested`
+  - `merge-conflicts`
+  - `approved-and-green`
+  - `agent-idle`
+  - `agent-stuck`
+  - `agent-needs-input`
+  - `agent-exited`
+  - `all-complete`
+- **Durations** in `reactions.*.threshold` and `reactions.*.escalate_after` must match \(^\d+(s|m|h)$\) (examples: `"10s"`, `"5m"`, `"2h"`).
+
+### Notifiers + routing
+
+- `defaults.notifiers[]` and `notification_routing.<priority>[]` must reference a supported notifier name:
+  - `stdout`, `desktop`, `ntfy`, `discord`, `slack`
+
+### Projects
+
+- `projects.*.repo` must be `"owner/repo"`.
+- `projects.*.path` must be an **absolute path** (must start with `/`; `~` is not supported).
+
+## Tooling
+
+- `ao-rs doctor` reports config load/validation failures as **FAIL**, and unsupported/unknown fields as **warnings**.
+


### PR DESCRIPTION
## Summary
- Add `ao-rs.yaml` supported-subset validation with file+field-scoped errors (unknown reaction key, bad duration, unknown notifier name, invalid project repo/path).
- Warn-and-ignore unknown/unsupported YAML keys (recorded via `serde_ignored`) and surface warnings in `start`, `spawn`, `watch`, `dashboard`, and `doctor`.
- Document config subset + validation policy in `docs/config.md` and update `docs/architecture.md` + `docs/cli-reference.md`.

## Test plan
- `cargo test -p ao-core -p ao-cli`
- `cargo clippy -p ao-core -p ao-cli -- -D warnings`

Fixes #26

Made with [Cursor](https://cursor.com)