### PR TITLE
UI: Colorize status/project/branch mini-pills by project

### DIFF
--- a/crates/ao-desktop/ui/src/components/SessionDetail.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.tsx
@@ -2,6 +2,7 @@ import { useMemo, useState } from "react";
 import type { DashboardSession } from "../lib/types";
 import { getDashboardLane, isTerminalSession } from "../lib/types";
 import { getSessionTitle } from "../lib/format";
+import { projectAccentStyle } from "../lib/projectColors";
 import { ConfirmModal } from "./ConfirmModal";
 
 function IssueLink({ id, url }: { id: string; url: string }) {
@@ -25,6 +26,7 @@ export function SessionDetail({
 }) {
   const lane = getDashboardLane(session);
   const title = getSessionTitle(session);
+  const projectAccent = useMemo(() => projectAccentStyle(session.projectId), [session.projectId]);
   const [message, setMessage] = useState("");
   const [sending, setSending] = useState(false);
   const [killing, setKilling] = useState(false);
@@ -131,7 +133,12 @@ export function SessionDetail({
               title
             )}
           </div>
-          <span className="mini-pill detail-hero__status" data-tone={lane}>
+          <span
+            className="mini-pill detail-hero__status"
+            data-tone={lane}
+            data-project-accent="true"
+            style={projectAccent}
+          >
             {lane}
           </span>
         </div>
@@ -141,10 +148,20 @@ export function SessionDetail({
           </span>
         </div>
         <div className="detail-tags">
-          {session.projectId ? <span className="mini-pill">project: {session.projectId}</span> : null}
-          {session.branch ? <span className="mini-pill">branch: {session.branch}</span> : null}
+          {session.projectId ? (
+            <span className="mini-pill" data-project-accent="true" style={projectAccent}>
+              project: {session.projectId}
+            </span>
+          ) : null}
+          {session.branch ? (
+            <span className="mini-pill" data-project-accent="true" style={projectAccent}>
+              branch: {session.branch}
+            </span>
+          ) : null}
           {session.pr ? <span className="mini-pill">PR #{session.pr.number}</span> : null}
-          <span className="mini-pill">status: {session.status}</span>
+          <span className="mini-pill" data-project-accent="true" style={projectAccent}>
+            status: {session.status}
+          </span>
           {session.activity ? <span className="mini-pill">activity: {session.activity}</span> : null}
         </div>
         <div className="detail-meta">

--- a/crates/ao-desktop/ui/src/lib/projectColors.test.ts
+++ b/crates/ao-desktop/ui/src/lib/projectColors.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from "vitest";
+
+import { projectAccentStyle, projectHue } from "./projectColors";
+
+describe("projectColors", () => {
+  it("is deterministic for the same projectId", () => {
+    const a = projectHue("ao-rs");
+    const b = projectHue("ao-rs");
+    expect(a).toBe(b);
+
+    const styleA = projectAccentStyle("ao-rs");
+    const styleB = projectAccentStyle("ao-rs");
+    expect(styleA["--project-h"]).toBe(styleB["--project-h"]);
+  });
+
+  it("produces a hue in range", () => {
+    const hue = projectHue("ao-rs");
+    expect(hue).toBeGreaterThanOrEqual(0);
+    expect(hue).toBeLessThan(360);
+  });
+
+  it("changes hue across different projectIds", () => {
+    const h1 = projectHue("ao-rs");
+    const h2 = projectHue("ao-desktop");
+    // Collision is theoretically possible due to modulo, but extremely unlikely.
+    expect(h1).not.toBe(h2);
+  });
+});
+

--- a/crates/ao-desktop/ui/src/lib/projectColors.ts
+++ b/crates/ao-desktop/ui/src/lib/projectColors.ts
@@ -1,0 +1,23 @@
+function fnv1a32(input: string): number {
+  // Deterministic 32-bit hash (FNV-1a).
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < input.length; i++) {
+    hash ^= input.charCodeAt(i);
+    hash = (hash * 0x01000193) >>> 0;
+  }
+  return hash >>> 0;
+}
+
+export function projectHue(projectId: string): number {
+  // Hue is stable across reloads for the same projectId.
+  return fnv1a32(projectId) % 360;
+}
+
+export function projectAccentStyle(projectId: string | null | undefined): Record<string, string> {
+  if (!projectId) return {};
+  return {
+    // Used by CSS: `hsl(var(--project-h) ... / ...)`.
+    "--project-h": String(projectHue(projectId)),
+  };
+}
+

--- a/crates/ao-desktop/ui/styles.css
+++ b/crates/ao-desktop/ui/styles.css
@@ -468,6 +468,18 @@ body[data-theme="dark"] .session-card:hover { border-color: rgba(255, 255, 255, 
   text-transform: uppercase;
 }
 
+/* Project-based accent mini-pills (SessionDetail: lane/status/project/branch). */
+.mini-pill[data-project-accent="true"] {
+  background: hsl(var(--project-h) 85% 55% / 0.12);
+  border-color: hsl(var(--project-h) 85% 55% / 0.35);
+  color: hsl(var(--project-h) 85% 35% / 0.95);
+}
+body[data-theme="dark"] .mini-pill[data-project-accent="true"] {
+  background: hsl(var(--project-h) 85% 60% / 0.14);
+  border-color: hsl(var(--project-h) 85% 60% / 0.4);
+  color: hsl(var(--project-h) 85% 80% / 0.95);
+}
+
 .session-tab__label {
   display: inline-block;
   max-width: 240px;


### PR DESCRIPTION
## Summary
Colorize the `SessionDetail` mini-pills (lane/status, `project: ...`, and `branch: ...`) using a deterministic accent derived from `session.projectId`.

This keeps the accent consistent across reloads and visually groups sessions from the same project.

## Test plan
- `cd crates/ao-desktop/ui && npm run typecheck`
- `cd crates/ao-desktop/ui && npm test`
- `cd crates/ao-desktop/ui && npm run build`

Resolves #115

Made with [Cursor](https://cursor.com)