### PR TITLE
feat(scm-github): add is_resolved via GraphQL reviewThreads (fixes #76)

### DIFF
--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -42,8 +42,8 @@ use ao_core::{
     AoError, CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest, Result, Review,
     ReviewComment, ReviewDecision, Scm, ScmObservation, Session,
 };
-use std::collections::HashMap;
 use async_trait::async_trait;
+use std::collections::HashMap;
 use std::path::Path;
 use std::time::Duration;
 use tokio::process::Command;
@@ -241,42 +241,20 @@ impl Scm for GitHubScm {
     }
 
     async fn pending_comments(&self, pr: &PullRequest) -> Result<Vec<ReviewComment>> {
-        // Phase B uses the REST `comments` endpoint — simpler to parse than
-        // the GraphQL `reviewThreads` query, at the cost of losing the
-        // resolved/unresolved flag. Everything we return has
-        // `is_resolved: false`; see `parse::parse_review_comments`.
-        //
-        // TODO(reaction-engine, Phase D): the `changes-requested` reaction
-        // MUST dedupe by `ReviewComment::id` across ticks. Because
-        // `is_resolved` is always `false` here, a naive reaction would
-        // spam the agent every poll cycle for already-addressed comments.
-        // Either fix at the source (swap to the GraphQL `reviewThreads`
-        // query that does expose `isResolved`) or at the consumer
-        // (ReactionTracker remembers seen ids and only fires for new ones).
-        // `docs/reactions.md` calls this out too.
-        //
-        // Pagination: REST returns ≤100 per page. A PR with >100 comments
-        // must be walked page-by-page; stopping early either on empty or
-        // under-full page. Mirrors TS lines 880–906.
-        const PER_PAGE: usize = 100;
-        // Defensive ceiling: 100 pages × 100 = 10k review comments. If a
-        // real PR ever hits this we have bigger problems than pagination.
-        const MAX_PAGES: u32 = 100;
-        let mut all = Vec::new();
-        for page in 1..=MAX_PAGES {
-            let endpoint = format!(
-                "repos/{}/{}/pulls/{}/comments?per_page={PER_PAGE}&page={page}",
-                pr.owner, pr.repo, pr.number
-            );
-            let json = gh(&["api", "--method", "GET", &endpoint]).await?;
-            let page_comments = parse::parse_review_comments(&json)?;
-            let got = page_comments.len();
-            all.extend(page_comments);
-            if got < PER_PAGE {
-                break;
+        match pending_comments_graphql(pr).await {
+            Ok(comments) => Ok(comments),
+            Err(e) => {
+                // Keep resilience: GH GraphQL can fail due to auth scope,
+                // enterprise quirks, or transient outages. Fall back to the
+                // REST endpoint so consumers still get *some* signal (but
+                // without resolution status).
+                tracing::warn!(
+                    "pending_comments: GraphQL reviewThreads failed for PR #{} (falling back to REST): {e}",
+                    pr.number
+                );
+                pending_comments_rest(pr).await
             }
         }
-        Ok(all)
     }
 
     async fn mergeability(&self, pr: &PullRequest) -> Result<MergeReadiness> {
@@ -493,6 +471,94 @@ fn repo_flag(pr: &PullRequest) -> String {
 /// stderr suffix (trimmed) so callers get an actionable message.
 async fn gh(args: &[&str]) -> Result<String> {
     run("gh", args, None).await
+}
+
+async fn pending_comments_rest(pr: &PullRequest) -> Result<Vec<ReviewComment>> {
+    // REST fallback: loses thread resolution status (`is_resolved` will be
+    // `false` for everything). Kept for resilience.
+    const PER_PAGE: usize = 100;
+    const MAX_PAGES: u32 = 100;
+    let mut all = Vec::new();
+    for page in 1..=MAX_PAGES {
+        let endpoint = format!(
+            "repos/{}/{}/pulls/{}/comments?per_page={PER_PAGE}&page={page}",
+            pr.owner, pr.repo, pr.number
+        );
+        let json = gh(&["api", "--method", "GET", &endpoint]).await?;
+        let page_comments = parse::parse_review_comments(&json)?;
+        let got = page_comments.len();
+        all.extend(page_comments);
+        if got < PER_PAGE {
+            break;
+        }
+    }
+    Ok(all)
+}
+
+const REVIEW_THREADS_QUERY: &str = r#"
+query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: String) {
+  repository(owner: $owner, name: $name) {
+    pullRequest(number: $number) {
+      reviewThreads(first: 100, after: $after) {
+        pageInfo { hasNextPage endCursor }
+        nodes {
+          isResolved
+          comments(first: 100) {
+            nodes {
+              id
+              databaseId
+              body
+              url
+              path
+              line
+              originalLine
+              position
+              originalPosition
+              author { login }
+            }
+          }
+        }
+      }
+    }
+  }
+}
+"#;
+
+async fn pending_comments_graphql(pr: &PullRequest) -> Result<Vec<ReviewComment>> {
+    const MAX_PAGES: u32 = 100;
+    let mut after: Option<String> = None;
+    let mut all = Vec::new();
+
+    for _ in 0..MAX_PAGES {
+        let mut args: Vec<String> = vec!["api".into(), "graphql".into()];
+        args.push("-f".into());
+        args.push(format!("owner={}", pr.owner));
+        args.push("-f".into());
+        args.push(format!("name={}", pr.repo));
+        args.push("-F".into());
+        args.push(format!("number={}", pr.number));
+        if let Some(ref cursor) = after {
+            args.push("-f".into());
+            args.push(format!("after={cursor}"));
+        }
+        args.push("-f".into());
+        args.push(format!("query={REVIEW_THREADS_QUERY}"));
+
+        let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
+        let json = gh(&args_refs).await?;
+        let page = parse::parse_review_threads_page(&json)?;
+        all.extend(page.comments);
+
+        if !page.has_next_page {
+            break;
+        }
+        after = page.end_cursor;
+        if after.is_none() {
+            break;
+        }
+    }
+
+    Ok(all)
 }
 
 /// Run `git -C <cwd> <args>`. Separate from `gh` because `git` is the

--- a/crates/plugins/scm-github/src/parse.rs
+++ b/crates/plugins/scm-github/src/parse.rs
@@ -31,6 +31,16 @@ fn bad(msg: impl Into<String>, err: impl std::fmt::Display) -> AoError {
 }
 
 // ---------------------------------------------------------------------------
+// GraphQL helpers
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+struct GraphQlError {
+    #[serde(default)]
+    message: String,
+}
+
+// ---------------------------------------------------------------------------
 // PR list / view → PullRequest
 // ---------------------------------------------------------------------------
 
@@ -373,6 +383,175 @@ pub(crate) fn parse_review_comments(json: &str) -> Result<Vec<ReviewComment>> {
             url: c.html_url,
         })
         .collect())
+}
+
+// ---------------------------------------------------------------------------
+// Review threads (GraphQL) — includes resolution status
+// ---------------------------------------------------------------------------
+
+#[derive(Debug)]
+pub(crate) struct ReviewThreadsPage {
+    pub comments: Vec<ReviewComment>,
+    pub end_cursor: Option<String>,
+    pub has_next_page: bool,
+}
+
+/// Parse `gh api graphql` response for a `reviewThreads` query.
+///
+/// Flattens threads → comments and stamps each comment with the thread's
+/// `isResolved` value.
+pub(crate) fn parse_review_threads_page(json: &str) -> Result<ReviewThreadsPage> {
+    #[derive(Debug, Deserialize)]
+    struct Resp {
+        #[serde(default)]
+        data: Option<Data>,
+        #[serde(default)]
+        errors: Option<Vec<GraphQlError>>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Data {
+        #[serde(default)]
+        repository: Option<Repo>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Repo {
+        #[serde(default)]
+        #[serde(rename = "pullRequest")]
+        pull_request: Option<Pr>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct Pr {
+        #[serde(default)]
+        #[serde(rename = "reviewThreads")]
+        review_threads: Threads,
+    }
+
+    #[derive(Debug, Deserialize, Default)]
+    struct Threads {
+        #[serde(default)]
+        nodes: Vec<ThreadNode>,
+        #[serde(default)]
+        #[serde(rename = "pageInfo")]
+        page_info: PageInfo,
+    }
+
+    #[derive(Debug, Deserialize, Default)]
+    struct PageInfo {
+        #[serde(default)]
+        #[serde(rename = "hasNextPage")]
+        has_next_page: bool,
+        #[serde(default)]
+        #[serde(rename = "endCursor")]
+        end_cursor: Option<String>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct ThreadNode {
+        #[serde(default)]
+        #[serde(rename = "isResolved")]
+        is_resolved: bool,
+        #[serde(default)]
+        comments: CommentConn,
+    }
+
+    #[derive(Debug, Deserialize, Default)]
+    struct CommentConn {
+        #[serde(default)]
+        nodes: Vec<CommentNode>,
+    }
+
+    #[derive(Debug, Deserialize)]
+    struct CommentNode {
+        #[serde(default)]
+        id: String,
+        #[serde(default)]
+        #[serde(rename = "databaseId")]
+        database_id: Option<u64>,
+        #[serde(default)]
+        body: String,
+        #[serde(default)]
+        url: String,
+        #[serde(default)]
+        path: Option<String>,
+        #[serde(default)]
+        line: Option<u32>,
+        #[serde(default)]
+        #[serde(rename = "originalLine")]
+        original_line: Option<u32>,
+        #[serde(default)]
+        position: Option<u32>,
+        #[serde(default)]
+        #[serde(rename = "originalPosition")]
+        original_position: Option<u32>,
+        #[serde(default)]
+        author: Option<RawLogin>,
+    }
+
+    let resp: Resp = serde_json::from_str(json).map_err(|e| bad("parse review threads", e))?;
+
+    if let Some(errors) = resp.errors {
+        let msgs: Vec<String> = errors
+            .into_iter()
+            .map(|e| e.message)
+            .filter(|m| !m.trim().is_empty())
+            .collect();
+        if !msgs.is_empty() {
+            return Err(AoError::Scm(format!("GraphQL errors: {}", msgs.join("; "))));
+        }
+    }
+
+    let threads = resp
+        .data
+        .and_then(|d| d.repository)
+        .and_then(|r| r.pull_request)
+        .map(|p| p.review_threads)
+        .unwrap_or(Threads {
+            nodes: Vec::new(),
+            page_info: PageInfo {
+                has_next_page: false,
+                end_cursor: None,
+            },
+        });
+
+    let mut out = Vec::new();
+    for t in threads.nodes {
+        for c in t.comments.nodes {
+            let id = c
+                .database_id
+                .map(|n| n.to_string())
+                .filter(|s| !s.is_empty())
+                .unwrap_or(c.id);
+            let author = c
+                .author
+                .map(|a| a.login)
+                .filter(|s| !s.is_empty())
+                .unwrap_or_else(|| "unknown".to_string());
+            let path = c.path.filter(|p| !p.trim().is_empty());
+            let line = c
+                .line
+                .or(c.original_line)
+                .or(c.position)
+                .or(c.original_position);
+            out.push(ReviewComment {
+                id,
+                author,
+                body: c.body,
+                path,
+                line,
+                is_resolved: t.is_resolved,
+                url: c.url,
+            });
+        }
+    }
+
+    Ok(ReviewThreadsPage {
+        comments: out,
+        end_cursor: threads.page_info.end_cursor,
+        has_next_page: threads.page_info.has_next_page,
+    })
 }
 
 // ---------------------------------------------------------------------------
@@ -801,5 +980,38 @@ mod tests {
         assert_eq!(raw.review_decision, None);
         assert_eq!(raw.merge_state_status, "");
         assert!(!raw.is_draft);
+    }
+
+    #[test]
+    fn parse_review_threads_page_flattens_and_sets_resolution_flag() {
+        let json = include_str!("../tests/fixtures/review_threads_page1.json");
+        let page = parse_review_threads_page(json).unwrap();
+        assert!(page.has_next_page);
+        assert_eq!(page.end_cursor.as_deref(), Some("CURSOR_1"));
+        assert_eq!(page.comments.len(), 3);
+
+        // Thread 1 is unresolved → comments unresolved
+        assert!(!page.comments[0].is_resolved);
+        assert_eq!(page.comments[0].id, "111");
+        assert_eq!(page.comments[0].author, "alice");
+        assert_eq!(page.comments[0].path.as_deref(), Some("src/lib.rs"));
+        assert_eq!(page.comments[0].line, Some(10));
+
+        // Thread 2 is resolved → its comment resolved
+        assert!(page.comments[2].is_resolved);
+        assert_eq!(page.comments[2].id, "333");
+        assert_eq!(page.comments[2].author, "unknown"); // null author
+        assert_eq!(page.comments[2].path.as_deref(), Some("src/main.rs"));
+        // line is null, originalLine present
+        assert_eq!(page.comments[2].line, Some(42));
+    }
+
+    #[test]
+    fn parse_review_threads_page_empty_data_is_ok() {
+        let json = r#"{"data":{"repository":null}}"#;
+        let page = parse_review_threads_page(json).unwrap();
+        assert!(!page.has_next_page);
+        assert!(page.end_cursor.is_none());
+        assert!(page.comments.is_empty());
     }
 }

--- a/crates/plugins/scm-github/tests/fixtures/review_threads_page1.json
+++ b/crates/plugins/scm-github/tests/fixtures/review_threads_page1.json
@@ -1,0 +1,66 @@
+{
+  "data": {
+    "repository": {
+      "pullRequest": {
+        "reviewThreads": {
+          "pageInfo": {
+            "hasNextPage": true,
+            "endCursor": "CURSOR_1"
+          },
+          "nodes": [
+            {
+              "isResolved": false,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "MDExOlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDE=",
+                    "databaseId": 111,
+                    "body": "nit: rename this",
+                    "url": "https://github.com/acme/widgets/pull/1#discussion_r111",
+                    "path": "src/lib.rs",
+                    "line": 10,
+                    "originalLine": 9,
+                    "position": 5,
+                    "originalPosition": 4,
+                    "author": { "login": "alice" }
+                  },
+                  {
+                    "id": "MDExOlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDI=",
+                    "databaseId": 222,
+                    "body": "please add a test",
+                    "url": "https://github.com/acme/widgets/pull/1#discussion_r222",
+                    "path": "src/lib.rs",
+                    "line": null,
+                    "originalLine": null,
+                    "position": 7,
+                    "originalPosition": 6,
+                    "author": { "login": "bob" }
+                  }
+                ]
+              }
+            },
+            {
+              "isResolved": true,
+              "comments": {
+                "nodes": [
+                  {
+                    "id": "MDExOlB1bGxSZXF1ZXN0UmV2aWV3Q29tbWVudDM=",
+                    "databaseId": 333,
+                    "body": "resolved thread comment",
+                    "url": "https://github.com/acme/widgets/pull/1#discussion_r333",
+                    "path": "src/main.rs",
+                    "line": null,
+                    "originalLine": 42,
+                    "position": null,
+                    "originalPosition": null,
+                    "author": null
+                  }
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Fetch GitHub PR review threads via GraphQL `reviewThreads` and map `isResolved` into `ReviewComment.is_resolved`.
- Keep a REST fallback for resilience when GraphQL fails.
- Add fixture-based unit tests for GraphQL payload parsing.

## Test plan
- `cargo test -p ao-plugin-scm-github`
- `cargo clippy -p ao-plugin-scm-github --all-targets -- -D warnings`


Made with [Cursor](https://cursor.com)