### PR TITLE
feat(reactions): resolve per-project reaction config

### DIFF
--- a/crates/ao-cli/src/cli/spawn_helpers.rs
+++ b/crates/ao-cli/src/cli/spawn_helpers.rs
@@ -133,7 +133,7 @@ pub(crate) fn git_safe_branch_namespace(input: &str) -> String {
     // - "ao agent//team" => "ao-agent/team"
     let parts: Vec<String> = input
         .split('/')
-        .map(|p| git_safe_branch_fragment(p))
+        .map(git_safe_branch_fragment)
         .filter(|p| p != "work")
         .collect();
     let joined = parts.join("/");

--- a/crates/ao-cli/src/commands/dashboard.rs
+++ b/crates/ao-cli/src/commands/dashboard.rs
@@ -18,7 +18,10 @@ use crate::cli::printing::print_config_warnings;
 /// Reuses the same plugin wiring as `watch` and adds an axum HTTP server.
 /// Both run concurrently under `tokio::select!` so Ctrl-C stops them
 /// together.
-pub async fn dashboard(port: u16, interval_override: Option<Duration>) -> Result<(), Box<dyn std::error::Error>> {
+pub async fn dashboard(
+    port: u16,
+    interval_override: Option<Duration>,
+) -> Result<(), Box<dyn std::error::Error>> {
     let pid_path = paths::lifecycle_pid_file();
     let _lock = match PidFile::acquire(&pid_path) {
         Ok(lock) => lock,
@@ -47,8 +50,8 @@ pub async fn dashboard(port: u16, interval_override: Option<Duration>) -> Result
         AoConfig::load_from_or_default_with_warnings(&config_path)
             .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
     print_config_warnings(&config_path, &warnings);
-    let interval = interval_override
-        .unwrap_or_else(|| Duration::from_secs(config.poll_interval));
+    let config = Arc::new(config);
+    let interval = interval_override.unwrap_or_else(|| Duration::from_secs(config.poll_interval));
 
     let runtime_name = config
         .defaults
@@ -62,10 +65,10 @@ pub async fn dashboard(port: u16, interval_override: Option<Duration>) -> Result
         .with_poll_interval(interval);
     let events_tx = lifecycle_builder.events_sender();
 
-    let notifier_registry = notifier_registry_from_config(&config);
+    let notifier_registry = notifier_registry_from_config(config.as_ref());
 
     let engine = Arc::new(
-        ReactionEngine::new(config.reactions, runtime.clone(), events_tx.clone())
+        ReactionEngine::new_with_config(Arc::clone(&config), runtime.clone(), events_tx.clone())
             .with_scm(scm.clone())
             .with_notifier_registry(notifier_registry),
     );

--- a/crates/ao-cli/src/commands/watch.rs
+++ b/crates/ao-cli/src/commands/watch.rs
@@ -59,6 +59,7 @@ pub async fn watch(interval_override: Option<Duration>) -> Result<(), Box<dyn st
         AoConfig::load_from_or_default_with_warnings(&config_path)
             .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
     print_config_warnings(&config_path, &warnings);
+    let config = Arc::new(config);
     if !config.reactions.is_empty() {
         println!(
             "→ loaded {} reaction(s) from {}",
@@ -66,8 +67,7 @@ pub async fn watch(interval_override: Option<Duration>) -> Result<(), Box<dyn st
             config_path.display()
         );
     }
-    let interval = interval_override
-        .unwrap_or_else(|| Duration::from_secs(config.poll_interval));
+    let interval = interval_override.unwrap_or_else(|| Duration::from_secs(config.poll_interval));
 
     let runtime_name = config
         .defaults
@@ -81,7 +81,7 @@ pub async fn watch(interval_override: Option<Duration>) -> Result<(), Box<dyn st
         .with_poll_interval(interval);
     let events_tx = lifecycle_builder.events_sender();
 
-    let notifier_registry = notifier_registry_from_config(&config);
+    let notifier_registry = notifier_registry_from_config(config.as_ref());
 
     // Phase F wires SCM into both engines. `LifecycleManager` uses it to
     // drive PR-driven status transitions; `ReactionEngine` uses it to
@@ -89,7 +89,7 @@ pub async fn watch(interval_override: Option<Duration>) -> Result<(), Box<dyn st
     // `Arc<dyn Scm>` shared by both so we only pay for one plugin
     // instance.
     let engine = Arc::new(
-        ReactionEngine::new(config.reactions, runtime.clone(), events_tx)
+        ReactionEngine::new_with_config(Arc::clone(&config), runtime.clone(), events_tx)
             .with_scm(scm.clone())
             .with_notifier_registry(notifier_registry),
     );

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -157,7 +157,7 @@ impl LifecycleManager {
         let Some(engine) = self.reaction_engine.as_ref() else {
             return false;
         };
-        let Some(cfg) = engine.reaction_config("agent-stuck") else {
+        let Some(cfg) = engine.resolve_reaction_config(session, "agent-stuck") else {
             return false;
         };
         let Some(raw) = cfg.threshold.as_deref() else {
@@ -768,7 +768,7 @@ impl LifecycleManager {
             if let Some(next_key) = status_to_reaction_key(to) {
                 match engine.dispatch(session, next_key).await {
                     Ok(Some(outcome))
-                        if should_park_in_merge_failed(engine, to, next_key, &outcome) =>
+                        if should_park_in_merge_failed(engine, session, to, next_key, &outcome) =>
                     {
                         persisted_to = SessionStatus::MergeFailed;
                         session.status = persisted_to;
@@ -953,6 +953,7 @@ fn assemble_observation(
 /// path via the normal ladder.
 fn should_park_in_merge_failed(
     engine: &ReactionEngine,
+    session: &Session,
     to: SessionStatus,
     reaction_key: &str,
     outcome: &ReactionOutcome,
@@ -960,7 +961,7 @@ fn should_park_in_merge_failed(
     to == SessionStatus::Mergeable
         && reaction_key == "approved-and-green"
         && engine
-            .reaction_config(reaction_key)
+            .resolve_reaction_config(session, reaction_key)
             .is_some_and(|c| c.action == ReactionAction::AutoMerge)
         && !outcome.success
         && !outcome.escalated
@@ -1043,9 +1044,7 @@ fn clear_tracker_on_transition(
 const fn is_review_stable(status: SessionStatus) -> bool {
     matches!(
         status,
-        SessionStatus::ChangesRequested
-            | SessionStatus::ReviewPending
-            | SessionStatus::Approved
+        SessionStatus::ChangesRequested | SessionStatus::ReviewPending | SessionStatus::Approved
     )
 }
 

--- a/crates/ao-core/src/reaction_engine.rs
+++ b/crates/ao-core/src/reaction_engine.rs
@@ -73,6 +73,7 @@
 //!   [`default_priority_for_reaction_key`](crate::reactions::default_priority_for_reaction_key).
 
 use crate::{
+    config::AoConfig,
     error::Result,
     events::{OrchestratorEvent, UiNotification},
     notifier::{NotificationPayload, NotifierError, NotifierRegistry},
@@ -136,6 +137,36 @@ pub const fn status_to_reaction_key(status: SessionStatus) -> Option<&'static st
         SessionStatus::Stuck => Some("agent-stuck"),
         _ => None,
     }
+}
+
+/// Merge a global reaction with a project override. Boolean fields always
+/// come from `project`; [`Option`] fields only override when the project
+/// sets `Some(_)`, preserving the global value when the project leaves
+/// `None`.
+fn merge_reaction_config(global: ReactionConfig, project: ReactionConfig) -> ReactionConfig {
+    let mut out = global;
+    out.auto = project.auto;
+    out.action = project.action;
+    if project.message.is_some() {
+        out.message = project.message;
+    }
+    if project.priority.is_some() {
+        out.priority = project.priority;
+    }
+    if project.retries.is_some() {
+        out.retries = project.retries;
+    }
+    if project.escalate_after.is_some() {
+        out.escalate_after = project.escalate_after;
+    }
+    if project.threshold.is_some() {
+        out.threshold = project.threshold;
+    }
+    out.include_summary = project.include_summary;
+    if project.merge_method.is_some() {
+        out.merge_method = project.merge_method;
+    }
+    out
 }
 
 /// Parse a duration string matching the TS reference's `parseDuration`:
@@ -224,10 +255,13 @@ fn build_payload(
 ///
 /// `Arc<ReactionEngine>` is what gets wired into `LifecycleManager`.
 pub struct ReactionEngine {
-    /// Reaction-key → config. Sourced from `AoConfig::reactions` at build
-    /// time. Hot-reload is deferred — a config change today needs a
-    /// lifecycle restart, which matches how the TS reference behaves.
+    /// Global reaction-key → config for [`ReactionEngine::new`] (tests and
+    /// back-compat). Ignored when [`Self::ao_config`] is set — then globals
+    /// are read from `ao_config.reactions`.
     config: HashMap<String, ReactionConfig>,
+    /// Full orchestrator config from [`ReactionEngine::new_with_config`].
+    /// Enables per-session merges with `projects.<id>.reactions`.
+    ao_config: Option<Arc<AoConfig>>,
     /// Runtime used for `SendToAgent`. Required because every reaction
     /// configuration today could choose `send-to-agent` as its action.
     runtime: Arc<dyn Runtime>,
@@ -272,12 +306,66 @@ impl ReactionEngine {
     ) -> Self {
         Self {
             config,
+            ao_config: None,
             runtime,
             events_tx,
             trackers: Mutex::new(HashMap::new()),
             warned_parse_failures: Mutex::new(HashSet::new()),
             scm: None,
             notifier_registry: None,
+        }
+    }
+
+    /// Build an engine with access to per-project `reactions` overrides.
+    ///
+    /// Global rules come from `ao_config.reactions`; for each session,
+    /// [`Self::resolve_reaction_config`] merges in
+    /// `ao_config.projects[session.project_id].reactions` when present.
+    pub fn new_with_config(
+        ao_config: Arc<AoConfig>,
+        runtime: Arc<dyn Runtime>,
+        events_tx: broadcast::Sender<OrchestratorEvent>,
+    ) -> Self {
+        Self {
+            config: HashMap::new(),
+            ao_config: Some(ao_config),
+            runtime,
+            events_tx,
+            trackers: Mutex::new(HashMap::new()),
+            warned_parse_failures: Mutex::new(HashSet::new()),
+            scm: None,
+            notifier_registry: None,
+        }
+    }
+
+    fn global_reactions(&self) -> &HashMap<String, ReactionConfig> {
+        self.ao_config
+            .as_ref()
+            .map(|c| &c.reactions)
+            .unwrap_or(&self.config)
+    }
+
+    /// Effective reaction config for `key` in `session`'s project context.
+    ///
+    /// - Both global and project define `key`: start from global, overlay
+    ///   project — booleans and `action` always from project; each
+    ///   [`Option`] field uses project when `Some`, otherwise keeps global.
+    /// - Only project: return the project entry.
+    /// - Only global: return the global entry.
+    pub fn resolve_reaction_config(&self, session: &Session, key: &str) -> Option<ReactionConfig> {
+        let global = self.global_reactions().get(key).cloned();
+        let project = self
+            .ao_config
+            .as_ref()
+            .and_then(|c| c.projects.get(&session.project_id))
+            .and_then(|p| p.reactions.get(key))
+            .cloned();
+
+        match (global, project) {
+            (Some(g), Some(p)) => Some(merge_reaction_config(g, p)),
+            (Some(g), None) => Some(g),
+            (None, Some(p)) => Some(p),
+            (None, None) => None,
         }
     }
 
@@ -300,20 +388,6 @@ impl ReactionEngine {
         self
     }
 
-    /// Read-only accessor so the lifecycle layer can peek at a single
-    /// reaction config without taking ownership of the whole map.
-    ///
-    /// Phase H uses this in `LifecycleManager::check_stuck` to read the
-    /// `agent-stuck` threshold; it returns `None` when the user has not
-    /// configured that reaction, which `check_stuck` treats as "stuck
-    /// detection is disabled for this session" and silently skips.
-    ///
-    /// Deliberately `pub(crate)` — this is an internal contract with
-    /// the lifecycle manager, not a public extension point.
-    pub(crate) fn reaction_config(&self, reaction_key: &str) -> Option<&ReactionConfig> {
-        self.config.get(reaction_key)
-    }
-
     /// Fire the reaction configured for `reaction_key` against `session`,
     /// if any. Returns `None` when there's no matching config — the
     /// caller (usually `LifecycleManager::transition`) treats that as
@@ -326,7 +400,7 @@ impl ReactionEngine {
         session: &Session,
         reaction_key: &str,
     ) -> Result<Option<ReactionOutcome>> {
-        let Some(cfg) = self.config.get(reaction_key).cloned() else {
+        let Some(cfg) = self.resolve_reaction_config(session, reaction_key) else {
             tracing::debug!(
                 reaction = reaction_key,
                 session = %session.id,
@@ -1002,7 +1076,8 @@ impl ReactionEngine {
 mod tests {
     use super::*;
     use crate::{
-        reactions::{EscalateAfter, ReactionAction, ReactionConfig},
+        config::{AoConfig, ProjectConfig},
+        reactions::{EscalateAfter, EventPriority, ReactionAction, ReactionConfig},
         traits::Runtime,
         types::{now_ms, ActivityState, Session, SessionId, SessionStatus},
     };
@@ -1080,6 +1155,33 @@ mod tests {
         }
     }
 
+    fn minimal_project(reactions: HashMap<String, ReactionConfig>) -> ProjectConfig {
+        ProjectConfig {
+            name: None,
+            repo: "test/test".into(),
+            path: "/tmp/ao-test-project".into(),
+            default_branch: "main".into(),
+            session_prefix: None,
+            branch_namespace: None,
+            runtime: None,
+            agent: None,
+            workspace: None,
+            tracker: None,
+            scm: None,
+            symlinks: vec![],
+            post_create: vec![],
+            agent_config: None,
+            orchestrator: None,
+            worker: None,
+            reactions,
+            agent_rules: None,
+            agent_rules_file: None,
+            orchestrator_rules: None,
+            orchestrator_session_strategy: None,
+            opencode_issue_session_strategy: None,
+        }
+    }
+
     fn build(
         cfg_map: HashMap<String, ReactionConfig>,
     ) -> (
@@ -1134,6 +1236,85 @@ mod tests {
         assert_eq!(status_to_reaction_key(SessionStatus::NeedsInput), None);
         assert_eq!(status_to_reaction_key(SessionStatus::MergeFailed), None);
         assert_eq!(status_to_reaction_key(SessionStatus::Errored), None);
+    }
+
+    #[test]
+    fn resolve_reaction_config_merges_global_and_project() {
+        let mut global = ReactionConfig::new(ReactionAction::SendToAgent);
+        global.message = Some("global-msg".into());
+        global.retries = Some(3);
+        global.auto = true;
+        global.priority = Some(EventPriority::Warning);
+
+        let mut proj_cfg = ReactionConfig::new(ReactionAction::Notify);
+        proj_cfg.message = None;
+        proj_cfg.retries = None;
+        proj_cfg.auto = false;
+        proj_cfg.priority = Some(EventPriority::Urgent);
+
+        let mut reactions = HashMap::new();
+        reactions.insert("ci-failed".into(), global);
+
+        let mut proj_reactions = HashMap::new();
+        proj_reactions.insert("ci-failed".into(), proj_cfg);
+
+        let mut projects = HashMap::new();
+        projects.insert("demo".into(), minimal_project(proj_reactions));
+
+        let ao = AoConfig {
+            reactions,
+            projects,
+            ..Default::default()
+        };
+
+        let (tx, _rx) = broadcast::channel(4);
+        let engine = ReactionEngine::new_with_config(
+            Arc::new(ao),
+            Arc::new(RecordingRuntime::new()) as Arc<dyn Runtime>,
+            tx,
+        );
+        let session = fake_session("s1");
+
+        let resolved = engine
+            .resolve_reaction_config(&session, "ci-failed")
+            .expect("merged config");
+
+        assert_eq!(resolved.action, ReactionAction::Notify);
+        assert!(!resolved.auto);
+        assert_eq!(resolved.message.as_deref(), Some("global-msg"));
+        assert_eq!(resolved.retries, Some(3));
+        assert_eq!(resolved.priority, Some(EventPriority::Urgent));
+    }
+
+    #[test]
+    fn resolve_reaction_config_project_only_key() {
+        let mut proj_cfg = ReactionConfig::new(ReactionAction::Notify);
+        proj_cfg.message = Some("project-local".into());
+
+        let mut proj_reactions = HashMap::new();
+        proj_reactions.insert("only-in-project".into(), proj_cfg);
+
+        let mut projects = HashMap::new();
+        projects.insert("demo".into(), minimal_project(proj_reactions));
+
+        let ao = AoConfig {
+            projects,
+            ..Default::default()
+        };
+
+        let (tx, _rx) = broadcast::channel(4);
+        let engine = ReactionEngine::new_with_config(
+            Arc::new(ao),
+            Arc::new(RecordingRuntime::new()) as Arc<dyn Runtime>,
+            tx,
+        );
+        let session = fake_session("s1");
+
+        let resolved = engine
+            .resolve_reaction_config(&session, "only-in-project")
+            .expect("project-only reaction");
+        assert_eq!(resolved.action, ReactionAction::Notify);
+        assert_eq!(resolved.message.as_deref(), Some("project-local"));
     }
 
     // ---------- Phase H: parse_duration ---------- //


### PR DESCRIPTION
## Summary
- Implement project-level reaction resolution: global `reactions[key]` provides defaults and `projects.<id>.reactions[key]` overrides (project wins).
- Wire CLI lifecycle (`watch`, `dashboard`) to pass full `AoConfig` into `ReactionEngine`.
- Add unit tests covering merge behavior and project-only reaction keys.

## Test plan
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`

Closes #75.

Made with [Cursor](https://cursor.com)