### PR TITLE
fix(dashboard): contextual session tab labels

### DIFF
--- a/crates/ao-core/src/reaction_engine.rs
+++ b/crates/ao-core/src/reaction_engine.rs
@@ -2501,10 +2501,7 @@ mod tests {
             EventPriority::Action
         );
         assert_eq!(resolve_priority("agent-idle", &cfg), EventPriority::Info);
-        assert_eq!(
-            resolve_priority("agent-stuck", &cfg),
-            EventPriority::Urgent
-        );
+        assert_eq!(resolve_priority("agent-stuck", &cfg), EventPriority::Urgent);
         assert_eq!(
             resolve_priority("agent-needs-input", &cfg),
             EventPriority::Urgent

--- a/crates/ao-desktop/ui/src/lib/format.test.ts
+++ b/crates/ao-desktop/ui/src/lib/format.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+
+import { getSessionTabLabel } from "./format";
+import type { DashboardSession } from "./types";
+
+describe("getSessionTabLabel", () => {
+  it("formats `{project} - #{issue}: {status}` when issueId present", () => {
+    const s: DashboardSession = {
+      id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+      projectId: "ao-rs",
+      status: "working",
+      activity: null,
+      branch: null,
+      summary: null,
+      summaryIsFallback: false,
+      issueTitle: null,
+      issueId: "70",
+      issueUrl: null,
+      userPrompt: null,
+      pr: null,
+      attentionLevel: null,
+      metadata: {},
+    };
+
+    expect(getSessionTabLabel(s)).toBe("ao-rs - #70: working");
+  });
+});
+

--- a/crates/ao-desktop/ui/src/lib/format.ts
+++ b/crates/ao-desktop/ui/src/lib/format.ts
@@ -11,6 +11,16 @@ export function humanizeBranch(branch: string): string {
     .trim();
 }
 
+export function getSessionTabLabel(session: DashboardSession): string {
+  const project = session.projectId || "project";
+  const issueOrPr =
+    (session.issueId ? String(session.issueId) : null) ??
+    (session.pr?.number ? String(session.pr.number) : null) ??
+    session.id.slice(-4);
+  const status = session.status || "unknown";
+  return `${project} - #${issueOrPr}: ${status}`;
+}
+
 export function getSessionTitle(session: DashboardSession): string {
   if (session.pr?.title) return session.pr.title;
   if (session.issueId && session.issueTitle) return `#${session.issueId} ${session.issueTitle}`;

--- a/crates/ao-desktop/ui/src/ui/App.test.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.test.tsx
@@ -14,8 +14,8 @@ vi.mock("../components/TerminalView", () => {
 
 vi.mock("../api/client", () => {
   const sessions = [
-    { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", project_id: "p1", status: "running", activity: "work" },
-    { id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", project_id: "p1", status: "running", activity: "work" },
+    { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", project_id: "my-app", issue_id: "42", status: "pr_open", activity: "work" },
+    { id: "bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb", project_id: "my-app", issue_id: "59", status: "working", activity: "work" },
   ];
 
   return {
@@ -42,7 +42,7 @@ describe("App session tabs", () => {
     // Click the tab for session A.
     const tabsRegion = screen.getByText("Dashboard").closest("section");
     expect(tabsRegion).not.toBeNull();
-    const tabButtonA = await within(tabsRegion!).findByRole("button", { name: "aaaaaaaa" });
+    const tabButtonA = await within(tabsRegion!).findByRole("button", { name: "my-app - #42: pr_open" });
     await user.click(tabButtonA);
 
     // The Session Detail hero shows the active session id prefix (not just the tab label).

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -12,6 +12,7 @@ import {
 import { Board } from "../components/Board";
 import { ProjectSidebar } from "../components/ProjectSidebar";
 import { SessionDetail } from "../components/SessionDetail";
+import { getSessionTabLabel } from "../lib/format";
 import type { DashboardSession } from "../lib/types";
 import { getAttentionLevel } from "../lib/types";
 
@@ -347,6 +348,14 @@ export function App() {
     return dashboardSessions.find((s) => s.id === activeSessionId) ?? null;
   }, [dashboardSessions, activeSessionId]);
 
+  useEffect(() => {
+    if (activeTab === "dashboard" || !activeSession) {
+      document.title = "Ao Dashboard";
+      return;
+    }
+    document.title = `Ao — ${getSessionTabLabel(activeSession)}`;
+  }, [activeTab, activeSession]);
+
   const openSessionDetail = (id: string) => {
     setSelectedSessionId(id);
     setActiveTab({ sessionId: id });
@@ -517,7 +526,12 @@ export function App() {
                       }}
                       title={sid}
                     >
-                      {sid.slice(0, 8)}
+                      <span className="session-tab__label">
+                        {(() => {
+                          const s = sessionById.get(sid);
+                          return s ? getSessionTabLabel(s) : sid.slice(0, 8);
+                        })()}
+                      </span>
                     </button>
                     <button type="button" className="hint" onClick={() => closeSessionTab(sid)} title="Close tab">
                       ×

--- a/crates/ao-desktop/ui/styles.css
+++ b/crates/ao-desktop/ui/styles.css
@@ -463,6 +463,15 @@ body[data-theme="dark"] .session-card:hover { border-color: rgba(255, 255, 255, 
   text-transform: uppercase;
 }
 
+.session-tab__label {
+  display: inline-block;
+  max-width: 240px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  vertical-align: bottom;
+}
+
 /* Session detail (matches dark reference panel structure) */
 .detail-hero {
   background: rgba(255, 255, 255, 0.04);


### PR DESCRIPTION
## Summary
- Session tabs now show `{project} - #{issue}: {status}` (fallback to PR number or session id suffix).
- Tab `title` keeps the full session id for debugging.
- Long tab labels truncate with CSS ellipsis.
- Browser `document.title` updates when a session tab is active.

## Test plan
- `crates/ao-desktop/ui`: `npm test`

Fixes #70.

Made with [Cursor](https://cursor.com)