### PR TITLE
docs: update plugin spec for local issues, attention buckets, wiring

### DIFF
--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -13,7 +13,8 @@ idiomatically in Rust. Feature parity is explicitly **not** a goal.
 
 Not ported, not planned:
 
-- Web dashboard (Next.js)
+- TS-style web dashboard (Next.js). ao-rs instead ships a small Rust dashboard API (`crates/ao-dashboard`)
+  and a desktop shell (`crates/ao-desktop`) for local inspection.
 - Plugin marketplace / registry install flow
 - `~/.agent-orchestrator/plugins/` external install store
 - TS-style Zod config validation (ao-rs uses `serde_yaml` + a supported-subset validator; see `docs/config.md`)

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -15,7 +15,7 @@ Logging honors `RUST_LOG`; default is `warn,ao_core=info` — bump to
 ## `ao-rs start` — initialize config
 
 ```
-ao-rs start [--repo PATH]
+ao-rs start [--repo PATH] [--run] [--port N] [--interval SECS] [--open]
 ```
 
 Creates or loads a project-local `ao-rs.yaml` config file.
@@ -25,12 +25,19 @@ Creates or loads a project-local `ao-rs.yaml` config file.
 
 Also installs ai-devkit skills (best-effort).
 
+When `--run` is set, `start` will also launch the dashboard + lifecycle loop
+(equivalent to running `ao-rs dashboard` after `ao-rs start`). `--open` opens
+the dashboard URL in your default browser (requires `--run`).
+
 ## `ao-rs spawn` — create a new session
 
 ```
 ao-rs spawn (--task "<task>" | --issue <N|#N> | --local-issue PATH)
             [--repo PATH] [--default-branch BRANCH] [--project NAME]
-            [--no-prompt] [--force] [--agent <claude-code|cursor|codex>]
+            [--no-prompt] [--force]
+            [--agent <claude-code|cursor|aider|codex>]
+            [--runtime <tmux|process>]
+            [--template <bugfix|feature|refactor|docs|test>]
 ```
 
 Wires up, in order:
@@ -60,7 +67,9 @@ Flags:
 | `--project` | repo directory name | Namespaces sessions + worktrees on disk. |
 | `--no-prompt` | off | Skip the initial `send_message` call. Handy when `claude` isn't installed — you still get a bootstrapped session you can attach to. |
 | `--force` | off | Allow duplicate spawns for the same issue/local-issue id (normally rejected). |
-| `--agent` | config default (fallback `claude-code`) | Agent plugin to use. Supported: `claude-code`, `cursor`, `codex`. |
+| `--agent` | config default (fallback `claude-code`) | Agent plugin to use. Supported: `claude-code`, `cursor`, `aider`, `codex`. |
+| `--runtime` | config default (fallback `tmux`) | Runtime plugin to use. Supported: `tmux`, `process`. |
+| `--template` | none | Append a built-in template to the initial prompt. Built-ins: `bugfix`, `feature`, `refactor`, `docs`, `test`. |
 
 Notes:
 

--- a/docs/plugin-spec.md
+++ b/docs/plugin-spec.md
@@ -3,6 +3,10 @@
 Condensed from `docs/PLUGIN_SPEC.md` in the TS reference, rewritten for the
 Rust port's compile-time trait-object model.
 
+This document is intentionally **behavioral**: it describes what ao-rs does
+today, including divergences from the TS reference where they matter for
+operators, the dashboard UI, and plugin authors.
+
 ## Runtime contract
 
 A plugin is a regular Rust struct that implements **one** of the traits
@@ -34,6 +38,21 @@ let runtime: Arc<dyn Runtime> = Arc::new(TmuxRuntime::new());
 let agent:   Arc<dyn Agent>   = Arc::new(ClaudeCodeAgent::new());
 ```
 
+## Compile-time wiring (vs TS discovery)
+
+The TS reference discovers plugins dynamically (npm packages + a registry +
+runtime `detect()` checks). ao-rs intentionally does **compile-time wiring**:
+
+- Plugin implementations are **workspace members** (Cargo crates).
+- Selection is done by **string names** in config and CLI flags (e.g.
+  `defaults.agent: cursor`, `ao-rs spawn --agent codex`), but the mapping from
+  name → concrete type lives in `ao-cli` (and in `ao-dashboard` for API-spawn).
+- There is **no install store** and no runtime marketplace. If a plugin is not
+  compiled into the binary, it is not selectable.
+
+Practical implication: “plugin availability” is a build-time concern. The docs
+and examples should match the names accepted by the binary you built.
+
 ## Supported slots
 
 The TS reference has seven plugin slots. ao-rs implements six across
@@ -48,6 +67,56 @@ eleven crates; the `terminal` slot is not ported.
 | scm | `Scm` | `crates/plugins/scm-github` | ✅ done |
 | notifier | `Notifier` | `crates/plugins/notifier-stdout`, `notifier-ntfy`, `notifier-desktop`, `notifier-discord` | ✅ done |
 | terminal | — | — | ❌ not ported |
+
+## Tracker sources (GitHub issues + local markdown)
+
+ao-rs has **two** ways to supply “issue context” to `spawn`, and they differ
+intentionally:
+
+- **Remote tracker issues** (`ao-rs spawn --issue <N|#N>`): uses the configured
+  `Tracker` plugin to fetch a remote issue and format a structured prompt
+  section (via `Tracker::generate_prompt`).
+- **Local markdown issues** (`ao-rs issue …` + `ao-rs spawn --local-issue PATH`):
+  bypasses the `Tracker` trait entirely. The CLI reads a local markdown file
+  under `docs/issues/`, extracts title/body, and formats an “Issue context”
+  section for the prompt builder.
+
+Local issues still participate in duplicate detection by storing a synthetic
+`Session.issue_id` like `local-0007` (there is no `issue_url` for local files).
+
+### Selecting the tracker plugin
+
+For `spawn --issue`, tracker selection is:
+
+- Per-project override: `projects.<id>.tracker.plugin`
+- Otherwise `defaults.tracker`
+- Otherwise fallback `"github"`
+
+The Rust port currently supports at least `"github"` and `"linear"` as tracker
+names (depending on which plugins are compiled into your `ao-rs` binary).
+
+## Selection defaults (config vs flags)
+
+ao-rs uses a small set of **string defaults** in `ao-rs.yaml` to choose which
+compiled-in plugins to use when a command does not specify an explicit flag.
+
+Common fields:
+
+- `defaults.agent` (e.g. `claude-code`, `cursor`, `aider`, `codex`)
+- `defaults.runtime` (e.g. `tmux`, `process`)
+- `defaults.workspace` (e.g. `worktree`)
+- `defaults.tracker` (e.g. `github`, `linear`)
+- `defaults.notifiers` (list of notifier names for reaction routing)
+
+Precedence is “more specific wins”:
+
+- CLI flags (e.g. `ao-rs spawn --agent cursor --runtime process`)
+- Per-project overrides under `projects.<id>.*` (where supported)
+- `defaults.*`
+- Hard-coded fallback (only when no config is present)
+
+Note: the dashboard’s HTTP `POST /api/sessions/spawn` uses its own defaults for
+`agent` and `default_branch` when omitted from the request body.
 
 ## Decision: do not port the TS `terminal` slot (Phase 5 / Issue #20)
 
@@ -179,6 +248,39 @@ This mirrors `spawn()` in `packages/core/src/session-manager.ts`.
 7. CLI sleeps briefly (tmux needs to finish drawing) then calls
    `Runtime::send_message` with the initial prompt.
 8. `LifecycleManager` takes over polling on the next tick.
+
+## Dashboard attention buckets (UI “what needs attention”)
+
+The dashboard/UI groups sessions into **attention buckets** that are *derived*
+from the session’s lifecycle state and (optionally) PR enrichment.
+
+Bucket labels (stable strings used by the API/UI):
+
+- `working`
+- `pending`
+- `review`
+- `respond`
+- `merge`
+- `done`
+
+Derivation rules (current behavior in `ao-dashboard`):
+
+- Terminal sessions → `done`
+- If PR info is available:
+  - Open + mergeable + CI passing → `merge`
+  - Changes requested **or** CI failing → `respond`
+  - Review pending → `review`
+  - CI pending → `pending`
+  - Any other open-PR state (including “no decision”, draft, branch protection) → `review`
+- Without PR info, fall back to `SessionStatus`:
+  - `pr_open`, `review_pending`, `approved` → `review`
+  - `ci_failed`, `changes_requested`, `needs_input`, `stuck` → `respond`
+  - `mergeable`, `merge_failed` → `merge`
+  - everything else (e.g. `spawning`, `working`) → `working`
+
+This is intentionally **dashboard-focused** and not a core enum: the core
+state machine stays in `SessionStatus` / `ActivityState` and the dashboard
+chooses a UX-friendly grouping.
 
 ## Testing plugins
 


### PR DESCRIPTION
## Summary
- Update `docs/plugin-spec.md` to match ao-rs behavior: compile-time wiring (no TS-style discovery), local markdown issues as a spawn input, and dashboard attention buckets.
- Update `docs/cli-reference.md` to match current clap flags for `start` and `spawn` (runtime + template + agent list).
- Clarify in `docs/architecture.md` that TS Next.js dashboard isn’t ported, while ao-rs has a Rust dashboard API + desktop shell.

## Linked issue
- Closes #31

## Test plan
- `cargo fmt`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo test --all-features`

Made with [Cursor](https://cursor.com)