### PR TITLE
Fix issue spawn branch naming convention (#114)

### DIFF
--- a/crates/ao-cli/src/cli/spawn_helpers.rs
+++ b/crates/ao-cli/src/cli/spawn_helpers.rs
@@ -144,9 +144,49 @@ pub(crate) fn git_safe_branch_namespace(input: &str) -> String {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Issue-based branch naming
+// ---------------------------------------------------------------------------
+
+fn slugify_issue_title(issue_title: &str) -> String {
+    // Slug rules (intentionally ASCII-only):
+    // - Lowercase
+    // - Keep ASCII alphanumeric as-is
+    // - Replace any run of non-alphanumeric with a single `-`
+    // - Trim leading/trailing `-`
+    // - If the slug is empty after cleaning, the caller falls back to `issue`
+    //
+    // This differs from `git_safe_branch_fragment`: we want predictable,
+    // team-convention slugs for issue-based spawns.
+    let mut out = String::with_capacity(issue_title.len());
+    let mut prev_dash = false;
+
+    for c in issue_title.chars() {
+        if c.is_ascii_alphanumeric() {
+            out.push(c.to_ascii_lowercase());
+            prev_dash = false;
+        } else if !prev_dash && !out.is_empty() {
+            out.push('-');
+            prev_dash = true;
+        } else {
+            prev_dash = true;
+        }
+    }
+
+    out.trim_matches('-').to_string()
+}
+
+pub(crate) fn issue_branch_name(issue_id: &str, issue_title: &str) -> String {
+    let mut slug = slugify_issue_title(issue_title);
+    if slug.is_empty() {
+        slug = issue_id.to_string();
+    }
+    format!("feature/{}-{}", issue_id, slug)
+}
+
 #[cfg(test)]
 mod spawn_helpers_tests {
-    use super::{git_safe_branch_fragment, git_safe_branch_namespace};
+    use super::{git_safe_branch_fragment, git_safe_branch_namespace, issue_branch_name};
 
     #[test]
     fn git_safe_branch_fragment_is_stable_and_safe() {
@@ -163,5 +203,52 @@ mod spawn_helpers_tests {
     fn git_safe_branch_namespace_preserves_slashes_and_sanitizes_segments() {
         assert_eq!(git_safe_branch_namespace("Ao/Agent"), "ao/agent");
         assert_eq!(git_safe_branch_namespace("ao agent//team"), "ao-agent/team");
+    }
+
+    #[test]
+    fn issue_branch_name_slugifies_title_and_sets_feature_prefix() {
+        assert_eq!(
+            issue_branch_name("77", "My Feature Title"),
+            "feature/77-my-feature-title"
+        );
+        assert_eq!(
+            issue_branch_name("77", "Hello!!!World"),
+            "feature/77-hello-world"
+        );
+        assert_eq!(
+            issue_branch_name("77", "Hello...World"),
+            "feature/77-hello-world"
+        );
+        assert_eq!(
+            issue_branch_name("77", "Hello--World"),
+            "feature/77-hello-world"
+        );
+    }
+
+    #[test]
+    fn issue_branch_name_trims_dashes_and_collapses_runs() {
+        assert_eq!(issue_branch_name("77", "---Hello---"), "feature/77-hello");
+        assert_eq!(
+            issue_branch_name("77", "Hello___World"),
+            "feature/77-hello-world"
+        );
+        assert_eq!(
+            issue_branch_name("77", "Hello / World"),
+            "feature/77-hello-world"
+        );
+    }
+
+    #[test]
+    fn issue_branch_name_uses_issue_when_slug_empty() {
+        assert_eq!(issue_branch_name("77", "   "), "feature/77-77");
+        assert_eq!(issue_branch_name("77", "!!!"), "feature/77-77");
+        assert_eq!(issue_branch_name("77", "你好"), "feature/77-77");
+    }
+
+    #[test]
+    fn issue_branch_name_unicode_letters_are_ascii_only_slugified() {
+        // `é` is not ASCII alphanumeric; it should be treated as a separator
+        // and then trimmed (resulting in "caf").
+        assert_eq!(issue_branch_name("77", "Café"), "feature/77-caf");
     }
 }

--- a/crates/ao-cli/src/commands/spawn.rs
+++ b/crates/ao-cli/src/commands/spawn.rs
@@ -20,7 +20,7 @@ use crate::cli::plugins::{select_agent, select_runtime, DuplicateIssue};
 use crate::cli::printing::{print_config_warnings, short_id};
 use crate::cli::project::{resolve_project_id, resolve_repo_root};
 use crate::cli::spawn_helpers::{
-    git_safe_branch_fragment, git_safe_branch_namespace, shell_escape_single_quotes,
+    git_safe_branch_namespace, issue_branch_name, shell_escape_single_quotes,
     spawn_template_by_name, tmux_send_keys_literal_no_enter,
 };
 #[allow(clippy::too_many_arguments)]
@@ -72,7 +72,7 @@ pub async fn spawn(
         .map(spawn_template_by_name)
         .transpose()?;
 
-    let (resolved_task, branch_prefix, resolved_issue_id, resolved_issue_url, issue_context) =
+    let (resolved_task, branch_override, resolved_issue_id, resolved_issue_url, issue_context) =
         if let Some(ref id) = issue {
             // Normalize: strip leading `#` so `#42` and `42` match the stored
             // `issue_id` (which is always a bare number from `gh issue view`).
@@ -105,16 +105,18 @@ pub async fn spawn(
             };
 
             let fetched = tracker.get_issue(id).await?;
-            let branch = tracker.branch_name(id);
             // Generate structured issue context via the tracker plugin's
             // generate_prompt() — this is the extension point for custom
             // formatting (Linear cycle info, Jira sprint fields, etc.).
             let ctx = tracker.generate_prompt(&fetched);
+            let issue_title = fetched.title.clone();
+            let issue_id = fetched.id.clone();
+            let branch = issue_branch_name(&issue_id, &issue_title);
             println!("  issue:     #{} — {}", fetched.id, fetched.title);
             (
-                fetched.title.clone(),
+                issue_title,
                 Some(branch),
-                Some(fetched.id.clone()),
+                Some(issue_id),
                 Some(fetched.url.clone()),
                 Some(ctx),
             )
@@ -123,7 +125,7 @@ pub async fn spawn(
             if !path.is_file() {
                 return Err(format!("local issue is not a file: {}", path.display()).into());
             }
-            let (issue_id, branch_suffix) = local_issue_ids_from_path(&path)?;
+            let (issue_id, _branch_suffix) = local_issue_ids_from_path(&path)?;
             if !force {
                 let manager = SessionManager::with_default();
                 let dupes = manager.find_by_issue_id(&issue_id).await?;
@@ -138,10 +140,11 @@ pub async fn spawn(
             }
             let text = std::fs::read_to_string(&path)?;
             let (title, body) = parse_local_issue_markdown(&text);
+            let branch = issue_branch_name(&issue_id, &title);
             let ctx = format_local_issue_context(&title, &path, &body);
             println!("→ local issue: {}", path.display());
             println!("  id:        {issue_id} — {title}");
-            (title, Some(branch_suffix), Some(issue_id), None, Some(ctx))
+            (title, Some(branch), Some(issue_id), None, Some(ctx))
         } else {
             (task.unwrap(), None, None, None, None)
         };
@@ -175,11 +178,10 @@ pub async fn spawn(
     let session_id = SessionId::new();
     // Short id is what tmux + worktree dirs see — uuid is too long for a tmux name.
     let short_id: String = session_id.0.chars().take(8).collect();
-    // Issue-first: prefix tracker branch with a short-id for uniqueness so
-    // spawning the same issue twice doesn't collide on `git worktree add`.
-    //
-    // Default (no namespace): `ao-<shortid>-<issue_branch>` (legacy)
-    // With namespace: `<ns>/<shortid>/<issue_branch>` (more obviously machine-owned)
+    // For task spawns, include the short-id in the branch name to make
+    // concurrent sessions non-colliding. For issue spawns we override
+    // `branch` to `feature/<issue>-<slug>` and bypass `branch_namespace`
+    // and the short-id in the branch format.
     let branch_namespace = project_config
         .and_then(|p| p.branch_namespace.clone())
         .or_else(|| {
@@ -189,17 +191,13 @@ pub async fn spawn(
                 .and_then(|d| d.branch_namespace.clone())
         })
         .map(|s| git_safe_branch_namespace(&s));
-    let branch = match (branch_namespace.as_deref(), branch_prefix) {
-        (Some(ns), Some(b)) => {
-            let safe = git_safe_branch_fragment(&b);
-            format!("{ns}/{short_id}/{safe}")
+    let branch = if let Some(b) = branch_override {
+        b
+    } else {
+        match branch_namespace.as_deref() {
+            Some(ns) => format!("{ns}/{short_id}"),
+            None => format!("ao-{short_id}"),
         }
-        (Some(ns), None) => format!("{ns}/{short_id}"),
-        (None, Some(b)) => {
-            let safe = git_safe_branch_fragment(&b);
-            format!("ao-{short_id}-{safe}")
-        }
-        (None, None) => format!("ao-{short_id}"),
     };
 
     println!("→ project:   {project}");


### PR DESCRIPTION
## Summary
Issue-based `ao-rs spawn` now creates deterministic Git branches that match the team convention:
- `spawn --issue` (GitHub): `feature/<issue>-<slug>` where `<slug>` is derived from the fetched issue title.
- `spawn --local-issue` (markdown): `feature/<local-id>-<slug>` where `<slug>` is derived from the markdown `# ...` title.

This bypasses both `branch_namespace` and the `ao-<shortid>-` prefix for issue spawns.

## Test plan
- `cargo test -p ao-cli`
- `cargo fmt --check`
- `cargo clippy -p ao-cli`

Made with [Cursor](https://cursor.com)