### PR TITLE
feat(cli): deterministic issue-based spawn branch naming

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -60,8 +60,8 @@ pub enum Command {
         task: Option<String>,
 
         /// GitHub issue number (e.g. `42` or `#42`). Fetches the issue title
-        /// and body, derives the branch name as `feat/issue-<n>`, and uses
-        /// them as the agent task.
+        /// and body, derives the branch name as `feature/<issue>-<slug>`, and
+        /// uses the issue title as the agent task.
         #[arg(
             short,
             long,

--- a/crates/ao-cli/src/cli/spawn_helpers.rs
+++ b/crates/ao-cli/src/cli/spawn_helpers.rs
@@ -144,9 +144,43 @@ pub(crate) fn git_safe_branch_namespace(input: &str) -> String {
     }
 }
 
+pub(crate) fn issue_branch_name(issue_id: &str, issue_title: &str) -> String {
+    let slug = slugify_issue_title_for_branch(issue_title);
+    let slug = if slug.is_empty() {
+        issue_id.to_string()
+    } else {
+        slug
+    };
+    format!("feature/{}-{}", issue_id, slug)
+}
+
+fn slugify_issue_title_for_branch(input: &str) -> String {
+    // Slug rules for issue-based branches:
+    // - Lowercase
+    // - Keep ASCII alphanumeric as-is
+    // - Replace any run of non-alphanumeric with a single '-'
+    // - Trim leading/trailing '-'
+    // - If empty after cleaning, the caller falls back to `issue_id`
+    let mut out = String::with_capacity(input.len());
+    let mut prev_dash = false;
+
+    for c in input.chars() {
+        let lower = c.to_ascii_lowercase();
+        if lower.is_ascii_alphanumeric() {
+            out.push(lower);
+            prev_dash = false;
+        } else if !prev_dash {
+            out.push('-');
+            prev_dash = true;
+        }
+    }
+
+    out.trim_matches('-').to_string()
+}
+
 #[cfg(test)]
 mod spawn_helpers_tests {
-    use super::{git_safe_branch_fragment, git_safe_branch_namespace};
+    use super::{git_safe_branch_fragment, git_safe_branch_namespace, issue_branch_name};
 
     #[test]
     fn git_safe_branch_fragment_is_stable_and_safe() {
@@ -163,5 +197,39 @@ mod spawn_helpers_tests {
     fn git_safe_branch_namespace_preserves_slashes_and_sanitizes_segments() {
         assert_eq!(git_safe_branch_namespace("Ao/Agent"), "ao/agent");
         assert_eq!(git_safe_branch_namespace("ao agent//team"), "ao-agent/team");
+    }
+
+    #[test]
+    fn issue_branch_name_slugifies_title_and_falls_back_to_issue() {
+        assert_eq!(
+            issue_branch_name("77", "My Feature Title"),
+            "feature/77-my-feature-title"
+        );
+        assert_eq!(
+            issue_branch_name("local-0007", "My Feature Title"),
+            "feature/local-0007-my-feature-title"
+        );
+
+        // Runs of punctuation collapse into a single dash.
+        assert_eq!(
+            issue_branch_name("77", "Fix CI: core/lifecycle"),
+            "feature/77-fix-ci-core-lifecycle"
+        );
+
+        // Leading/trailing punctuation is trimmed.
+        assert_eq!(
+            issue_branch_name("77", "---Hello---"),
+            "feature/77-hello"
+        );
+
+        // Unicode isn't ASCII alphanumeric, so it becomes '-'.
+        assert_eq!(
+            issue_branch_name("77", "My Café Title"),
+            "feature/77-my-caf-title"
+        );
+
+        // If the title cleans into an empty slug, fall back to issue_id.
+        assert_eq!(issue_branch_name("77", "!!!"), "feature/77-77");
+        assert_eq!(issue_branch_name("77", "   "), "feature/77-77");
     }
 }

--- a/crates/ao-cli/src/commands/spawn.rs
+++ b/crates/ao-cli/src/commands/spawn.rs
@@ -20,7 +20,7 @@ use crate::cli::plugins::{select_agent, select_runtime, DuplicateIssue};
 use crate::cli::printing::{print_config_warnings, short_id};
 use crate::cli::project::{resolve_project_id, resolve_repo_root};
 use crate::cli::spawn_helpers::{
-    git_safe_branch_fragment, git_safe_branch_namespace, shell_escape_single_quotes,
+    git_safe_branch_namespace, issue_branch_name, shell_escape_single_quotes,
     spawn_template_by_name, tmux_send_keys_literal_no_enter,
 };
 #[allow(clippy::too_many_arguments)]
@@ -72,7 +72,7 @@ pub async fn spawn(
         .map(spawn_template_by_name)
         .transpose()?;
 
-    let (resolved_task, branch_prefix, resolved_issue_id, resolved_issue_url, issue_context) =
+    let (resolved_task, issue_based_branch, resolved_issue_id, resolved_issue_url, issue_context) =
         if let Some(ref id) = issue {
             // Normalize: strip leading `#` so `#42` and `42` match the stored
             // `issue_id` (which is always a bare number from `gh issue view`).
@@ -105,15 +105,15 @@ pub async fn spawn(
             };
 
             let fetched = tracker.get_issue(id).await?;
-            let branch = tracker.branch_name(id);
             // Generate structured issue context via the tracker plugin's
             // generate_prompt() — this is the extension point for custom
             // formatting (Linear cycle info, Jira sprint fields, etc.).
+            let issue_branch = issue_branch_name(&fetched.id, &fetched.title);
             let ctx = tracker.generate_prompt(&fetched);
             println!("  issue:     #{} — {}", fetched.id, fetched.title);
             (
                 fetched.title.clone(),
-                Some(branch),
+                Some(issue_branch),
                 Some(fetched.id.clone()),
                 Some(fetched.url.clone()),
                 Some(ctx),
@@ -123,7 +123,7 @@ pub async fn spawn(
             if !path.is_file() {
                 return Err(format!("local issue is not a file: {}", path.display()).into());
             }
-            let (issue_id, branch_suffix) = local_issue_ids_from_path(&path)?;
+            let (issue_id, _branch_suffix) = local_issue_ids_from_path(&path)?;
             if !force {
                 let manager = SessionManager::with_default();
                 let dupes = manager.find_by_issue_id(&issue_id).await?;
@@ -141,7 +141,8 @@ pub async fn spawn(
             let ctx = format_local_issue_context(&title, &path, &body);
             println!("→ local issue: {}", path.display());
             println!("  id:        {issue_id} — {title}");
-            (title, Some(branch_suffix), Some(issue_id), None, Some(ctx))
+            let issue_branch = issue_branch_name(&issue_id, &title);
+            (title, Some(issue_branch), Some(issue_id), None, Some(ctx))
         } else {
             (task.unwrap(), None, None, None, None)
         };
@@ -175,11 +176,8 @@ pub async fn spawn(
     let session_id = SessionId::new();
     // Short id is what tmux + worktree dirs see — uuid is too long for a tmux name.
     let short_id: String = session_id.0.chars().take(8).collect();
-    // Issue-first: prefix tracker branch with a short-id for uniqueness so
-    // spawning the same issue twice doesn't collide on `git worktree add`.
-    //
-    // Default (no namespace): `ao-<shortid>-<issue_branch>` (legacy)
-    // With namespace: `<ns>/<shortid>/<issue_branch>` (more obviously machine-owned)
+    // short_id is used for session/worktree uniqueness; issue-based branches
+    // are derived deterministically from issue_id + slugified title.
     let branch_namespace = project_config
         .and_then(|p| p.branch_namespace.clone())
         .or_else(|| {
@@ -189,17 +187,12 @@ pub async fn spawn(
                 .and_then(|d| d.branch_namespace.clone())
         })
         .map(|s| git_safe_branch_namespace(&s));
-    let branch = match (branch_namespace.as_deref(), branch_prefix) {
-        (Some(ns), Some(b)) => {
-            let safe = git_safe_branch_fragment(&b);
-            format!("{ns}/{short_id}/{safe}")
-        }
-        (Some(ns), None) => format!("{ns}/{short_id}"),
-        (None, Some(b)) => {
-            let safe = git_safe_branch_fragment(&b);
-            format!("ao-{short_id}-{safe}")
-        }
-        (None, None) => format!("ao-{short_id}"),
+    let branch = match issue_based_branch {
+        Some(b) => b,
+        None => match branch_namespace.as_deref() {
+            Some(ns) => format!("{ns}/{short_id}"),
+            None => format!("ao-{short_id}"),
+        },
     };
 
     println!("→ project:   {project}");


### PR DESCRIPTION
## Summary
- Issue-based `ao-rs spawn --issue` and `ao-rs spawn --local-issue` now create git branches as `feature/<issue>-<slug>` derived from the issue title.
- This bypasses `branch_namespace` and the legacy `ao-<shortid>-` prefix.

## Test plan
- `cargo test`
- `cargo clippy --all-targets`
- Added unit tests for `issue_branch_name(issue_id, issue_title)` slugification edge cases (runs of punctuation, Unicode, and empty-after-cleaning).

## Notes
- `--force` keeps the existing duplicate issue detection behavior; concurrent forced spawns of the same issue may still race on worktree creation if the branch already exists.

Made with [Cursor](https://cursor.com)