### PR TITLE
docs: mark workspace hooks as implemented

### DIFF
--- a/docs/plans/remaining-to-port/1-3-workspace-plugin-hooks-symlinks-postcreate-restore.md
+++ b/docs/plans/remaining-to-port/1-3-workspace-plugin-hooks-symlinks-postcreate-restore.md
@@ -1,6 +1,6 @@
 # 1.3 Workspace plugin hooks (symlinks, postCreate, restore)
 
-Status: planned
+Status: implemented (symlinks + postCreate); restore/list parity still open
 
 ## Why
 
@@ -10,10 +10,16 @@ Status: planned
 
 - Config supports:
   - `crates/ao-core/src/config.rs`: `ProjectConfig.symlinks`, `ProjectConfig.post_create`
-- Workspace plugins are minimal:
-  - `crates/plugins/workspace-worktree/src/lib.rs`: only `create()` and `destroy()`
-  - `crates/plugins/workspace-clone/src/lib.rs`: only `create()` and `destroy()`
-- No `Workspace::restore` or `Workspace::list` surface in `crates/ao-core/src/traits.rs` today.
+- Workspace creation executes hooks:
+  - `crates/ao-core/src/workspace_hooks.rs`: `apply_workspace_hooks()` (symlinks + `postCreate`)
+  - `crates/plugins/workspace-worktree/src/lib.rs`: calls `apply_workspace_hooks()` during `create()`
+  - `crates/plugins/workspace-clone/src/lib.rs`: calls `apply_workspace_hooks()` during `create()`
+  - `crates/ao-cli/src/commands/spawn.rs`: threads `symlinks` + `post_create` into `WorkspaceCreateConfig`
+- Integration coverage:
+  - `crates/plugins/workspace-worktree/tests/integration.rs`: `create_symlinks_and_post_create`
+  - `crates/plugins/workspace-clone/tests/integration.rs`: `create_symlinks_and_post_create`
+- Remaining parity gap:
+  - No `Workspace::list` / `Workspace::restore` surface in `crates/ao-core/src/traits.rs` today.
 
 ## Target behavior (ao-ts parity)
 

--- a/docs/remaining-to-port.md
+++ b/docs/remaining-to-port.md
@@ -20,13 +20,6 @@ Status: **Complete inventory** of what ao-ts has that ao-rs does not.
 - **Files to modify**: `crates/plugins/scm-github/src/lib.rs` (switch `pending_comments` to GraphQL), `crates/plugins/scm-github/src/parse.rs` (parse `reviewThreads` response)
 - **Effort**: Medium — requires GraphQL query design and response parsing.
 
-### 1.3 Workspace plugin hooks (symlinks, postCreate, restore)
-
-- **ao-ts**: Workspace plugins support `symlinks`, `postCreate` commands, `list`, and `restore` hooks.
-- **ao-rs**: `workspace-worktree` and `workspace-clone` implement only `create` and `destroy`. Config fields (`symlinks`, `post_create`) are parsed but not executed.
-- **Files to modify**: `crates/plugins/workspace-worktree/src/lib.rs`, `crates/plugins/workspace-clone/src/lib.rs`
-- **Effort**: Medium — symlinks and postCreate are straightforward; restore requires design.
-
 ### 1.4 Session restore prompt redelivery
 
 - **ao-ts**: `restore()` re-delivers the initial prompt after restarting the runtime.
@@ -172,9 +165,7 @@ Status: **Complete inventory** of what ao-ts has that ao-rs does not.
 
 ### 5.5 workspace-worktree / workspace-clone
 
-- No symlinks execution
-- No postCreate hooks execution
-- No list/restore support
+- `list`/`restore` parity is not implemented (workspace plugins remain `create`/`destroy` only)
 
 ### 5.6 scm-gitlab
 
@@ -237,7 +228,6 @@ Decision needed: integrate into runtime or keep as test infrastructure only.
 |------|--------|--------|
 | Project-level reaction resolution | Small | High — config feature silently broken |
 | Review thread resolution | Medium | High — reaction accuracy |
-| Workspace hooks (symlinks/postCreate) | Medium | Medium — config fields parsed but ignored |
 | Restore prompt redelivery | Small | Medium — UX gap |
 | `stop` command | Medium | Medium — supervisor management |
 | `--json` on status | Small | Medium — scripting/CI integration |


### PR DESCRIPTION
## Summary
- Update the ao-ts parity inventory to reflect that workspace `symlinks` and `postCreate` hooks are already implemented.
- Note the remaining parity gap for workspace `list`/`restore`.

Closes #77.

## Test plan
- `cargo test`

Made with [Cursor](https://cursor.com)