### PR TITLE
feat(workspace): run symlinks + postCreate hooks

### DIFF
--- a/crates/ao-cli/src/commands/spawn.rs
+++ b/crates/ao-cli/src/commands/spawn.rs
@@ -20,8 +20,8 @@ use crate::cli::plugins::{select_agent, select_runtime, DuplicateIssue};
 use crate::cli::printing::{print_config_warnings, short_id};
 use crate::cli::project::{resolve_project_id, resolve_repo_root};
 use crate::cli::spawn_helpers::{
-    git_safe_branch_fragment, git_safe_branch_namespace, shell_escape_single_quotes, spawn_template_by_name,
-    tmux_send_keys_literal_no_enter,
+    git_safe_branch_fragment, git_safe_branch_namespace, shell_escape_single_quotes,
+    spawn_template_by_name, tmux_send_keys_literal_no_enter,
 };
 #[allow(clippy::too_many_arguments)]
 pub async fn spawn(
@@ -182,7 +182,12 @@ pub async fn spawn(
     // With namespace: `<ns>/<shortid>/<issue_branch>` (more obviously machine-owned)
     let branch_namespace = project_config
         .and_then(|p| p.branch_namespace.clone())
-        .or_else(|| ao_config.defaults.as_ref().and_then(|d| d.branch_namespace.clone()))
+        .or_else(|| {
+            ao_config
+                .defaults
+                .as_ref()
+                .and_then(|d| d.branch_namespace.clone())
+        })
         .map(|s| git_safe_branch_namespace(&s));
     let branch = match (branch_namespace.as_deref(), branch_prefix) {
         (Some(ns), Some(b)) => {
@@ -205,12 +210,20 @@ pub async fn spawn(
 
     // ---- 3. Workspace: git worktree add ----
     let workspace = WorktreeWorkspace::new();
+    let symlinks = project_config
+        .map(|p| p.symlinks.clone())
+        .unwrap_or_default();
+    let post_create = project_config
+        .map(|p| p.post_create.clone())
+        .unwrap_or_default();
     let workspace_cfg = WorkspaceCreateConfig {
         project_id: project.clone(),
         session_id: short_id.clone(),
         branch: branch.clone(),
         repo_path: repo_path.clone(),
         default_branch,
+        symlinks,
+        post_create,
     };
 
     println!("→ creating worktree...");

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -98,8 +98,15 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             )
             .await
         }
-        Command::Status { project, pr, cost, all } => commands::status::status(project, pr, cost, all).await,
-        Command::Watch { interval } => commands::watch::watch(interval.map(Duration::from_secs)).await,
+        Command::Status {
+            project,
+            pr,
+            cost,
+            all,
+        } => commands::status::status(project, pr, cost, all).await,
+        Command::Watch { interval } => {
+            commands::watch::watch(interval.map(Duration::from_secs)).await
+        }
         Command::Dashboard {
             port,
             interval,

--- a/crates/ao-core/src/lib.rs
+++ b/crates/ao-core/src/lib.rs
@@ -26,13 +26,13 @@ pub mod scm_transitions;
 pub mod session_manager;
 pub mod traits;
 pub mod types;
+pub mod workspace_hooks;
 
 pub use config::{
     default_agent_rules, default_orchestrator_rules, default_reactions, default_routing,
     detect_git_repo, generate_config, install_skills, AgentConfig, AoConfig, ConfigWarning,
     DefaultsConfig, LoadedConfig, ProjectConfig, RoleAgentConfig, ScmWebhookConfig,
 };
-pub use parity_session_strategy::{OpencodeIssueSessionStrategy, OrchestratorSessionStrategy};
 pub use error::{AoError, Result};
 pub use events::{OrchestratorEvent, TerminationReason};
 pub use lifecycle::{LifecycleHandle, LifecycleManager, DEFAULT_POLL_INTERVAL};
@@ -41,6 +41,7 @@ pub use notifier::{
     NotificationPayload, NotificationRouting, Notifier, NotifierError, NotifierRegistry,
 };
 pub use orchestrator_prompt::{generate_orchestrator_prompt, OrchestratorPromptConfig};
+pub use parity_session_strategy::{OpencodeIssueSessionStrategy, OrchestratorSessionStrategy};
 pub use prompt_builder::build_prompt;
 pub use reaction_engine::{status_to_reaction_key, ReactionEngine};
 pub use reactions::{

--- a/crates/ao-core/src/types.rs
+++ b/crates/ao-core/src/types.rs
@@ -305,6 +305,12 @@ pub struct WorkspaceCreateConfig {
     pub branch: String,
     pub repo_path: PathBuf,
     pub default_branch: String,
+    /// Relative paths (from `repo_path`) to symlink into the workspace
+    /// root. Mirrors ao-ts `symlinks`.
+    pub symlinks: Vec<String>,
+    /// Shell commands to run after the workspace is created. Mirrors
+    /// ao-ts `postCreate`.
+    pub post_create: Vec<String>,
 }
 
 #[cfg(test)]

--- a/crates/ao-core/src/workspace_hooks.rs
+++ b/crates/ao-core/src/workspace_hooks.rs
@@ -1,0 +1,252 @@
+use crate::{AoError, Result};
+use std::path::{Component, Path};
+use tokio::process::Command;
+
+/// Create configured symlinks and execute `postCreate` commands for a
+/// workspace, matching ao-ts behavior at a pragmatic level.
+///
+/// - `symlinks` entries are treated as *relative paths* from `project_root`
+///   (git repo root) to create inside `workspace_root`.
+/// - Each `postCreate` command is executed via a shell with
+///   `workspace_root` as the current working directory.
+pub async fn apply_workspace_hooks(
+    project_root: &Path,
+    workspace_root: &Path,
+    symlinks: &[String],
+    post_create: &[String],
+) -> Result<()> {
+    for entry in symlinks {
+        validate_symlink_entry(entry)?;
+        let src = project_root.join(entry);
+        let dest = workspace_root.join(entry);
+
+        if !src.exists() {
+            return Err(AoError::Workspace(format!(
+                "symlink source missing for entry {entry:?}: {}",
+                src.display()
+            )));
+        }
+
+        // Avoid clobbering anything users may already have staged into a
+        // workspace. Workspaces are expected to be fresh per session.
+        if dest.symlink_metadata().is_ok() {
+            return Err(AoError::Workspace(format!(
+                "workspace path already exists for symlink {entry:?}: {}",
+                dest.display()
+            )));
+        }
+
+        if let Some(parent) = dest.parent() {
+            tokio::fs::create_dir_all(parent).await?;
+        }
+
+        create_symlink(&src, &dest).map_err(|e| {
+            AoError::Workspace(format!(
+                "failed to create symlink {entry:?}: {} -> {} ({e})",
+                src.display(),
+                dest.display()
+            ))
+        })?;
+    }
+
+    for cmd in post_create {
+        run_post_create_command(workspace_root, cmd).await?;
+    }
+
+    Ok(())
+}
+
+/// Reject `symlinks` path segments that could escape the workspace root.
+///
+/// We only allow *relative* paths made of `Normal` components and we
+/// disallow:
+/// - absolute paths
+/// - `..` parent traversal
+/// - `.` segments (keeps behavior predictable)
+pub fn validate_symlink_entry(entry: &str) -> Result<()> {
+    let p = Path::new(entry);
+
+    if entry.is_empty() {
+        return Err(AoError::Workspace("symlink entry must not be empty".into()));
+    }
+    // Reject `.` segments explicitly. `Path::components()` may represent
+    // `./` inconsistently (e.g. as `CurDir` vs `Normal(".")`) across
+    // platforms, so we also validate at the string level.
+    if entry == "." || entry.starts_with("./") || entry.contains("/./") || entry.ends_with("/.") {
+        return Err(AoError::Workspace(format!(
+            "symlink entry must not contain '.' segments: {entry:?}"
+        )));
+    }
+    if p.is_absolute() {
+        return Err(AoError::Workspace(format!(
+            "symlink entry must be relative, got {entry:?}"
+        )));
+    }
+
+    for c in p.components() {
+        match c {
+            Component::Normal(s) => {
+                if s == "." {
+                    return Err(AoError::Workspace(format!(
+                        "symlink entry must not contain '.': {entry:?}"
+                    )));
+                }
+            }
+            Component::CurDir => {
+                return Err(AoError::Workspace(format!(
+                    "symlink entry must not contain '.': {entry:?}"
+                )));
+            }
+            Component::ParentDir => {
+                return Err(AoError::Workspace(format!(
+                    "symlink entry must not contain '..': {entry:?}"
+                )));
+            }
+            Component::RootDir | Component::Prefix(_) => {
+                return Err(AoError::Workspace(format!(
+                    "symlink entry must not contain absolute components: {entry:?}"
+                )));
+            }
+        }
+    }
+
+    Ok(())
+}
+
+fn create_symlink(src: &Path, dest: &Path) -> std::io::Result<()> {
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::symlink;
+        symlink(src, dest)
+    }
+
+    #[cfg(windows)]
+    {
+        use std::os::windows::fs::{symlink_dir, symlink_file};
+
+        let src_meta = std::fs::metadata(src)?;
+        if src_meta.is_dir() {
+            symlink_dir(src, dest)
+        } else {
+            symlink_file(src, dest)
+        }
+    }
+}
+
+async fn run_post_create_command(workspace_root: &Path, cmd: &str) -> Result<()> {
+    // User-provided string: intended to be executed intentionally via shell.
+    let mut command = shell_command();
+    command.arg(cmd).current_dir(workspace_root);
+
+    let output = command
+        .output()
+        .await
+        .map_err(|e| AoError::Workspace(format!("postCreate spawn failed: {e}")))?;
+
+    if !output.status.success() {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+
+        return Err(AoError::Workspace(format!(
+            "postCreate command failed (exit={}) cmd={cmd:?}\nstdout:\n{}\nstderr:\n{}",
+            output.status,
+            truncate(&stdout, 4000),
+            truncate(&stderr, 4000),
+        )));
+    }
+
+    Ok(())
+}
+
+fn truncate(s: &str, max: usize) -> String {
+    let mut iter = s.chars();
+    let mut out = String::new();
+    for _ in 0..max {
+        match iter.next() {
+            Some(ch) => out.push(ch),
+            None => return out,
+        }
+    }
+
+    // We consumed `max` chars and there may be more.
+    out.push('…');
+    out
+}
+
+/// Shell that can interpret `cmd` strings.
+fn shell_command() -> Command {
+    #[cfg(unix)]
+    {
+        let mut c = Command::new("sh");
+        c.arg("-c");
+        c
+    }
+
+    #[cfg(not(unix))]
+    {
+        let mut c = Command::new("cmd");
+        c.args(["/C"]);
+        c
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::path::PathBuf;
+    use std::sync::atomic::{AtomicU64, Ordering};
+
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+
+    fn unique_dir(label: &str) -> PathBuf {
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("ao-rs-hooks-{label}-{n}"))
+    }
+
+    #[test]
+    fn validate_rejects_empty() {
+        assert!(validate_symlink_entry("").is_err());
+    }
+
+    #[test]
+    fn validate_accepts_relative_normals() {
+        assert!(validate_symlink_entry(".env").is_ok());
+        assert!(validate_symlink_entry("dir/file.txt").is_ok());
+    }
+
+    #[test]
+    fn validate_rejects_traversal() {
+        for s in ["../x", "a/../b", "./x", "a/./b", "..", ""] {
+            if s.is_empty() {
+                continue;
+            }
+            assert!(validate_symlink_entry(s).is_err(), "expected reject: {s}");
+        }
+    }
+
+    #[tokio::test]
+    async fn apply_fails_when_source_missing() {
+        let project_root = unique_dir("project-missing");
+        let workspace_root = unique_dir("ws-missing");
+        let _ = tokio::fs::create_dir_all(&project_root).await;
+        let _ = tokio::fs::create_dir_all(&workspace_root).await;
+
+        let err = apply_workspace_hooks(
+            &project_root,
+            &workspace_root,
+            &vec![".env".into()],
+            &vec![],
+        )
+        .await
+        .unwrap_err();
+
+        let msg = err.to_string();
+        assert!(
+            msg.contains("symlink source missing"),
+            "unexpected error: {msg}"
+        );
+
+        let _ = tokio::fs::remove_dir_all(&project_root).await;
+        let _ = tokio::fs::remove_dir_all(&workspace_root).await;
+    }
+}

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -119,6 +119,8 @@ pub async fn spawn_session(
         branch: branch.clone(),
         repo_path: repo_path.clone(),
         default_branch: body.default_branch.clone(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let workspace_path = workspace

--- a/crates/plugins/scm-github/src/graphql_batch.rs
+++ b/crates/plugins/scm-github/src/graphql_batch.rs
@@ -140,9 +140,7 @@ pub fn clear_caches() {
 /// Returns a map keyed by `"{owner}/{repo}#{number}"` with the observation
 /// for each PR that was successfully fetched. Missing entries should fall
 /// back to individual REST calls.
-pub async fn enrich_prs_batch(
-    prs: &[PullRequest],
-) -> Result<HashMap<String, ScmObservation>> {
+pub async fn enrich_prs_batch(prs: &[PullRequest]) -> Result<HashMap<String, ScmObservation>> {
     if prs.is_empty() {
         return Ok(HashMap::new());
     }
@@ -247,9 +245,7 @@ async fn check_pr_list_etag(owner: &str, repo: &str) -> bool {
         state.pr_list_etags.get(&repo_key)
     };
 
-    let url = format!(
-        "repos/{repo_key}/pulls?state=open&sort=updated&direction=desc&per_page=1"
-    );
+    let url = format!("repos/{repo_key}/pulls?state=open&sort=updated&direction=desc&per_page=1");
     let mut args = vec!["api", "--method", "GET", &url, "-i"];
     let header;
     if let Some(ref etag) = cached_etag {
@@ -407,9 +403,7 @@ fn generate_batch_query(prs: &[PullRequest]) -> (String, Vec<(String, serde_json
     (query, variables)
 }
 
-async fn run_graphql_batches(
-    prs: &[PullRequest],
-) -> Result<HashMap<String, ScmObservation>> {
+async fn run_graphql_batches(prs: &[PullRequest]) -> Result<HashMap<String, ScmObservation>> {
     let mut result = HashMap::new();
 
     for chunk in prs.chunks(MAX_BATCH_SIZE) {
@@ -438,10 +432,7 @@ async fn run_graphql_batches(
                 }
             }
             Err(e) => {
-                tracing::warn!(
-                    "[GraphQL Batch] Batch failed ({} PRs): {e}",
-                    chunk.len()
-                );
+                tracing::warn!("[GraphQL Batch] Batch failed ({} PRs): {e}", chunk.len());
                 // Continue — individual REST calls will be the fallback
             }
         }
@@ -450,9 +441,7 @@ async fn run_graphql_batches(
     Ok(result)
 }
 
-async fn execute_batch_query(
-    prs: &[PullRequest],
-) -> Result<HashMap<String, serde_json::Value>> {
+async fn execute_batch_query(prs: &[PullRequest]) -> Result<HashMap<String, serde_json::Value>> {
     let (query, variables) = generate_batch_query(prs);
 
     let mut args: Vec<String> = vec!["api".into(), "graphql".into()];
@@ -471,8 +460,8 @@ async fn execute_batch_query(
     let args_refs: Vec<&str> = args.iter().map(|s| s.as_str()).collect();
     let stdout = run_gh(&args_refs).await?;
 
-    let parsed: serde_json::Value =
-        serde_json::from_str(&stdout).map_err(|e| ao_core::AoError::Scm(format!("GraphQL JSON parse: {e}")))?;
+    let parsed: serde_json::Value = serde_json::from_str(&stdout)
+        .map_err(|e| ao_core::AoError::Scm(format!("GraphQL JSON parse: {e}")))?;
 
     if let Some(errors) = parsed.get("errors").and_then(|e| e.as_array()) {
         if !errors.is_empty() {
@@ -503,10 +492,14 @@ async fn execute_batch_query(
 // Response parsing
 // ---------------------------------------------------------------------------
 
-fn extract_pr_enrichment(
-    pr: &serde_json::Value,
-) -> Option<(ScmObservation, Option<String>)> {
-    let state = match pr.get("state").and_then(|s| s.as_str()).unwrap_or("").to_uppercase().as_str() {
+fn extract_pr_enrichment(pr: &serde_json::Value) -> Option<(ScmObservation, Option<String>)> {
+    let state = match pr
+        .get("state")
+        .and_then(|s| s.as_str())
+        .unwrap_or("")
+        .to_uppercase()
+        .as_str()
+    {
         "MERGED" => PrState::Merged,
         "CLOSED" => PrState::Closed,
         _ => PrState::Open,
@@ -607,7 +600,15 @@ fn extract_pr_enrichment(
         blockers,
     };
 
-    Some((ScmObservation { state, ci, review, readiness }, head_sha))
+    Some((
+        ScmObservation {
+            state,
+            ci,
+            review,
+            readiness,
+        },
+        head_sha,
+    ))
 }
 
 fn ci_label(ci: CiStatus) -> &'static str {
@@ -759,7 +760,8 @@ mod tests {
 
     #[test]
     fn extract_etag_from_headers() {
-        let response = "HTTP/2 200\r\netag: W/\"abc123\"\r\ncontent-type: application/json\r\n\r\n{}";
+        let response =
+            "HTTP/2 200\r\netag: W/\"abc123\"\r\ncontent-type: application/json\r\n\r\n{}";
         assert_eq!(extract_etag(response), Some("W/\"abc123\"".into()));
     }
 

--- a/crates/plugins/workspace-clone/src/lib.rs
+++ b/crates/plugins/workspace-clone/src/lib.rs
@@ -9,6 +9,7 @@
 //! repo but scoped to the same minimal surface as the worktree plugin:
 //! no symlinks, no postCreate hooks, no list/restore.
 
+use ao_core::workspace_hooks::apply_workspace_hooks;
 use ao_core::{AoError, Result, Workspace, WorkspaceCreateConfig};
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
@@ -108,6 +109,15 @@ impl Workspace for CloneWorkspace {
             branch = %cfg.branch,
             "workspace clone created"
         );
+
+        // Workspace hooks: symlinks + `postCreate`.
+        if let Err(hook_err) =
+            apply_workspace_hooks(&cfg.repo_path, &clone_path, &cfg.symlinks, &cfg.post_create)
+                .await
+        {
+            let _ = self.destroy(&clone_path).await;
+            return Err(hook_err);
+        }
 
         Ok(clone_path)
     }

--- a/crates/plugins/workspace-clone/tests/integration.rs
+++ b/crates/plugins/workspace-clone/tests/integration.rs
@@ -56,6 +56,8 @@ async fn create_and_destroy_clone() {
         branch: "feat-test".to_string(),
         repo_path: repo.clone(),
         default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let path = workspace.create(&cfg).await.expect("create failed");
@@ -100,6 +102,8 @@ async fn shallow_clone_creates_valid_workspace() {
         branch: "feat-shallow".to_string(),
         repo_path: repo.clone(),
         default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let path = workspace.create(&cfg).await.expect("shallow create failed");
@@ -128,6 +132,8 @@ async fn rejects_unsafe_session_id() {
         branch: "feat-test".to_string(),
         repo_path: repo.clone(),
         default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let result = workspace.create(&cfg).await;
@@ -152,6 +158,8 @@ async fn rejects_unsafe_project_id() {
         branch: "feat-test".to_string(),
         repo_path: repo.clone(),
         default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let result = workspace.create(&cfg).await;
@@ -176,5 +184,84 @@ async fn destroy_is_idempotent() {
         .await
         .expect("destroy of nonexistent path should succeed");
 
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn create_symlinks_and_post_create() {
+    let repo = init_repo();
+    std::fs::write(repo.join(".env"), "env=1\n").unwrap();
+
+    let base = unique_dir("clones-hooks");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess-hooks".to_string(),
+        branch: "feat-test-hooks".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+        symlinks: vec![".env".to_string()],
+        post_create: vec!["echo ok > post_create_marker.txt".to_string()],
+    };
+
+    let path = workspace
+        .create(&cfg)
+        .await
+        .expect("clone create should succeed with hooks");
+
+    let env = path.join(".env");
+    let meta = std::fs::symlink_metadata(&env).expect("symlink metadata missing");
+    assert!(meta.file_type().is_symlink(), ".env should be a symlink");
+
+    #[cfg(unix)]
+    {
+        let target = std::fs::read_link(&env).expect("read_link failed");
+        assert_eq!(target, repo.join(".env"));
+    }
+
+    let marker = path.join("post_create_marker.txt");
+    assert!(
+        marker.exists(),
+        "postCreate command should create marker file"
+    );
+    let marker_text = std::fs::read_to_string(marker).unwrap();
+    assert_eq!(marker_text.trim(), "ok");
+
+    workspace
+        .destroy(&path)
+        .await
+        .expect("destroy should succeed");
+    assert!(!path.exists(), "workspace should be removed after destroy");
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn rejects_missing_symlink_source() {
+    let repo = init_repo();
+
+    let base = unique_dir("clones-hooks-missing");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess-missing".to_string(),
+        branch: "feat-test-missing".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+        symlinks: vec![".missing".to_string()],
+        post_create: vec![],
+    };
+
+    let err = workspace.create(&cfg).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("symlink source missing"),
+        "unexpected error: {msg}"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
     let _ = std::fs::remove_dir_all(&base);
 }

--- a/crates/plugins/workspace-worktree/src/lib.rs
+++ b/crates/plugins/workspace-worktree/src/lib.rs
@@ -5,6 +5,7 @@
 //! `packages/plugins/workspace-worktree/src/index.ts` in the reference repo,
 //! but with Slice 0 scope: no symlinks, no postCreate hooks, no list/restore.
 
+use ao_core::workspace_hooks::apply_workspace_hooks;
 use ao_core::{AoError, Result, Workspace, WorkspaceCreateConfig};
 use async_trait::async_trait;
 use std::path::{Path, PathBuf};
@@ -91,8 +92,8 @@ impl Workspace for WorktreeWorkspace {
         )
         .await;
 
-        match first_attempt {
-            Ok(_) => Ok(worktree_path),
+        let created_path = match first_attempt {
+            Ok(_) => worktree_path,
             Err(AoError::Workspace(msg)) if msg.contains("already exists") => {
                 // Branch already exists — create the worktree without -b, then check it out.
                 git(
@@ -110,10 +111,27 @@ impl Workspace for WorktreeWorkspace {
                     .await;
                     return Err(checkout_err);
                 }
-                Ok(worktree_path)
+
+                worktree_path
             }
-            Err(e) => Err(e),
+            Err(e) => return Err(e),
+        };
+
+        // Workspace hooks: symlinks + `postCreate`.
+        if let Err(hook_err) = apply_workspace_hooks(
+            &cfg.repo_path,
+            &created_path,
+            &cfg.symlinks,
+            &cfg.post_create,
+        )
+        .await
+        {
+            // Avoid leaving a half-materialized workspace behind.
+            let _ = self.destroy(&created_path).await;
+            return Err(hook_err);
         }
+
+        Ok(created_path)
     }
 
     async fn destroy(&self, workspace_path: &Path) -> Result<()> {

--- a/crates/plugins/workspace-worktree/tests/integration.rs
+++ b/crates/plugins/workspace-worktree/tests/integration.rs
@@ -57,6 +57,8 @@ async fn create_and_destroy_worktree() {
         branch: "feat-test".to_string(),
         repo_path: repo.clone(),
         default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let path = workspace.create(&cfg).await.expect("create failed");
@@ -87,6 +89,8 @@ async fn rejects_unsafe_session_id() {
         branch: "feat-test".to_string(),
         repo_path: repo.clone(),
         default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
     };
 
     let result = workspace.create(&cfg).await;
@@ -122,5 +126,84 @@ async fn destroy_refuses_paths_outside_base_dir() {
     );
 
     let _ = std::fs::remove_dir_all(&victim_parent);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn create_symlinks_and_post_create() {
+    let repo = init_repo();
+    std::fs::write(repo.join(".env"), "env=1\n").unwrap();
+
+    let base = unique_dir("worktrees-hooks");
+    let workspace = WorktreeWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess-hooks".to_string(),
+        branch: "feat-test-hooks".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+        symlinks: vec![".env".to_string()],
+        post_create: vec!["echo ok > post_create_marker.txt".to_string()],
+    };
+
+    let path = workspace
+        .create(&cfg)
+        .await
+        .expect("create should succeed with hooks");
+
+    let env = path.join(".env");
+    let meta = std::fs::symlink_metadata(&env).expect("symlink metadata missing");
+    assert!(meta.file_type().is_symlink(), ".env should be a symlink");
+
+    #[cfg(unix)]
+    {
+        let target = std::fs::read_link(&env).expect("read_link failed");
+        assert_eq!(target, repo.join(".env"));
+    }
+
+    let marker = path.join("post_create_marker.txt");
+    assert!(
+        marker.exists(),
+        "postCreate command should create marker file"
+    );
+    let marker_text = std::fs::read_to_string(marker).unwrap();
+    assert_eq!(marker_text.trim(), "ok");
+
+    workspace
+        .destroy(&path)
+        .await
+        .expect("destroy should succeed");
+    assert!(!path.exists(), "workspace should be removed after destroy");
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
+async fn rejects_missing_symlink_source() {
+    let repo = init_repo();
+
+    let base = unique_dir("worktrees-hooks-missing");
+    let workspace = WorktreeWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess-missing".to_string(),
+        branch: "feat-test-missing".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+        symlinks: vec![".missing".to_string()],
+        post_create: vec![],
+    };
+
+    let err = workspace.create(&cfg).await.unwrap_err();
+    let msg = err.to_string();
+    assert!(
+        msg.contains("symlink source missing"),
+        "unexpected error: {msg}"
+    );
+
+    let _ = std::fs::remove_dir_all(&repo);
     let _ = std::fs::remove_dir_all(&base);
 }


### PR DESCRIPTION
## Summary
This implements ao-ts-style workspace setup hooks so `ao-rs spawn` produces a ready-to-use workspace.

- `ProjectConfig.symlinks` are materialized into the workspace root during `Workspace::create`.
- `ProjectConfig.postCreate` commands are executed after workspace creation with the workspace root as `cwd`.

## Acceptance Criteria
- Given `symlinks: [.env]` and a `.env` file exists in the project root, the spawned workspace contains `.env` as a symlink.
- Given `postCreate: ["echo ok"]`, the command runs successfully after the workspace is created.

## Test Plan
- `cargo test`
- `cargo clippy -- -D warnings`


Made with [Cursor](https://cursor.com)