### PR TITLE
fix(scm-github): paginate reviewThreads for resolution state

### DIFF
--- a/crates/ao-core/src/workspace_hooks.rs
+++ b/crates/ao-core/src/workspace_hooks.rs
@@ -231,14 +231,11 @@ mod tests {
         let _ = tokio::fs::create_dir_all(&project_root).await;
         let _ = tokio::fs::create_dir_all(&workspace_root).await;
 
-        let err = apply_workspace_hooks(
-            &project_root,
-            &workspace_root,
-            &vec![".env".into()],
-            &vec![],
-        )
-        .await
-        .unwrap_err();
+        let symlinks = [".env".to_string()];
+        let post_create: [String; 0] = [];
+        let err = apply_workspace_hooks(&project_root, &workspace_root, &symlinks, &post_create)
+            .await
+            .unwrap_err();
 
         let msg = err.to_string();
         assert!(

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -75,6 +75,9 @@ const PENDING_COMMENTS_TTL: Duration = Duration::from_secs(30);
 const PENDING_COMMENTS_CACHE_MAX: usize = 128;
 const GITHUB_RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(120);
 
+type PendingCommentsCacheMap = HashMap<String, (Instant, Vec<ReviewComment>)>;
+type PendingCommentsCacheLock = Mutex<PendingCommentsCacheMap>;
+
 fn is_rate_limited_error(msg: &str) -> bool {
     let m = msg.to_lowercase();
     m.contains("api rate limit")
@@ -101,8 +104,8 @@ fn enter_cooldown() {
     }
 }
 
-fn pending_comments_cache() -> &'static Mutex<HashMap<String, (Instant, Vec<ReviewComment>)>> {
-    static CACHE: OnceLock<Mutex<HashMap<String, (Instant, Vec<ReviewComment>)>>> = OnceLock::new();
+fn pending_comments_cache() -> &'static PendingCommentsCacheLock {
+    static CACHE: OnceLock<PendingCommentsCacheLock> = OnceLock::new();
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
@@ -592,10 +595,9 @@ query ReviewThreads($owner: String!, $name: String!, $number: Int!, $after: Stri
 "#;
 
 async fn pending_comments_graphql(pr: &PullRequest) -> Result<Vec<ReviewComment>> {
-    // Hotfix: bound GraphQL usage to avoid burning rate limit on large PRs.
-    // If there are more pages, we intentionally fail fast so the caller
-    // falls back to the REST endpoint.
-    const MAX_PAGES: u32 = 1;
+    // Paginate review threads so `is_resolved` is accurate even on large PRs.
+    // Keep a hard cap as a safety valve against pathological pagination loops.
+    const MAX_PAGES: u32 = 100;
     let mut after: Option<String> = None;
     let mut all = Vec::new();
 
@@ -620,14 +622,27 @@ async fn pending_comments_graphql(pr: &PullRequest) -> Result<Vec<ReviewComment>
         all.extend(page.comments);
 
         if page.has_next_page {
-            return Err(AoError::Scm(
-                "GraphQL reviewThreads pagination exceeds hotfix cap; falling back to REST".into(),
-            ));
+            // GitHub should provide an endCursor if it claims there's another page.
+            // If it doesn't, bail out so the caller can fall back to REST.
+            after = page.end_cursor;
+            if after.is_none() {
+                return Err(AoError::Scm(
+                    "GraphQL reviewThreads signaled hasNextPage but omitted endCursor".into(),
+                ));
+            }
+            continue;
         }
-        after = page.end_cursor;
-        if after.is_none() {
-            break;
-        }
+        // No next page: clear cursor so we don't trip the MAX_PAGES guard below.
+        after = None;
+        break;
+    }
+
+    if after.is_some() {
+        // We hit MAX_PAGES but still had an `after` cursor, implying pagination
+        // didn't converge. Treat as an error so callers can fall back to REST.
+        return Err(AoError::Scm(format!(
+            "GraphQL reviewThreads pagination exceeded max pages ({MAX_PAGES})"
+        )));
     }
 
     Ok(all)

--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -285,7 +285,7 @@ impl Tracker for GitHubTracker {
             if cache.len() >= ISSUE_STATE_CACHE_MAX {
                 cache.clear();
             }
-            cache.insert(key, (Instant::now(), state.clone()));
+            cache.insert(key, (Instant::now(), state));
         }
         Ok(matches!(state, IssueState::Closed | IssueState::Cancelled))
     }


### PR DESCRIPTION
Large PRs can exceed a single reviewThreads page; paginate so pending comments retain accurate `is_resolved` instead of falling back to the REST endpoint.
Closes: #76 
Made-with: Cursor