### PR TITLE
fix(scm-github): reduce GraphQL usage for pending comments

### DIFF
--- a/crates/ao-cli/src/cli/spawn_helpers.rs
+++ b/crates/ao-cli/src/cli/spawn_helpers.rs
@@ -317,7 +317,8 @@ mod spawn_helpers_tests {
 
     #[test]
     fn issue_branch_name_shortens_very_long_slugs() {
-        let title = "Feature: this is a very long title that should be shortened for branch names in git";
+        let title =
+            "Feature: this is a very long title that should be shortened for branch names in git";
         let branch = issue_branch_name("77", title, &[]);
         assert!(branch.starts_with("feature/77-"));
         assert!(branch.len() <= "feature/".len() + "77-".len() + 48);

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -73,6 +73,33 @@ const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 
 const PENDING_COMMENTS_TTL: Duration = Duration::from_secs(30);
 const PENDING_COMMENTS_CACHE_MAX: usize = 128;
+const GITHUB_RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(120);
+
+fn is_rate_limited_error(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("api rate limit")
+        || m.contains("secondary rate limit")
+        || m.contains("rate limit exceeded")
+        || m.contains("graphql: api rate limit")
+}
+
+fn cooldown_until() -> &'static Mutex<Option<Instant>> {
+    static COOLDOWN: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    COOLDOWN.get_or_init(|| Mutex::new(None))
+}
+
+fn in_cooldown_now() -> bool {
+    let Ok(guard) = cooldown_until().lock() else {
+        return false;
+    };
+    guard.is_some_and(|until| Instant::now() < until)
+}
+
+fn enter_cooldown() {
+    if let Ok(mut guard) = cooldown_until().lock() {
+        *guard = Some(Instant::now() + GITHUB_RATE_LIMIT_COOLDOWN);
+    }
+}
 
 fn pending_comments_cache() -> &'static Mutex<HashMap<String, (Instant, Vec<ReviewComment>)>> {
     static CACHE: OnceLock<Mutex<HashMap<String, (Instant, Vec<ReviewComment>)>>> = OnceLock::new();
@@ -505,6 +532,11 @@ fn repo_flag(pr: &PullRequest) -> String {
 /// Non-zero exit, timeout, or spawn failure → `AoError::Scm(...)` with the
 /// stderr suffix (trimmed) so callers get an actionable message.
 async fn gh(args: &[&str]) -> Result<String> {
+    if in_cooldown_now() {
+        return Err(AoError::Scm(
+            "GitHub rate-limit cooldown active; skipping gh subprocess".into(),
+        ));
+    }
     run("gh", args, None).await
 }
 
@@ -630,6 +662,9 @@ async fn run(bin: &str, args: &[&str], cwd: Option<&Path>) -> Result<String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_rate_limited_error(stderr.as_ref()) {
+            enter_cooldown();
+        }
         return Err(AoError::Scm(format!(
             "{bin} {} failed: {}",
             args.join(" "),

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -45,7 +45,8 @@ use ao_core::{
 use async_trait::async_trait;
 use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::process::Command;
 
 pub mod graphql_batch;
@@ -65,6 +66,22 @@ fn is_not_found_error(msg: &str) -> bool {
 /// easily take 5–10s; 30s is the "the network is wedged, kill it" bound,
 /// not the expected latency.
 const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Short-lived caches (reduce GitHub API fan-out)
+// ---------------------------------------------------------------------------
+
+const PENDING_COMMENTS_TTL: Duration = Duration::from_secs(30);
+const PENDING_COMMENTS_CACHE_MAX: usize = 128;
+
+fn pending_comments_cache() -> &'static Mutex<HashMap<String, (Instant, Vec<ReviewComment>)>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, (Instant, Vec<ReviewComment>)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn pending_comments_cache_key(pr: &PullRequest) -> String {
+    format!("{}/{}/{}", pr.owner, pr.repo, pr.number)
+}
 
 // ---------------------------------------------------------------------------
 // Plugin type
@@ -241,8 +258,17 @@ impl Scm for GitHubScm {
     }
 
     async fn pending_comments(&self, pr: &PullRequest) -> Result<Vec<ReviewComment>> {
-        match pending_comments_graphql(pr).await {
-            Ok(comments) => Ok(comments),
+        let key = pending_comments_cache_key(pr);
+        if let Ok(cache) = pending_comments_cache().lock() {
+            if let Some((at, cached)) = cache.get(&key) {
+                if at.elapsed() < PENDING_COMMENTS_TTL {
+                    return Ok(cached.clone());
+                }
+            }
+        }
+
+        let fetched = match pending_comments_graphql(pr).await {
+            Ok(comments) => comments,
             Err(e) => {
                 // Keep resilience: GH GraphQL can fail due to auth scope,
                 // enterprise quirks, or transient outages. Fall back to the
@@ -252,9 +278,18 @@ impl Scm for GitHubScm {
                     "pending_comments: GraphQL reviewThreads failed for PR #{} (falling back to REST): {e}",
                     pr.number
                 );
-                pending_comments_rest(pr).await
+                pending_comments_rest(pr).await?
             }
+        };
+
+        if let Ok(mut cache) = pending_comments_cache().lock() {
+            if cache.len() >= PENDING_COMMENTS_CACHE_MAX {
+                cache.clear();
+            }
+            cache.insert(key, (Instant::now(), fetched.clone()));
         }
+
+        Ok(fetched)
     }
 
     async fn mergeability(&self, pr: &PullRequest) -> Result<MergeReadiness> {
@@ -525,7 +560,10 @@ query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: Stri
 "#;
 
 async fn pending_comments_graphql(pr: &PullRequest) -> Result<Vec<ReviewComment>> {
-    const MAX_PAGES: u32 = 100;
+    // Hotfix: bound GraphQL usage to avoid burning rate limit on large PRs.
+    // If there are more pages, we intentionally fail fast so the caller
+    // falls back to the REST endpoint.
+    const MAX_PAGES: u32 = 1;
     let mut after: Option<String> = None;
     let mut all = Vec::new();
 
@@ -549,8 +587,10 @@ async fn pending_comments_graphql(pr: &PullRequest) -> Result<Vec<ReviewComment>
         let page = parse::parse_review_threads_page(&json)?;
         all.extend(page.comments);
 
-        if !page.has_next_page {
-            break;
+        if page.has_next_page {
+            return Err(AoError::Scm(
+                "GraphQL reviewThreads pagination exceeds hotfix cap; falling back to REST".into(),
+            ));
         }
         after = page.end_cursor;
         if after.is_none() {

--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -33,13 +33,76 @@
 use ao_core::{AoError, Issue, IssueState, Result, Tracker};
 use async_trait::async_trait;
 use serde::Deserialize;
+use std::collections::HashMap;
 use std::path::Path;
-use std::time::Duration;
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
 use tokio::process::Command;
 
 /// Per-subprocess timeout. Same 30s bound as the SCM plugin — this is the
 /// "network is wedged" ceiling, not the expected latency.
 const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(30);
+
+// ---------------------------------------------------------------------------
+// Rate limit resilience (hotfix #119)
+// ---------------------------------------------------------------------------
+
+const ISSUE_STATE_TTL: Duration = Duration::from_secs(30);
+const ISSUE_STATE_CACHE_MAX: usize = 256;
+const RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(120);
+
+fn is_rate_limited_error(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("api rate limit")
+        || m.contains("secondary rate limit")
+        || m.contains("rate limit exceeded")
+        || m.contains("graphql: api rate limit")
+}
+
+fn cooldown_until() -> &'static Mutex<Option<Instant>> {
+    static COOLDOWN: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    COOLDOWN.get_or_init(|| Mutex::new(None))
+}
+
+fn in_cooldown_now() -> bool {
+    let Ok(guard) = cooldown_until().lock() else {
+        return false;
+    };
+    guard.is_some_and(|until| Instant::now() < until)
+}
+
+fn enter_cooldown() {
+    if let Ok(mut guard) = cooldown_until().lock() {
+        *guard = Some(Instant::now() + RATE_LIMIT_COOLDOWN);
+    }
+}
+
+fn issue_state_cache() -> &'static Mutex<HashMap<String, (Instant, IssueState)>> {
+    static CACHE: OnceLock<Mutex<HashMap<String, (Instant, IssueState)>>> = OnceLock::new();
+    CACHE.get_or_init(|| Mutex::new(HashMap::new()))
+}
+
+fn issue_state_cache_key(owner: &str, repo: &str, number: &str) -> String {
+    format!("{owner}/{repo}#{number}")
+}
+
+#[derive(Debug, Deserialize)]
+struct RawIssueState {
+    #[serde(default)]
+    state: Option<String>,
+    #[serde(default, rename = "stateReason")]
+    state_reason: Option<String>,
+}
+
+fn parse_issue_state(json: &str) -> Result<IssueState> {
+    let raw: RawIssueState =
+        serde_json::from_str(json).map_err(|e| AoError::Scm(format!("parse issue state: {e}")))?;
+    let state = raw.state.unwrap_or_default();
+    if state.trim().is_empty() {
+        return Err(AoError::Scm("parse issue state: missing `state`".into()));
+    }
+    Ok(map_state(&state, raw.state_reason.as_deref()))
+}
 
 // ---------------------------------------------------------------------------
 // Plugin type
@@ -120,7 +183,22 @@ impl Tracker for GitHubTracker {
     }
 
     async fn get_issue(&self, identifier: &str) -> Result<Issue> {
+        if in_cooldown_now() {
+            tracing::debug!(
+                "tracker-github: cooldown active; skipping get_issue {} in {}",
+                identifier,
+                self.repo_slug()
+            );
+            return Err(AoError::Other(
+                "GitHub rate-limit cooldown active; skipping full issue fetch".into(),
+            ));
+        }
         let number = normalize_identifier(identifier);
+        tracing::debug!(
+            "tracker-github: get_issue {} in {}",
+            number,
+            self.repo_slug()
+        );
         let json = gh(&[
             "issue",
             "view",
@@ -135,20 +213,81 @@ impl Tracker for GitHubTracker {
     }
 
     async fn is_completed(&self, identifier: &str) -> Result<bool> {
-        // TODO(perf, Phase D+): this fetches the full issue payload
-        // (~8 fields) to read a single bit. Reusing `get_issue` keeps
-        // state-mapping logic single-sourced so an `IssueState` tweak
-        // can't regress one call site and leave the other behind. The
-        // reaction engine polls this every few seconds, but `gh`'s own
-        // ~100ms subprocess overhead dominates the ~2KB wasted bytes —
-        // not worth specializing until polling is hot enough to measure.
-        // When we optimize, extract a private `fetch_state` helper so
-        // both methods still funnel through `map_state`.
-        let issue = self.get_issue(identifier).await?;
-        Ok(matches!(
-            issue.state,
-            IssueState::Closed | IssueState::Cancelled
-        ))
+        let number = normalize_identifier(identifier);
+        let key = issue_state_cache_key(&self.owner, &self.repo, &number);
+
+        if let Ok(cache) = issue_state_cache().lock() {
+            if let Some((at, state)) = cache.get(&key) {
+                if at.elapsed() < ISSUE_STATE_TTL {
+                    tracing::debug!(
+                        "tracker-github: is_completed cache hit {} in {}",
+                        number,
+                        self.repo_slug()
+                    );
+                    return Ok(matches!(state, IssueState::Closed | IssueState::Cancelled));
+                }
+            }
+        }
+
+        if in_cooldown_now() {
+            // Prefer stale cache during cooldown to avoid hammering.
+            if let Ok(cache) = issue_state_cache().lock() {
+                if let Some((_at, state)) = cache.get(&key) {
+                    tracing::debug!(
+                        "tracker-github: cooldown active; using stale cached state for {} in {}",
+                        number,
+                        self.repo_slug()
+                    );
+                    return Ok(matches!(state, IssueState::Closed | IssueState::Cancelled));
+                }
+            }
+            tracing::debug!(
+                "tracker-github: cooldown active; skipping is_completed {} in {}",
+                number,
+                self.repo_slug()
+            );
+            return Err(AoError::Other(
+                "GitHub rate-limit cooldown active; skipping issue completion check".into(),
+            ));
+        }
+
+        tracing::debug!(
+            "tracker-github: is_completed fetch (minimal) {} in {}",
+            number,
+            self.repo_slug()
+        );
+        let json = match gh(&[
+            "issue",
+            "view",
+            &number,
+            "--repo",
+            &self.repo_slug(),
+            "--json",
+            "state,stateReason",
+        ])
+        .await
+        {
+            Ok(j) => j,
+            Err(e) => {
+                let msg = e.to_string();
+                if is_rate_limited_error(&msg) {
+                    tracing::warn!(
+                        "tracker-github: rate-limited during is_completed; entering cooldown: {e}"
+                    );
+                    enter_cooldown();
+                }
+                return Err(e);
+            }
+        };
+
+        let state = parse_issue_state(&json)?;
+        if let Ok(mut cache) = issue_state_cache().lock() {
+            if cache.len() >= ISSUE_STATE_CACHE_MAX {
+                cache.clear();
+            }
+            cache.insert(key, (Instant::now(), state.clone()));
+        }
+        Ok(matches!(state, IssueState::Closed | IssueState::Cancelled))
     }
 
     fn issue_url(&self, identifier: &str) -> String {
@@ -327,6 +466,11 @@ fn parse_github_remote(url: &str) -> Option<(String, String)> {
 /// env hardening as the SCM plugin (`GH_PAGER=cat`, etc.) so stdout stays
 /// deterministic regardless of the user's shell config.
 async fn gh(args: &[&str]) -> Result<String> {
+    if in_cooldown_now() {
+        return Err(AoError::Scm(
+            "GitHub rate-limit cooldown active; skipping gh subprocess".into(),
+        ));
+    }
     let mut cmd = Command::new("gh");
     cmd.args(args);
     cmd.env("GH_PAGER", "cat");
@@ -340,6 +484,9 @@ async fn gh(args: &[&str]) -> Result<String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
+        if is_rate_limited_error(stderr.as_ref()) {
+            enter_cooldown();
+        }
         return Err(AoError::Scm(format!(
             "gh {} failed: {}",
             args.join(" "),


### PR DESCRIPTION
## Summary
- Reduce GitHub API usage during polling by caching and minimizing expensive calls.
- `scm-github`: cache `pending_comments`, cap GraphQL `reviewThreads` pagination, and enter a short cooldown when rate limits are detected.
- `tracker-github`: make `is_completed` fetch only `state/stateReason`, add a short TTL cache for repeated checks, and enter cooldown/backoff on detected rate limits.

## Test plan
- [x] `cargo test -p ao-plugin-scm-github`
- [x] `cargo test -p ao-plugin-tracker-github`

Closes #119.