### PR TITLE
feat(ui): simplify dashboard status lanes

### DIFF
--- a/crates/ao-core/tests/parity_test_utils.rs
+++ b/crates/ao-core/tests/parity_test_utils.rs
@@ -14,6 +14,7 @@ pub fn unique_temp_dir(label: &str) -> PathBuf {
     std::env::temp_dir().join(format!("ao-rs-ts-parity-{label}-{nanos}-{n}"))
 }
 
+#[allow(dead_code)]
 pub fn fake_session(id: &str) -> Session {
     Session {
         id: SessionId(id.into()),

--- a/crates/ao-desktop/ui/src/components/AttentionZone.tsx
+++ b/crates/ao-desktop/ui/src/components/AttentionZone.tsx
@@ -1,22 +1,20 @@
 import { memo, useState } from "react";
-import type { AttentionLevel, DashboardSession } from "../lib/types";
+import type { DashboardLane, DashboardSession } from "../lib/types";
 import { SessionCard } from "./SessionCard";
 
 interface AttentionZoneProps {
-  level: AttentionLevel;
+  level: DashboardLane;
   sessions: DashboardSession[];
   onSelect?: (session: DashboardSession) => void;
   onOpen?: (session: DashboardSession) => void;
   defaultCollapsed?: boolean;
 }
 
-const zoneConfig: Record<AttentionLevel, { label: string; emptyMessage: string }> = {
-  merge: { label: "Ready", emptyMessage: "Nothing cleared to land yet." },
-  respond: { label: "Respond", emptyMessage: "No agents need your input." },
-  review: { label: "Review", emptyMessage: "No code waiting for review." },
-  pending: { label: "Pending", emptyMessage: "Nothing blocked." },
+const zoneConfig: Record<DashboardLane, { label: string; emptyMessage: string }> = {
   working: { label: "Working", emptyMessage: "No agents running." },
-  done: { label: "Done", emptyMessage: "No completed sessions." },
+  pending: { label: "Pending", emptyMessage: "Nothing pending." },
+  review: { label: "Review", emptyMessage: "No code waiting for review." },
+  merge: { label: "Merge", emptyMessage: "Nothing ready to land yet." },
 };
 
 function AttentionZoneView({ level, sessions, onSelect, onOpen, defaultCollapsed }: AttentionZoneProps) {

--- a/crates/ao-desktop/ui/src/components/Board.tsx
+++ b/crates/ao-desktop/ui/src/components/Board.tsx
@@ -1,17 +1,16 @@
 import { useMemo, useState } from "react";
 import type { AttentionLevel, DashboardSession } from "../lib/types";
-import { getAttentionLevel } from "../lib/types";
+import { getDashboardLane } from "../lib/types";
 import { SessionCard } from "./SessionCard";
 
-const order: AttentionLevel[] = ["pending", "working", "review", "respond", "merge", "done"];
+const order = ["working", "pending", "review", "merge"] as const;
+type Lane = (typeof order)[number];
 
-const labels: Record<AttentionLevel, string> = {
-  pending: "Backlog",
-  working: "In Progress",
-  review: "In Review",
-  respond: "Needs Input",
-  merge: "Ready",
-  done: "Done",
+const labels: Record<Lane, string> = {
+  working: "Working",
+  pending: "Pending",
+  review: "Review",
+  merge: "Merge",
 };
 
 export function Board({
@@ -29,24 +28,15 @@ export function Board({
   rightActionLabel?: string;
   onRightAction?: () => void;
 }) {
-  const grouped: Record<AttentionLevel, DashboardSession[]> = {
-    merge: [],
-    respond: [],
-    review: [],
-    pending: [],
-    working: [],
-    done: [],
-  };
+  const grouped: Record<Lane, DashboardSession[]> = { working: [], pending: [], review: [], merge: [] };
 
-  for (const s of sessions) grouped[getAttentionLevel(s)].push(s);
+  for (const s of sessions) grouped[getDashboardLane(s)].push(s);
 
-  const [collapsed, setCollapsed] = useState<Record<AttentionLevel, boolean>>({
-    pending: false,
+  const [collapsed, setCollapsed] = useState<Record<Lane, boolean>>({
     working: false,
+    pending: false,
     review: false,
-    respond: false,
     merge: false,
-    done: true,
   });
 
   const toggle = useMemo(

--- a/crates/ao-desktop/ui/src/components/Dashboard.tsx
+++ b/crates/ao-desktop/ui/src/components/Dashboard.tsx
@@ -1,5 +1,5 @@
 import type { DashboardSession } from "../lib/types";
-import { getAttentionLevel } from "../lib/types";
+import { getDashboardLane } from "../lib/types";
 import { AttentionZone } from "./AttentionZone";
 
 export function Dashboard({
@@ -11,27 +11,18 @@ export function Dashboard({
   onSelect?: (session: DashboardSession) => void;
   onOpen?: (session: DashboardSession) => void;
 }) {
-  const grouped: Record<string, DashboardSession[]> = {
-    merge: [],
-    respond: [],
-    review: [],
-    pending: [],
-    working: [],
-    done: [],
-  };
+  const grouped: Record<string, DashboardSession[]> = { working: [], pending: [], review: [], merge: [] };
 
   for (const s of sessions) {
-    grouped[getAttentionLevel(s)].push(s);
+    grouped[getDashboardLane(s)].push(s);
   }
 
   return (
     <div style={{ display: "grid", gridTemplateColumns: "1fr 1fr 1fr", gap: 12 }}>
-      <AttentionZone level="merge" sessions={grouped.merge} onSelect={onSelect} onOpen={onOpen} />
-      <AttentionZone level="respond" sessions={grouped.respond} onSelect={onSelect} onOpen={onOpen} />
-      <AttentionZone level="review" sessions={grouped.review} onSelect={onSelect} onOpen={onOpen} />
-      <AttentionZone level="pending" sessions={grouped.pending} onSelect={onSelect} onOpen={onOpen} />
       <AttentionZone level="working" sessions={grouped.working} onSelect={onSelect} onOpen={onOpen} />
-      <AttentionZone level="done" sessions={grouped.done} onSelect={onSelect} onOpen={onOpen} />
+      <AttentionZone level="pending" sessions={grouped.pending} onSelect={onSelect} onOpen={onOpen} />
+      <AttentionZone level="review" sessions={grouped.review} onSelect={onSelect} onOpen={onOpen} />
+      <AttentionZone level="merge" sessions={grouped.merge} onSelect={onSelect} onOpen={onOpen} />
     </div>
   );
 }

--- a/crates/ao-desktop/ui/src/components/ProjectSidebar.tsx
+++ b/crates/ao-desktop/ui/src/components/ProjectSidebar.tsx
@@ -1,6 +1,6 @@
 import { useState } from "react";
 import type { DashboardSession } from "../lib/types";
-import { getAttentionLevel } from "../lib/types";
+import { getDashboardLane, isTerminalSession } from "../lib/types";
 import { cn } from "../lib/cn";
 import { SessionCard } from "./SessionCard";
 
@@ -42,7 +42,7 @@ export function ProjectSidebar({
 
   const projects: ProjectInfo[] = Array.from(byProject.entries())
     .map(([id, list]) => {
-      const activeCount = list.filter((s) => getAttentionLevel(s) !== "done").length;
+      const activeCount = list.filter((s) => !isTerminalSession(s)).length;
       return {
         id,
         name: projectLabel(id),
@@ -58,15 +58,13 @@ export function ProjectSidebar({
       : sessions.filter((s) => s.projectId === activeProjectId);
 
   const visibleSorted = [...visibleSessions].sort((a, b) => {
-    const la = getAttentionLevel(a);
-    const lb = getAttentionLevel(b);
+    const la = getDashboardLane(a);
+    const lb = getDashboardLane(b);
     const order: Record<string, number> = {
-      respond: 0,
-      merge: 1,
-      review: 2,
-      pending: 3,
-      working: 4,
-      done: 5,
+      merge: 0,
+      review: 1,
+      pending: 2,
+      working: 3,
     };
     return (order[la] ?? 99) - (order[lb] ?? 99);
   });
@@ -144,7 +142,7 @@ export function ProjectSidebar({
         }}
       >
           {visibleSorted.map((s) => {
-            const level = getAttentionLevel(s);
+            const level = getDashboardLane(s);
             const selected = activeSessionId === s.id;
             return (
               <div key={s.id} data-level={level} data-selected={String(selected)}>

--- a/crates/ao-desktop/ui/src/components/SessionCard.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionCard.tsx
@@ -1,6 +1,6 @@
 import { memo } from "react";
 import type { DashboardSession } from "../lib/types";
-import { getAttentionLevel } from "../lib/types";
+import { getDashboardLane } from "../lib/types";
 import { getSessionTitle } from "../lib/format";
 import { cn } from "../lib/cn";
 
@@ -11,7 +11,7 @@ interface SessionCardProps {
 }
 
 function SessionCardView({ session, onClick, onOpen }: SessionCardProps) {
-  const level = getAttentionLevel(session);
+  const level = getDashboardLane(session);
   const title = getSessionTitle(session);
   const secondary =
     session.branch ? session.branch : session.summary && session.summary !== title ? session.summary : null;

--- a/crates/ao-desktop/ui/src/components/SessionDetail.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.tsx
@@ -1,6 +1,6 @@
 import { useMemo, useState } from "react";
 import type { DashboardSession } from "../lib/types";
-import { getAttentionLevel, TERMINAL_STATUSES } from "../lib/types";
+import { getDashboardLane, isTerminalSession } from "../lib/types";
 import { getSessionTitle } from "../lib/format";
 import { ConfirmModal } from "./ConfirmModal";
 
@@ -23,7 +23,7 @@ export function SessionDetail({
   onKill: () => Promise<void>;
   onRestore: () => Promise<void>;
 }) {
-  const level = getAttentionLevel(session);
+  const lane = getDashboardLane(session);
   const title = getSessionTitle(session);
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
@@ -34,22 +34,21 @@ export function SessionDetail({
   const [confirmRestoreOpen, setConfirmRestoreOpen] = useState(false);
 
   const isKillable = useMemo(() => {
-    const s = (session.status ?? "").toLowerCase();
-    return !TERMINAL_STATUSES.has(s);
-  }, [session.status]);
+    return !isTerminalSession(session);
+  }, [session]);
 
   const pills = useMemo(() => {
     const items: Array<{ label: string; tone?: "ok" | "bad" }> = [];
-    items.push({ label: `level: ${level}` });
+    items.push({ label: `lane: ${lane}` });
     if (session.activity) items.push({ label: `activity: ${session.activity}` });
     items.push({ label: `status: ${session.status}` });
     return items;
-  }, [level, session.activity, session.status]);
+  }, [lane, session.activity, session.status]);
 
   const isRestorable = useMemo(() => {
     const s = (session.status ?? "").toLowerCase();
-    return TERMINAL_STATUSES.has(s) && s !== "merged";
-  }, [session.status]);
+    return isTerminalSession(session) && s !== "merged";
+  }, [session]);
 
   const send = async () => {
     const trimmed = message.trim();
@@ -132,8 +131,8 @@ export function SessionDetail({
               title
             )}
           </div>
-          <span className="mini-pill detail-hero__status" data-tone={level}>
-            {level}
+          <span className="mini-pill detail-hero__status" data-tone={lane}>
+            {lane}
           </span>
         </div>
         <div className="detail-hero__sub">
@@ -150,8 +149,8 @@ export function SessionDetail({
         </div>
         <div className="detail-meta">
           <div className="kv">
-            <div className="kv__k">Level</div>
-            <div className="kv__v">{level}</div>
+            <div className="kv__k">Lane</div>
+            <div className="kv__v">{lane}</div>
           </div>
           <div className="kv">
             <div className="kv__k">Status</div>

--- a/crates/ao-desktop/ui/src/lib/types.ts
+++ b/crates/ao-desktop/ui/src/lib/types.ts
@@ -1,4 +1,9 @@
+// Raw attention buckets as served by `ao-dashboard` (mirrors the TS dashboard).
+// Note: UI may re-map these into fewer lanes.
 export type AttentionLevel = "merge" | "respond" | "review" | "pending" | "working" | "done";
+
+// Dashboard lanes (displayed columns/filters). Issue #59: simplify to 4 lanes.
+export type DashboardLane = "working" | "pending" | "review" | "merge";
 
 export type DashboardPR = {
   number: number;
@@ -44,6 +49,12 @@ export const TERMINAL_STATUSES = new Set([
 
 export const TERMINAL_ACTIVITIES = new Set(["exited"]);
 
+export function isTerminalSession(session: DashboardSession): boolean {
+  const status = (session.status ?? "").toLowerCase();
+  const activity = (session.activity ?? "").toLowerCase();
+  return TERMINAL_STATUSES.has(status) || TERMINAL_ACTIVITIES.has(activity);
+}
+
 export function getAttentionLevel(session: DashboardSession): AttentionLevel {
   if (session.attentionLevel) return session.attentionLevel;
   const status = (session.status ?? "").toLowerCase();
@@ -63,5 +74,31 @@ export function getAttentionLevel(session: DashboardSession): AttentionLevel {
     return "review";
   }
   return "working";
+}
+
+function laneFromLegacyAttention(session: DashboardSession, level: AttentionLevel): DashboardLane {
+  if (level === "working" || level === "pending" || level === "review" || level === "merge") return level;
+
+  // Legacy lanes folded into the simplified dashboard.
+  const status = (session.status ?? "").toLowerCase();
+  if (level === "respond") {
+    // CI failures + changes requested belong with Review; human-input blockers belong with Pending.
+    if (status === "ci_failed" || status === "changes_requested") return "review";
+    return "pending";
+  }
+
+  // level === "done"
+  // ao-ts-style dashboard doesn't show a dedicated Done column; folded into Merge when merged.
+  if (status === "merged" || status === "cleanup" || status === "done") return "merge";
+  return "pending";
+}
+
+export function getDashboardLane(session: DashboardSession): DashboardLane {
+  // Source of truth is `ao-dashboard` attention_level when present; it already encodes PR + CI.
+  if (session.attentionLevel) return laneFromLegacyAttention(session, session.attentionLevel);
+
+  // Fall back to local derivation, then fold into display lanes.
+  const level = getAttentionLevel(session);
+  return laneFromLegacyAttention(session, level);
 }
 

--- a/crates/plugins/agent-cursor/src/lib.rs
+++ b/crates/plugins/agent-cursor/src/lib.rs
@@ -266,7 +266,7 @@ fn detect_git_index_activity(workspace_path: &Path) -> Result<Option<ActivitySta
         workspace_path.join(git_dir)
     };
     let idx = git_dir.join("index");
-    Ok(state_from_mtime(idx)?)
+    state_from_mtime(&idx)
 }
 
 /// Check if any git commits were made in the workspace within the last 60s.


### PR DESCRIPTION
Fixes #59.

## Summary
- Simplifies Ao Desktop dashboard columns/labels to **Working**, **Pending**, **Review**, **Merge**.
- Keeps backend/internal lifecycle enums stable; UI remaps server-provided attention buckets into the 4 display lanes.
- Updates counts, chips, and sidebar ordering to match the new lanes.

## Mapping notes
- `respond` is folded into:
  - **Review** when status indicates CI/review changes (`ci_failed`, `changes_requested`).
  - **Pending** for input-blocked states (`needs_input`, `stuck`, `waiting_input`).
- Terminal/done states are no longer a column; merged/cleanup/done are folded into **Merge**.

## Test plan
- `cargo fmt --all --check`
- `cargo clippy --workspace --all-targets -- -D warnings`
- `cargo test --workspace`
- `cd crates/ao-desktop/ui && npm ci && npm run build`

Made with [Cursor](https://cursor.com)