### PR TITLE
feat(tracker): richer issue prompts, templates, git-safe branches

### DIFF
--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -407,6 +407,17 @@ enum Command {
         /// Supported: `tmux`, `process`.
         #[arg(long)]
         runtime: Option<String>,
+
+        /// Optional spawn template to append to the initial prompt.
+        ///
+        /// Built-ins:
+        /// - `bugfix`
+        /// - `feature`
+        /// - `refactor`
+        /// - `docs`
+        /// - `test`
+        #[arg(long)]
+        template: Option<String>,
     },
 
     /// Spawn multiple sessions from a list of GitHub issue numbers.
@@ -451,6 +462,10 @@ enum Command {
         /// Supported: `tmux`, `process`.
         #[arg(long)]
         runtime: Option<String>,
+
+        /// Optional spawn template to append to each session's initial prompt.
+        #[arg(long)]
+        template: Option<String>,
     },
 
     /// List all known sessions, newest first.
@@ -681,6 +696,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
             agent,
             runtime,
+            template,
         } => {
             spawn(
                 task,
@@ -693,6 +709,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 force,
                 agent,
                 runtime,
+                template,
             )
             .await
         }
@@ -705,6 +722,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             force,
             agent,
             runtime,
+            template,
         } => {
             batch_spawn(
                 issues,
@@ -715,6 +733,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 force,
                 agent,
                 runtime,
+                template,
             )
             .await
         }
@@ -1328,6 +1347,129 @@ fn print_config_warnings(config_path: &std::path::Path, warnings: &[ConfigWarnin
     }
 }
 
+fn git_safe_branch_fragment(input: &str) -> String {
+    // Conservative "safe for git refs" sanitization.
+    //
+    // - Only allow [a-z0-9_-]
+    // - Convert path separators and punctuation to '-'
+    // - Collapse repeated dashes
+    // - Trim leading/trailing dashes/underscores
+    //
+    // This intentionally drops dots and other valid-but-footgun characters.
+    let mut out = String::with_capacity(input.len());
+    let mut prev_dash = false;
+    for c in input.chars() {
+        let lower = c.to_ascii_lowercase();
+        let keep = lower.is_ascii_alphanumeric() || lower == '_' || lower == '-';
+        if keep {
+            if lower == '-' {
+                if prev_dash {
+                    continue;
+                }
+                prev_dash = true;
+            } else {
+                prev_dash = false;
+            }
+            out.push(lower);
+        } else {
+            if !prev_dash {
+                out.push('-');
+                prev_dash = true;
+            }
+        }
+    }
+    let trimmed = out.trim_matches(|c| c == '-' || c == '_').to_string();
+    if trimmed.is_empty() {
+        "work".to_string()
+    } else {
+        trimmed
+    }
+}
+
+fn spawn_template_by_name(name: &str) -> Result<String, Box<dyn std::error::Error>> {
+    let n = name.trim().to_ascii_lowercase();
+    let body = match n.as_str() {
+        "bugfix" => {
+            r#"## Template: Bugfix
+- **Hypothesis**: What is broken? What is the suspected root cause?
+- **Repro**: Steps to reproduce + expected vs actual behavior
+- **Fix**: Minimal change that addresses the root cause
+- **Regression tests**: Add/extend tests to prevent recurrence
+
+## Test plan
+- [ ] Run relevant unit/integration tests
+- [ ] Exercise the failing scenario manually (if applicable)
+"#
+        }
+        "feature" => {
+            r#"## Template: Feature
+- **Goal**: What outcome should exist after this change?
+- **Scope**: What's in / out of scope?
+- **UX/Behavior**: Any edge cases, error states, or backwards-compat constraints?
+
+## Acceptance criteria
+- [ ] Meets functional requirements
+- [ ] Has tests (unit/integration as appropriate)
+- [ ] Docs/CLI help updated if user-facing
+
+## Test plan
+- [ ] Run relevant tests
+- [ ] Verify behavior end-to-end
+"#
+        }
+        "refactor" => {
+            r#"## Template: Refactor
+- **Motivation**: Why refactor (maintainability, correctness, performance)?
+- **Constraints**: Behavior must remain identical unless specified
+- **Risks**: What could regress? How to mitigate?
+
+## Test plan
+- [ ] Run relevant tests
+- [ ] Confirm no behavior change (or document intended changes)
+"#
+        }
+        "docs" => {
+            r#"## Template: Docs
+- **Audience**: Who is this for?
+- **Goal**: What should the reader be able to do after reading?
+
+## Test plan
+- [ ] Validate instructions from a clean checkout (if possible)
+"#
+        }
+        "test" => {
+            r#"## Template: Tests
+- **Coverage goal**: What behavior should be locked in?
+- **Test types**: Unit vs integration vs e2e (pick the smallest that’s meaningful)
+- **Fixtures/mocks**: Keep them minimal and readable
+
+## Test plan
+- [ ] Run the added tests and the relevant suite
+"#
+        }
+        _ => {
+            return Err(format!(
+                "unknown template '{name}'. supported: bugfix, feature, refactor, docs, test"
+            )
+            .into())
+        }
+    };
+    Ok(body.to_string())
+}
+
+#[cfg(test)]
+mod spawn_helpers_tests {
+    use super::*;
+
+    #[test]
+    fn git_safe_branch_fragment_is_stable_and_safe() {
+        assert_eq!(git_safe_branch_fragment("feat/issue-42"), "feat-issue-42");
+        assert_eq!(git_safe_branch_fragment("Feat/ISSUE 42!!!"), "feat-issue-42");
+        assert_eq!(git_safe_branch_fragment("..."), "work");
+        assert_eq!(git_safe_branch_fragment("a--b"), "a-b");
+    }
+}
+
 async fn tmux_send_keys_literal_no_enter(handle: &str, text: &str) {
     // Best-effort: used for UI keystrokes (Cursor trust prompt) where sending
     // Enter can be harmful. Ignore failures so spawn doesn't fail just because
@@ -1350,6 +1492,7 @@ async fn spawn(
     force: bool,
     agent_name: Option<String>,
     runtime_name: Option<String>,
+    template: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     // ---- 1. Resolve repo path ----
     let repo_path = resolve_repo_root(repo)?;
@@ -1381,6 +1524,11 @@ async fn spawn(
     // For issue-first, it's just the title (the full issue body is rendered
     // by the prompt builder via `Tracker::generate_prompt`).
     // `issue_context` is the pre-formatted issue section for the prompt builder.
+    let template_context = template
+        .as_deref()
+        .map(spawn_template_by_name)
+        .transpose()?;
+
     let (resolved_task, branch_prefix, resolved_issue_id, resolved_issue_url, issue_context) =
         if let Some(ref id) = issue {
             // Normalize: strip leading `#` so `#42` and `42` match the stored
@@ -1471,7 +1619,10 @@ async fn spawn(
     // Result: `ao-3a4b5c6d-feat-issue-42` (slashes → dashes for git compat).
     // Prompt-first: plain `ao-<shortid>`.
     let branch = match branch_prefix {
-        Some(b) => format!("ao-{short_id}-{}", b.replace('/', "-")),
+        Some(b) => {
+            let safe = git_safe_branch_fragment(&b);
+            format!("ao-{short_id}-{safe}")
+        }
         None => format!("ao-{short_id}"),
     };
 
@@ -1527,7 +1678,12 @@ async fn spawn(
         session.agent_config = resolved_agent_config.clone();
         let agent: Box<dyn Agent> = select_agent(&agent_name, resolved_agent_config.as_ref());
         let env = agent.environment(&session);
-        let initial_prompt = build_prompt(&session, project_config, issue_context.as_deref());
+        let initial_prompt = build_prompt(
+            &session,
+            project_config,
+            issue_context.as_deref(),
+            template_context.as_deref(),
+        );
         let initial_prompt = if agent_name == "cursor" {
             format!(
                 "Execute the task now. Use tools (edit files, run commands) as needed.\n\
@@ -1645,7 +1801,14 @@ async fn batch_spawn(
     force: bool,
     agent_name: Option<String>,
     runtime_name: Option<String>,
+    template: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Validate the template once up front so we fail fast rather than after
+    // spawning N-1 sessions.
+    if let Some(ref name) = template {
+        let _ = spawn_template_by_name(name)?;
+    }
+
     let total = issues.len();
     let mut created = 0u32;
     let mut skipped = 0u32;
@@ -1668,6 +1831,7 @@ async fn batch_spawn(
             force,
             agent_name.clone(),
             runtime_name.clone(),
+            template.clone(),
         )
         .await
         {

--- a/crates/ao-core/src/prompt_builder.rs
+++ b/crates/ao-core/src/prompt_builder.rs
@@ -41,6 +41,7 @@ pub fn build_prompt(
     session: &Session,
     project: Option<&ProjectConfig>,
     issue_context: Option<&str>,
+    template_context: Option<&str>,
 ) -> String {
     let mut sections: Vec<String> = Vec::new();
 
@@ -50,6 +51,13 @@ pub fn build_prompt(
     // Layer 2: issue context (issue-first only)
     if let Some(ctx) = issue_context {
         sections.push(ctx.to_string());
+    }
+
+    // Optional: template context (issue-first and task-first)
+    if let Some(t) = template_context {
+        if !t.trim().is_empty() {
+            sections.push(t.to_string());
+        }
     }
 
     // Layer 3: task directive
@@ -66,13 +74,28 @@ pub fn build_prompt(
 /// outside the full `build_prompt` flow (e.g. `Tracker::generate_prompt`
 /// default impl).
 pub fn format_issue_context(issue: &Issue) -> String {
-    let mut lines = vec![format!("## Issue: {}", issue.title)];
+    let mut lines = vec![format!("## Issue: #{} — {}", issue.id, issue.title)];
 
     if !issue.url.is_empty() {
         lines.push(format!("URL: {}", issue.url));
     }
-    if !issue.labels.is_empty() {
-        lines.push(format!("Labels: {}", issue.labels.join(", ")));
+    lines.push(format!("State: {}", issue_state_str(issue.state)));
+
+    if let Some(ref milestone) = issue.milestone {
+        if !milestone.trim().is_empty() {
+            lines.push(format!("Milestone: {milestone}"));
+        }
+    }
+
+    let (priority, context_labels, other_labels) = classify_labels(&issue.labels);
+    if let Some(p) = priority {
+        lines.push(format!("Priority: {p}"));
+    }
+    if !context_labels.is_empty() {
+        lines.push(format!("Context: {}", context_labels.join(", ")));
+    }
+    if !other_labels.is_empty() {
+        lines.push(format!("Labels: {}", other_labels.join(", ")));
     }
     if let Some(ref assignee) = issue.assignee {
         lines.push(format!("Assignee: {assignee}"));
@@ -84,6 +107,73 @@ pub fn format_issue_context(issue: &Issue) -> String {
     }
 
     lines.join("\n")
+}
+
+fn issue_state_str(s: crate::scm::IssueState) -> &'static str {
+    match s {
+        crate::scm::IssueState::Open => "open",
+        crate::scm::IssueState::InProgress => "in_progress",
+        crate::scm::IssueState::Closed => "closed",
+        crate::scm::IssueState::Cancelled => "cancelled",
+    }
+}
+
+fn classify_labels(labels: &[String]) -> (Option<String>, Vec<String>, Vec<String>) {
+    // Heuristic: extract priority + a small "context" subset to help the agent.
+    // Everything else remains under Labels.
+    let mut priority: Option<String> = None;
+    let mut context: Vec<String> = Vec::new();
+    let mut other: Vec<String> = Vec::new();
+
+    for raw in labels {
+        let l = raw.trim();
+        if l.is_empty() {
+            continue;
+        }
+        let norm = l.to_ascii_lowercase();
+
+        // Priority labels
+        if matches!(norm.as_str(), "p0" | "p1" | "p2" | "p3") {
+            priority = Some(norm.clone());
+            continue;
+        }
+        if norm == "priority:high" || norm == "priority/high" || norm == "high" {
+            priority = Some("high".to_string());
+            continue;
+        }
+        if norm == "priority:medium" || norm == "priority/medium" || norm == "medium" {
+            if priority.is_none() {
+                priority = Some("medium".to_string());
+            }
+            continue;
+        }
+        if norm == "priority:low" || norm == "priority/low" || norm == "low" {
+            if priority.is_none() {
+                priority = Some("low".to_string());
+            }
+            continue;
+        }
+
+        // Context labels (common conventions)
+        if norm.starts_with("area/") || norm.starts_with("kind/") || norm.starts_with("type/") {
+            context.push(l.to_string());
+            continue;
+        }
+        if matches!(
+            norm.as_str(),
+            "bug" | "feature" | "enhancement" | "refactor" | "docs" | "test" | "chore"
+        ) {
+            context.push(l.to_string());
+            continue;
+        }
+
+        other.push(l.to_string());
+    }
+
+    // Keep output stable for snapshots/tests.
+    context.sort();
+    other.sort();
+    (priority, context, other)
 }
 
 // ---------------------------------------------------------------------------
@@ -180,6 +270,7 @@ mod tests {
             state: crate::scm::IssueState::Open,
             labels: vec!["feature".into(), "ui".into()],
             assignee: Some("bob".into()),
+            milestone: Some("Q2".into()),
         }
     }
 
@@ -188,7 +279,7 @@ mod tests {
     #[test]
     fn task_first_no_project_returns_branch_and_task() {
         let session = base_session();
-        let prompt = build_prompt(&session, None, None);
+        let prompt = build_prompt(&session, None, None, None);
 
         assert!(prompt.contains("branch `ao-abc123-feat-issue-42`"));
         assert!(prompt.contains("Fix the login bug"));
@@ -200,7 +291,7 @@ mod tests {
     fn task_first_with_project_includes_repo_context() {
         let session = base_session();
         let proj = sample_project();
-        let prompt = build_prompt(&session, Some(&proj), None);
+        let prompt = build_prompt(&session, Some(&proj), None, None);
 
         assert!(prompt.contains("acme/widgets"));
         assert!(prompt.contains("Default branch: main"));
@@ -218,7 +309,7 @@ mod tests {
         let issue = sample_issue();
         let issue_ctx = format_issue_context(&issue);
 
-        let prompt = build_prompt(&session, Some(&proj), Some(&issue_ctx));
+        let prompt = build_prompt(&session, Some(&proj), Some(&issue_ctx), None);
 
         // Layer 1: session context
         assert!(prompt.contains("branch `ao-abc123-feat-issue-42`"));
@@ -226,8 +317,10 @@ mod tests {
         assert!(prompt.contains("Issue: #42"));
 
         // Layer 2: issue context
-        assert!(prompt.contains("## Issue: Add dark mode"));
-        assert!(prompt.contains("Labels: feature, ui"));
+        assert!(prompt.contains("## Issue: #42 — Add dark mode"));
+        assert!(prompt.contains("State: open"));
+        assert!(prompt.contains("Milestone: Q2"));
+        assert!(prompt.contains("Context: feature, ui"));
         assert!(prompt.contains("Assignee: bob"));
         assert!(prompt.contains("Users keep asking"));
 
@@ -244,9 +337,9 @@ mod tests {
         let issue = sample_issue();
         let issue_ctx = format_issue_context(&issue);
 
-        let prompt = build_prompt(&session, None, Some(&issue_ctx));
+        let prompt = build_prompt(&session, None, Some(&issue_ctx), None);
 
-        assert!(prompt.contains("## Issue: Add dark mode"));
+        assert!(prompt.contains("## Issue: #42 — Add dark mode"));
         assert!(prompt.contains("open a pull request"));
         // No repo context line (the issue URL still contains the repo slug
         // naturally, but there's no "Repository:" metadata line).
@@ -261,9 +354,11 @@ mod tests {
         let issue = sample_issue();
         let ctx = format_issue_context(&issue);
 
-        assert!(ctx.contains("## Issue: Add dark mode"));
+        assert!(ctx.contains("## Issue: #42 — Add dark mode"));
         assert!(ctx.contains("https://github.com/acme/widgets/issues/42"));
-        assert!(ctx.contains("Labels: feature, ui"));
+        assert!(ctx.contains("State: open"));
+        assert!(ctx.contains("Milestone: Q2"));
+        assert!(ctx.contains("Context: feature, ui"));
         assert!(ctx.contains("Assignee: bob"));
         assert!(ctx.contains("Users keep asking"));
     }
@@ -278,11 +373,14 @@ mod tests {
             state: crate::scm::IssueState::Open,
             labels: vec![],
             assignee: None,
+            milestone: None,
         };
         let ctx = format_issue_context(&issue);
 
-        assert!(ctx.contains("## Issue: Fix typo"));
+        assert!(ctx.contains("## Issue: #7 — Fix typo"));
         assert!(!ctx.contains("URL:"));
+        assert!(ctx.contains("State: open"));
+        assert!(!ctx.contains("Milestone:"));
         assert!(!ctx.contains("Labels:"));
         assert!(!ctx.contains("Assignee:"));
     }

--- a/crates/ao-core/src/scm.rs
+++ b/crates/ao-core/src/scm.rs
@@ -229,6 +229,8 @@ pub struct Issue {
     pub labels: Vec<String>,
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub assignee: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub milestone: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]

--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -128,7 +128,7 @@ impl Tracker for GitHubTracker {
             "--repo",
             &self.repo_slug(),
             "--json",
-            "number,title,body,url,state,stateReason,labels,assignees",
+            "number,title,body,url,state,stateReason,labels,assignees,milestone",
         ])
         .await?;
         parse_issue(&json)
@@ -198,6 +198,8 @@ struct RawIssue {
     labels: Vec<RawLabel>,
     #[serde(default)]
     assignees: Vec<RawLogin>,
+    #[serde(default)]
+    milestone: Option<RawMilestone>,
 }
 
 #[derive(Debug, Deserialize)]
@@ -210,6 +212,12 @@ struct RawLabel {
 struct RawLogin {
     #[serde(default)]
     login: String,
+}
+
+#[derive(Debug, Deserialize)]
+struct RawMilestone {
+    #[serde(default)]
+    title: String,
 }
 
 fn parse_issue(json: &str) -> Result<Issue> {
@@ -239,6 +247,10 @@ fn parse_issue(json: &str) -> Result<Issue> {
             .next()
             .map(|a| a.login)
             .filter(|s| !s.is_empty()),
+        milestone: raw
+            .milestone
+            .map(|m| m.title)
+            .filter(|s| !s.trim().is_empty()),
     })
 }
 
@@ -434,7 +446,8 @@ mod tests {
           "state": "OPEN",
           "stateReason": null,
           "labels": [{"name": "feature"}, {"name": "ui"}],
-          "assignees": [{"login": "bob"}, {"login": "alice"}]
+          "assignees": [{"login": "bob"}, {"login": "alice"}],
+          "milestone": {"title": "Q2"}
         }
         "#;
         let issue = parse_issue(json).unwrap();
@@ -446,6 +459,7 @@ mod tests {
         assert_eq!(issue.labels, vec!["feature", "ui"]);
         // Only the first assignee survives — see `parse_issue` comment.
         assert_eq!(issue.assignee.as_deref(), Some("bob"));
+        assert_eq!(issue.milestone.as_deref(), Some("Q2"));
     }
 
     #[test]
@@ -464,7 +478,8 @@ mod tests {
           "state": "OPEN",
           "stateReason": null,
           "labels": [],
-          "assignees": []
+          "assignees": [],
+          "milestone": null
         }
         "#;
         let issue = parse_issue(json).unwrap();
@@ -473,6 +488,7 @@ mod tests {
         assert_eq!(issue.description, "");
         assert_eq!(issue.url, "");
         assert_eq!(issue.state, IssueState::Open);
+        assert_eq!(issue.milestone, None);
     }
 
     #[test]
@@ -511,6 +527,7 @@ mod tests {
         assert_eq!(issue.description, "");
         assert!(issue.labels.is_empty());
         assert_eq!(issue.assignee, None);
+        assert_eq!(issue.milestone, None);
     }
 
     #[test]

--- a/crates/plugins/tracker-linear/src/lib.rs
+++ b/crates/plugins/tracker-linear/src/lib.rs
@@ -161,6 +161,11 @@ impl Tracker for LinearTracker {
                 .as_ref()
                 .and_then(|a| a.name.clone())
                 .filter(|s| !s.is_empty()),
+            milestone: issue
+                .project
+                .as_ref()
+                .and_then(|p| p.name.clone())
+                .filter(|s| !s.trim().is_empty()),
         })
     }
 


### PR DESCRIPTION
## Summary
- Enrich issue-first prompts with **state + milestone** and label-derived **Priority/Context** metadata.
- Add `--template` to `ao-rs spawn` and `ao-rs batch-spawn` with built-in templates (bugfix/feature/refactor/docs/test) appended to the initial prompt.
- Make derived branch fragments **git-safe** and stable via conservative sanitization.

## Notes
- GitHub tracker now fetches `milestone` via `gh issue view --json ...` and maps it into `Issue`.
- Linear tracker maps `project.name` into `Issue.milestone` (best-effort).

## Test plan
- [x] `cargo test -p ao-plugin-tracker-github -p ao-cli`

Closes #29

Made with [Cursor](https://cursor.com)