### PR TITLE
Fix session PR enrichment for merged PRs

### DIFF
--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -1371,11 +1371,9 @@ fn git_safe_branch_fragment(input: &str) -> String {
                 prev_dash = false;
             }
             out.push(lower);
-        } else {
-            if !prev_dash {
-                out.push('-');
-                prev_dash = true;
-            }
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
         }
     }
     let trimmed = out.trim_matches(|c| c == '-' || c == '_').to_string();
@@ -1464,7 +1462,10 @@ mod spawn_helpers_tests {
     #[test]
     fn git_safe_branch_fragment_is_stable_and_safe() {
         assert_eq!(git_safe_branch_fragment("feat/issue-42"), "feat-issue-42");
-        assert_eq!(git_safe_branch_fragment("Feat/ISSUE 42!!!"), "feat-issue-42");
+        assert_eq!(
+            git_safe_branch_fragment("Feat/ISSUE 42!!!"),
+            "feat-issue-42"
+        );
         assert_eq!(git_safe_branch_fragment("..."), "work");
         assert_eq!(git_safe_branch_fragment("a--b"), "a-b");
     }

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -511,9 +511,9 @@ impl LifecycleManager {
         // for "exited but not explicitly killed" elsewhere, but lifecycle
         // liveness probes map to `killed` just like ao-ts.
         let terminal_status = match reason {
-            TerminationReason::RuntimeGone | TerminationReason::AgentExited | TerminationReason::NoHandle => {
-                SessionStatus::Killed
-            }
+            TerminationReason::RuntimeGone
+            | TerminationReason::AgentExited
+            | TerminationReason::NoHandle => SessionStatus::Killed,
         };
         if session.status != terminal_status {
             self.transition(session, terminal_status).await?;

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -118,6 +118,10 @@ impl Scm for GitHubScm {
             "list",
             "--repo",
             &repo_flag,
+            // Default is `open` only; include merged/closed so dashboard PR enrichment
+            // can still link a session after its PR has been merged.
+            "--state",
+            "all",
             "--head",
             &session.branch,
             "--json",


### PR DESCRIPTION
## Summary
- Fix GitHub SCM PR detection to include merged/closed PRs when linking a session branch.
- Prevents Session Detail from showing "No PR linked" after the PR is merged.

## Test plan
- [x] `cargo fmt --all`
- [x] `cargo clippy --all-targets --all-features -- -D warnings`
- [x] `cargo test --all --all-features`

Closes #57.

Made with [Cursor](https://cursor.com)