### PR TITLE
feat(terminal): backpressure notices, reconnect semantics, load probe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -147,18 +147,23 @@ dependencies = [
 name = "ao-dashboard"
 version = "0.0.1"
 dependencies = [
+ "anyhow",
  "ao-core",
  "ao-plugin-workspace-worktree",
  "async-trait",
  "axum",
+ "futures-util",
  "portable-pty",
  "serde",
  "serde_json",
  "tokio",
  "tokio-stream",
+ "tokio-tungstenite 0.29.0",
  "tower",
  "tower-http",
  "tracing",
+ "url",
+ "urlencoding",
 ]
 
 [[package]]
@@ -573,7 +578,7 @@ dependencies = [
  "sha1",
  "sync_wrapper",
  "tokio",
- "tokio-tungstenite",
+ "tokio-tungstenite 0.28.0",
  "tower",
  "tower-layer",
  "tower-service",
@@ -5035,7 +5040,19 @@ dependencies = [
  "futures-util",
  "log",
  "tokio",
- "tungstenite",
+ "tungstenite 0.28.0",
+]
+
+[[package]]
+name = "tokio-tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8f72a05e828585856dacd553fba484c242c46e391fb0e58917c942ee9202915c"
+dependencies = [
+ "futures-util",
+ "log",
+ "tokio",
+ "tungstenite 0.29.0",
 ]
 
 [[package]]
@@ -5308,6 +5325,22 @@ dependencies = [
  "sha1",
  "thiserror 2.0.18",
  "utf-8",
+]
+
+[[package]]
+name = "tungstenite"
+version = "0.29.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c01152af293afb9c7c2a57e4b559c5620b421f6d133261c60dd2d0cdb38e6b8"
+dependencies = [
+ "bytes",
+ "data-encoding",
+ "http",
+ "httparse",
+ "log",
+ "rand 0.9.3",
+ "sha1",
+ "thiserror 2.0.18",
 ]
 
 [[package]]

--- a/crates/ao-dashboard/Cargo.toml
+++ b/crates/ao-dashboard/Cargo.toml
@@ -16,6 +16,11 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 tracing = { workspace = true }
 portable-pty = "0.8"
+tokio-tungstenite = "0.29.0"
+futures-util = "0.3.32"
+url = "2.5.8"
+anyhow = "1.0.102"
+urlencoding = "2.1.3"
 
 [dev-dependencies]
 async-trait = { workspace = true }

--- a/crates/ao-dashboard/src/bin/terminal_load.rs
+++ b/crates/ao-dashboard/src/bin/terminal_load.rs
@@ -1,0 +1,108 @@
+use futures_util::{SinkExt, StreamExt};
+use std::time::{Duration, Instant};
+use tokio_tungstenite::tungstenite::Message;
+use url::Url;
+
+fn usage() -> ! {
+    eprintln!(
+        "usage: terminal_load --base <http://127.0.0.1:3000> --session <SESSION_PREFIX> [--slow-ms <N>] [--seconds <N>]\n\
+         \n\
+         Connects to the dashboard terminal WebSocket and reads output.\n\
+         Use --slow-ms to intentionally read slowly (exercise server backpressure/drop policy)."
+    );
+    std::process::exit(2);
+}
+
+fn ws_url(base: &str, session: &str) -> Url {
+    let base = base.trim_end_matches('/');
+    let mut u = Url::parse(base).unwrap_or_else(|_| usage());
+    match u.scheme() {
+        "http" => {
+            u.set_scheme("ws").ok();
+        }
+        "https" => {
+            u.set_scheme("wss").ok();
+        }
+        "ws" | "wss" => {}
+        _ => usage(),
+    }
+    u.set_path(&format!(
+        "/api/sessions/{}/terminal",
+        urlencoding::encode(session)
+    ));
+    u
+}
+
+#[tokio::main]
+async fn main() -> anyhow::Result<()> {
+    let mut base: Option<String> = None;
+    let mut session: Option<String> = None;
+    let mut slow_ms: u64 = 0;
+    let mut seconds: u64 = 15;
+
+    let mut args = std::env::args().skip(1);
+    while let Some(a) = args.next() {
+        match a.as_str() {
+            "--base" => base = args.next(),
+            "--session" => session = args.next(),
+            "--slow-ms" => slow_ms = args.next().unwrap_or_default().parse().unwrap_or(0),
+            "--seconds" => seconds = args.next().unwrap_or_default().parse().unwrap_or(15),
+            "--help" | "-h" => usage(),
+            _ => usage(),
+        }
+    }
+    let base = base.unwrap_or_else(|| usage());
+    let session = session.unwrap_or_else(|| usage());
+
+    let url = ws_url(&base, &session);
+    let url_s = url.to_string();
+    eprintln!("connecting to {url_s}");
+
+    let (mut ws, _) = tokio_tungstenite::connect_async(url_s).await?;
+
+    // Trigger an initial resize to keep tmux layouts sane.
+    let _ = ws
+        .send(Message::Text(
+            r#"{"type":"resize","cols":120,"rows":40}"#.into(),
+        ))
+        .await;
+
+    let start = Instant::now();
+    let stop_at = start + Duration::from_secs(seconds);
+    let mut bytes: u64 = 0;
+    let mut dropped_notices: u64 = 0;
+
+    while let Some(msg) = ws.next().await {
+        let msg = msg?;
+        match msg {
+            Message::Binary(b) => {
+                bytes += b.len() as u64;
+                if slow_ms > 0 {
+                    tokio::time::sleep(Duration::from_millis(slow_ms)).await;
+                }
+            }
+            Message::Text(t) => {
+                if t.contains(r#""type":"dropped""#) {
+                    dropped_notices += 1;
+                }
+            }
+            Message::Close(_) => break,
+            _ => {}
+        }
+
+        if Instant::now() >= stop_at {
+            break;
+        }
+    }
+
+    let elapsed = start.elapsed().as_secs_f64().max(0.001);
+    eprintln!(
+        "done: {:.2}s, {:.2} MiB read, {:.2} MiB/s, dropped_notices={}",
+        elapsed,
+        (bytes as f64) / (1024.0 * 1024.0),
+        (bytes as f64) / (1024.0 * 1024.0) / elapsed,
+        dropped_notices
+    );
+
+    Ok(())
+}

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -14,6 +14,7 @@ use axum::{
 };
 use serde::Deserialize;
 use std::path::PathBuf;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Semaphore};
 use tokio::time::Duration;
@@ -476,11 +477,40 @@ struct TerminalClientMsg {
     rows: Option<u16>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+enum TerminalClientAction {
+    Resize { cols: u16, rows: u16 },
+    InputBytes(Vec<u8>),
+}
+
+fn parse_terminal_client_action(msg: Message) -> Option<TerminalClientAction> {
+    match msg {
+        Message::Text(text) => {
+            let text = text.to_string();
+            // JSON control messages (resize). Any other text is treated as input bytes.
+            if text.starts_with('{') {
+                if let Ok(msg) = serde_json::from_str::<TerminalClientMsg>(&text) {
+                    if msg.kind == "resize" {
+                        if let (Some(cols), Some(rows)) = (msg.cols, msg.rows) {
+                            return Some(TerminalClientAction::Resize { cols, rows });
+                        }
+                        return None;
+                    }
+                }
+            }
+            Some(TerminalClientAction::InputBytes(text.into_bytes()))
+        }
+        Message::Binary(bytes) => Some(TerminalClientAction::InputBytes(bytes.to_vec())),
+        _ => None,
+    }
+}
+
 async fn stream_tmux_pty(mut socket: WebSocket, handle: String) {
     use portable_pty::{native_pty_system, CommandBuilder, PtySize};
     use std::io::{Read, Write};
 
     const WS_OUT_CAPACITY: usize = 128;
+    const DROP_NOTICE_INTERVAL_MS: u64 = 1000;
 
     // ---- 1) Create PTY + spawn `tmux attach` inside it ----
     let pty_system = native_pty_system();
@@ -541,6 +571,8 @@ async fn stream_tmux_pty(mut socket: WebSocket, handle: String) {
     let master = pair.master;
     let (out_tx, mut out_rx) = mpsc::channel::<Vec<u8>>(WS_OUT_CAPACITY);
     let (in_tx, mut in_rx) = mpsc::channel::<Vec<u8>>(128);
+    let dropped_chunks = Arc::new(AtomicU64::new(0));
+    let dropped_chunks_reader = dropped_chunks.clone();
 
     // Reader thread
     tokio::task::spawn_blocking(move || {
@@ -553,6 +585,7 @@ async fn stream_tmux_pty(mut socket: WebSocket, handle: String) {
                     // Dropping output is preferable to stalling the tmux session.
                     if out_tx.try_send(buf[..n].to_vec()).is_err() {
                         // channel full or closed; drop
+                        dropped_chunks_reader.fetch_add(1, Ordering::Relaxed);
                     }
                 }
                 Err(_) => break,
@@ -571,6 +604,8 @@ async fn stream_tmux_pty(mut socket: WebSocket, handle: String) {
     });
 
     // ---- 2) WS loop: forward PTY output + accept input/resize ----
+    let mut drop_notice_tick =
+        tokio::time::interval(Duration::from_millis(DROP_NOTICE_INTERVAL_MS));
     loop {
         tokio::select! {
             maybe_out = out_rx.recv() => {
@@ -583,28 +618,38 @@ async fn stream_tmux_pty(mut socket: WebSocket, handle: String) {
                     None => break,
                 }
             }
+            _ = drop_notice_tick.tick() => {
+                let dropped = dropped_chunks.swap(0, Ordering::Relaxed);
+                if dropped > 0 {
+                    // Keep as a JSON text frame so clients can render a compact notice.
+                    let notice = serde_json::json!({
+                        "type": "dropped",
+                        "dropped_chunks": dropped,
+                        "policy": "drop_newest"
+                    });
+                    let _ = socket.send(Message::Text(notice.to_string().into())).await;
+                }
+            }
             recv = socket.recv() => {
                 match recv {
-                    Some(Ok(Message::Text(text))) => {
-                        // JSON control messages (resize)
-                        if text.starts_with('{') {
-                            if let Ok(msg) = serde_json::from_str::<TerminalClientMsg>(&text) {
-                                if msg.kind == "resize" {
-                                    if let (Some(cols), Some(rows)) = (msg.cols, msg.rows) {
-                                        let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
+                    Some(Ok(msg)) => {
+                        match msg {
+                            Message::Close(_) => break,
+                            msg => {
+                                if let Some(action) = parse_terminal_client_action(msg) {
+                                    match action {
+                                        TerminalClientAction::Resize { cols, rows } => {
+                                            let _ = master.resize(PtySize { rows, cols, pixel_width: 0, pixel_height: 0 });
+                                        }
+                                        TerminalClientAction::InputBytes(bytes) => {
+                                            let _ = in_tx.send(bytes).await;
+                                        }
                                     }
-                                    continue;
                                 }
                             }
                         }
-                        // Treat as UTF-8 bytes
-                        let _ = in_tx.send(text.as_bytes().to_vec()).await;
                     }
-                    Some(Ok(Message::Binary(bytes))) => {
-                        let _ = in_tx.send(bytes.to_vec()).await;
-                    }
-                    Some(Ok(Message::Close(_))) | None => break,
-                    Some(Ok(_)) => {},
+                    None => break,
                     Some(Err(_)) => break,
                 }
             }
@@ -704,5 +749,47 @@ mod attention_tests {
     fn review_pending_status_without_pr_row_is_review() {
         let s = sess(SessionStatus::ReviewPending);
         assert_eq!(attention_level(&s, None), "review");
+    }
+}
+
+#[cfg(test)]
+mod terminal_ws_tests {
+    use super::{parse_terminal_client_action, TerminalClientAction};
+    use axum::extract::ws::Message;
+
+    #[test]
+    fn parse_resize_json() {
+        let msg = Message::Text(r#"{"type":"resize","cols":120,"rows":40}"#.into());
+        assert_eq!(
+            parse_terminal_client_action(msg),
+            Some(TerminalClientAction::Resize {
+                cols: 120,
+                rows: 40
+            })
+        );
+    }
+
+    #[test]
+    fn parse_text_input_bytes() {
+        let msg = Message::Text("ls -la\n".into());
+        assert_eq!(
+            parse_terminal_client_action(msg),
+            Some(TerminalClientAction::InputBytes(b"ls -la\n".to_vec()))
+        );
+    }
+
+    #[test]
+    fn parse_binary_input_bytes() {
+        let msg = Message::Binary(vec![0x1b, b'[', b'A'].into());
+        assert_eq!(
+            parse_terminal_client_action(msg),
+            Some(TerminalClientAction::InputBytes(vec![0x1b, b'[', b'A']))
+        );
+    }
+
+    #[test]
+    fn resize_missing_fields_is_ignored() {
+        let msg = Message::Text(r#"{"type":"resize","cols":80}"#.into());
+        assert_eq!(parse_terminal_client_action(msg), None);
     }
 }

--- a/crates/ao-desktop/ui/src/components/TerminalView.tsx
+++ b/crates/ao-desktop/ui/src/components/TerminalView.tsx
@@ -3,6 +3,10 @@ import { Terminal } from "@xterm/xterm";
 import { FitAddon } from "@xterm/addon-fit";
 import "@xterm/xterm/css/xterm.css";
 
+type TerminalServerControl =
+  | { type: "dropped"; dropped_chunks?: number; policy?: string }
+  | { type: string; [k: string]: unknown };
+
 function wsUrl(baseUrl: string, path: string): string {
   const trimmed = baseUrl.replace(/\/+$/, "");
   if (trimmed.startsWith("https://")) return `wss://${trimmed.slice("https://".length)}${path}`;
@@ -26,6 +30,7 @@ export function TerminalView({
   const reconnectTimerRef = useRef<number | null>(null);
   const reconnectAttemptRef = useRef(0);
   const connectRef = useRef<() => void>(() => {});
+  const decoderRef = useRef<TextDecoder | null>(null);
 
   const forceFocus = () => {
     const term = termRef.current;
@@ -123,6 +128,7 @@ export function TerminalView({
         term.writeln(`connected (${url})`);
         term.writeln("");
         forceFocus();
+        decoderRef.current = new TextDecoder();
 
         inputDisposableRef.current?.dispose();
         inputDisposableRef.current = term.onData((data) => {
@@ -156,6 +162,7 @@ export function TerminalView({
 
         const reason = evt.reason ? ` reason=${evt.reason}` : "";
         term.writeln(`\r\n[ws closed] code=${evt.code}${reason}`);
+        decoderRef.current = null;
         inputDisposableRef.current?.dispose();
         inputDisposableRef.current = null;
         resizeObserverRef.current?.disconnect();
@@ -180,11 +187,26 @@ export function TerminalView({
         if (typeof msg.data === "string") {
           const text = msg.data;
           if (!text) return;
+          if (text.startsWith("{")) {
+            try {
+              const parsed = JSON.parse(text) as TerminalServerControl;
+              if (parsed.type === "dropped") {
+                const n = typeof parsed.dropped_chunks === "number" ? parsed.dropped_chunks : 0;
+                const policy = typeof parsed.policy === "string" ? parsed.policy : "drop";
+                term.writeln(`\r\n[output dropped] chunks=${n} policy=${policy}`);
+                return;
+              }
+            } catch {
+              // fall through to rendering raw text
+            }
+          }
           term.writeln(`\r\n${text}`);
           return;
         }
         if (msg.data instanceof ArrayBuffer) {
-          const text = new TextDecoder().decode(new Uint8Array(msg.data));
+          const dec = decoderRef.current ?? new TextDecoder();
+          decoderRef.current = dec;
+          const text = dec.decode(new Uint8Array(msg.data), { stream: true });
           if (!text) return;
           term.write(text);
         }
@@ -197,6 +219,7 @@ export function TerminalView({
     return () => {
       cancelled = true;
       clearReconnect();
+      decoderRef.current = null;
       inputDisposableRef.current?.dispose();
       inputDisposableRef.current = null;
       resizeObserverRef.current?.disconnect();

--- a/docs/SMOKE.md
+++ b/docs/SMOKE.md
@@ -33,6 +33,10 @@ Run before a release or after large changes to `ao-cli`, `ao-dashboard`, or `ao-
 - [ ] **Send message** — succeeds; list refreshes without full-page reload
 - [ ] **Kill** / **Restore** — confirm modals; action completes; status updates
 - [ ] **Terminal** — connects; typing reaches tmux; resize does not break layout badly; disconnect shows reconnect message and recovers
+- [ ] **Terminal (load)** — run a high-output command (see `docs/terminal.md`) and confirm:
+  - [ ] UI stays responsive
+  - [ ] reconnect does not wedge the terminal
+  - [ ] drop notices may appear under load
 
 ## Regression triggers
 

--- a/docs/terminal.md
+++ b/docs/terminal.md
@@ -1,0 +1,70 @@
+## Interactive terminal (dashboard WS + desktop UI)
+
+This repo exposes an interactive terminal per session via a dashboard WebSocket endpoint and renders it in the desktop UI using `xterm.js`.
+
+### Endpoint
+
+- **URL**: `GET /api/sessions/:id/terminal` (WebSocket upgrade)
+- **Server implementation**: `crates/ao-dashboard/src/routes.rs` (`terminal_ws`, `stream_tmux_pty`)
+- **Client implementation**: `crates/ao-desktop/ui/src/components/TerminalView.tsx`
+
+### Message types
+
+- **Server → client**
+  - **Binary frames**: raw PTY output bytes (best-effort stream).
+  - **Text frames**:
+    - Human-readable error lines during setup failures (e.g. PTY open/spawn issues).
+    - Control JSON:
+      - `{"type":"dropped","dropped_chunks":N,"policy":"drop_newest"}`
+
+- **Client → server**
+  - **Text frames**: UTF-8 input to PTY (keystrokes / pasted text).
+  - **Binary frames**: raw input bytes (optional; supported).
+  - **Resize control**: `{"type":"resize","cols":<u16>,"rows":<u16>}`
+
+### Backpressure + drop policy (output)
+
+The PTY reader must never block behind a slow WebSocket client (otherwise the `tmux attach` session can stall).
+
+- **Policy**: bounded buffering + **drop newest** on overflow.
+  - The PTY reader thread forwards output into a bounded channel (`WS_OUT_CAPACITY`).
+  - If the channel is full, the newest chunk is dropped immediately.
+- **User-visible signal**: the server periodically emits a control JSON message describing how many output chunks were dropped since the last notice.
+
+**Guarantee**: terminal input remains responsive even if output is high-volume.  
+**Non-guarantee**: output is lossless; under load, output can be dropped.
+
+### Reconnect semantics
+
+Reconnect is **stateless** and safe:
+
+- **On each WebSocket connection**, the server creates a fresh PTY and runs `tmux attach -t <session>` inside it.
+- **If the socket disconnects**, the PTY process is torn down. The underlying tmux session remains intact.
+- **When the client reconnects**, it attaches again to the same tmux session.
+
+Client behavior:
+
+- `TerminalView` auto-reconnects with exponential backoff after unexpected disconnects.
+- On reconnect, the UI re-sends an initial resize to match the current container size.
+- The client uses a streaming UTF-8 decoder for binary output to avoid corrupting multibyte sequences that span frames.
+
+### Limitations
+
+- The output stream is best-effort; do not rely on it for complete logs. Use persisted logs/artifacts for correctness.
+- Extremely slow clients may observe frequent drop notices and gaps in output.
+- Output ordering is preserved for delivered chunks, but gaps can occur where chunks were dropped.
+
+### Manual load / stress probe
+
+To validate responsiveness, in a session terminal run a high-output command, for example:
+
+```bash
+yes "spam" | head -n 200000
+```
+
+Expected:
+
+- typing still works (input is accepted)
+- UI stays responsive (no wedged terminal)
+- you may see `[output dropped] ...` notices during peak output
+


### PR DESCRIPTION
Closes #32 (phase 3/5).

## Summary
- Server: keep PTY reader non-blocking under slow WS clients; count dropped output chunks and emit periodic `type=dropped` notices.
- Server: factor/cover resize + input framing with unit tests.
- Client: streaming UTF-8 decode for binary PTY output; render drop notices; keep reconnect behavior stable.
- Docs: document reconnect/backpressure guarantees + add smoke checklist item; add `terminal_load` probe binary.

## Test plan
- `cargo fmt`
- `cargo test -p ao-dashboard`
- `cd crates/ao-desktop/ui && npm install && npm run typecheck && npm test`

## Manual (optional)
- Run high-output command in terminal and confirm UI stays responsive; drop notices may appear.
- Use `cargo run -p ao-dashboard --bin terminal_load -- --base http://127.0.0.1:3000 --session <id> --slow-ms 50 --seconds 15` to exercise backpressure.

Made with [Cursor](https://cursor.com)