### PR TITLE
feat(cli): add open command

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -255,6 +255,23 @@ pub enum Command {
         open: bool,
     },
 
+    /// Open dashboard or session targets in your browser / file manager.
+    ///
+    /// Defaults to opening the dashboard root URL.
+    Open {
+        /// Port where the dashboard is expected to be reachable.
+        #[arg(long, default_value_t = 3000)]
+        port: u16,
+
+        /// Prefer opening a new window (best-effort; platform-dependent).
+        #[arg(short = 'w', long = "new-window")]
+        new_window: bool,
+
+        /// What to open. Defaults to `dashboard`.
+        #[command(subcommand)]
+        target: Option<OpenTarget>,
+    },
+
     /// Kill a running session: stop the runtime, remove the worktree,
     /// and archive the session file.
     ///
@@ -337,6 +354,17 @@ pub enum SessionAction {
     Attach {
         /// Session uuid or unambiguous prefix.
         session: String,
+    },
+}
+
+#[derive(Subcommand, Clone, Debug)]
+pub enum OpenTarget {
+    /// Open the dashboard root URL.
+    Dashboard,
+    /// Open a session: dashboard detail URL if available, otherwise the workspace folder.
+    Session {
+        /// Session uuid or unambiguous prefix (e.g. an 8-char short id).
+        id: String,
     },
 }
 

--- a/crates/ao-cli/src/commands/mod.rs
+++ b/crates/ao-cli/src/commands/mod.rs
@@ -4,6 +4,7 @@ pub mod cleanup;
 pub mod dashboard;
 pub mod doctor;
 pub mod kill;
+pub mod open;
 pub mod pr;
 pub mod review_check;
 pub mod send;

--- a/crates/ao-cli/src/commands/open.rs
+++ b/crates/ao-cli/src/commands/open.rs
@@ -4,9 +4,10 @@ use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
 use std::path::PathBuf;
 use std::time::Duration;
 
-use ao_core::SessionManager;
+use ao_core::{Scm, SessionManager};
 
 use crate::cli::args::OpenTarget;
+use crate::cli::auto_scm::AutoScm;
 
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub(crate) enum OpenRequest {
@@ -96,7 +97,17 @@ pub(crate) async fn resolve_open_request(
             let sessions = SessionManager::with_default();
             let session = sessions.find_by_prefix(&id).await?;
             let alive = probe_local_tcp(port);
-            choose_session_open_request(alive, port, &id, session.workspace_path)
+            let pr_url = if alive {
+                None
+            } else {
+                let scm = AutoScm::new();
+                scm.detect_pr(&session)
+                    .await
+                    .ok()
+                    .flatten()
+                    .map(|pr| pr.url)
+            };
+            choose_session_open_request(alive, port, &id, pr_url.as_deref(), session.workspace_path)
         }
     }
 }
@@ -115,6 +126,7 @@ pub(crate) fn choose_session_open_request(
     dashboard_alive: bool,
     port: u16,
     session_id_or_prefix: &str,
+    pr_url: Option<&str>,
     workspace_path: Option<PathBuf>,
 ) -> Result<OpenRequest, Box<dyn std::error::Error>> {
     if dashboard_alive {
@@ -122,6 +134,9 @@ pub(crate) fn choose_session_open_request(
             port,
             session_id_or_prefix,
         )));
+    }
+    if let Some(url) = pr_url {
+        return Ok(OpenRequest::Url(url.to_string()));
     }
     let ws = workspace_path.ok_or_else(|| "session has no workspace path".to_string())?;
     Ok(OpenRequest::Path(ws))

--- a/crates/ao-cli/src/commands/open.rs
+++ b/crates/ao-cli/src/commands/open.rs
@@ -1,0 +1,133 @@
+//! `ao-rs open` — open dashboard/session targets.
+
+use std::net::{IpAddr, Ipv4Addr, SocketAddr, TcpStream};
+use std::path::PathBuf;
+use std::time::Duration;
+
+use ao_core::SessionManager;
+
+use crate::cli::args::OpenTarget;
+
+#[derive(Clone, Debug, PartialEq, Eq)]
+pub(crate) enum OpenRequest {
+    Url(String),
+    Path(PathBuf),
+}
+
+pub(crate) trait Opener {
+    fn open(&self, req: &OpenRequest, new_window: bool) -> Result<(), Box<dyn std::error::Error>>;
+}
+
+pub(crate) struct OsOpener;
+
+impl Opener for OsOpener {
+    fn open(&self, req: &OpenRequest, new_window: bool) -> Result<(), Box<dyn std::error::Error>> {
+        match req {
+            OpenRequest::Url(url) => open_str(url, new_window),
+            OpenRequest::Path(path) => open_str(&path.display().to_string(), new_window),
+        }
+    }
+}
+
+fn open_str(target: &str, new_window: bool) -> Result<(), Box<dyn std::error::Error>> {
+    #[cfg(target_os = "macos")]
+    {
+        let mut cmd = std::process::Command::new("open");
+        if new_window {
+            cmd.arg("-n");
+        }
+        cmd.arg(target);
+        cmd.spawn()?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "linux")]
+    {
+        let mut cmd = std::process::Command::new("xdg-open");
+        let _ = new_window;
+        cmd.arg(target);
+        cmd.spawn()?;
+        Ok(())
+    }
+
+    #[cfg(target_os = "windows")]
+    {
+        let mut cmd = std::process::Command::new("cmd");
+        let _ = new_window;
+        cmd.args(["/C", "start", "", target]);
+        cmd.spawn()?;
+        Ok(())
+    }
+
+    #[cfg(not(any(target_os = "macos", target_os = "linux", target_os = "windows")))]
+    {
+        let _ = (target, new_window);
+        Err("open is not supported on this platform".into())
+    }
+}
+
+pub async fn open(
+    port: u16,
+    new_window: bool,
+    target: OpenTarget,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let opener = OsOpener;
+    open_with(&opener, port, new_window, target).await
+}
+
+pub(crate) async fn open_with(
+    opener: &dyn Opener,
+    port: u16,
+    new_window: bool,
+    target: OpenTarget,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let req = resolve_open_request(port, target).await?;
+    opener.open(&req, new_window)?;
+    Ok(())
+}
+
+pub(crate) async fn resolve_open_request(
+    port: u16,
+    target: OpenTarget,
+) -> Result<OpenRequest, Box<dyn std::error::Error>> {
+    match target {
+        OpenTarget::Dashboard => Ok(OpenRequest::Url(dashboard_root_url(port))),
+        OpenTarget::Session { id } => {
+            let sessions = SessionManager::with_default();
+            let session = sessions.find_by_prefix(&id).await?;
+            let alive = probe_local_tcp(port);
+            choose_session_open_request(alive, port, &id, session.workspace_path)
+        }
+    }
+}
+
+pub(crate) fn dashboard_root_url(port: u16) -> String {
+    format!("http://127.0.0.1:{port}/")
+}
+
+pub(crate) fn dashboard_session_url(port: u16, session_id_or_prefix: &str) -> String {
+    // The dashboard crate is API-only; the best "detail view" we can open
+    // is the single-session JSON endpoint.
+    format!("http://127.0.0.1:{port}/api/sessions/{session_id_or_prefix}")
+}
+
+pub(crate) fn choose_session_open_request(
+    dashboard_alive: bool,
+    port: u16,
+    session_id_or_prefix: &str,
+    workspace_path: Option<PathBuf>,
+) -> Result<OpenRequest, Box<dyn std::error::Error>> {
+    if dashboard_alive {
+        return Ok(OpenRequest::Url(dashboard_session_url(
+            port,
+            session_id_or_prefix,
+        )));
+    }
+    let ws = workspace_path.ok_or_else(|| "session has no workspace path".to_string())?;
+    Ok(OpenRequest::Path(ws))
+}
+
+pub(crate) fn probe_local_tcp(port: u16) -> bool {
+    let addr = SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), port);
+    TcpStream::connect_timeout(&addr, Duration::from_millis(120)).is_ok()
+}

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -23,7 +23,7 @@ use std::time::Duration;
 
 use clap::Parser;
 
-use crate::cli::args::{Cli, Command, IssueAction, SessionAction};
+use crate::cli::args::{Cli, Command, IssueAction, OpenTarget, SessionAction};
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
@@ -117,6 +117,11 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             }
             commands::dashboard::dashboard(port, interval.map(Duration::from_secs)).await
         }
+        Command::Open {
+            port,
+            new_window,
+            target,
+        } => commands::open::open(port, new_window, target.unwrap_or(OpenTarget::Dashboard)).await,
         Command::Send { session, message } => commands::send::send(session, message).await,
         Command::Pr { session } => commands::pr::pr(session).await,
         Command::Kill { session } => commands::kill::kill(session).await,

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -19,6 +19,9 @@ use crate::cli::local_issue::{
 };
 use crate::cli::printing::session_display_title;
 use crate::cli::project::resolve_project_id;
+use crate::commands::open::{
+    choose_session_open_request, dashboard_root_url, dashboard_session_url, OpenRequest,
+};
 use crate::commands::pr::{
     ci_status_label, format_pr_report, pr_state_label, review_decision_label,
 };
@@ -140,6 +143,46 @@ fn start_parses_run_flags() {
         }
         _ => panic!("expected Start command"),
     }
+}
+
+// ---- open command ------------------------------------------------------
+
+#[test]
+fn open_dashboard_url_uses_localhost_port() {
+    assert_eq!(dashboard_root_url(3000), "http://127.0.0.1:3000/");
+    assert_eq!(dashboard_root_url(4321), "http://127.0.0.1:4321/");
+}
+
+#[test]
+fn open_session_prefers_dashboard_when_alive() {
+    let req = choose_session_open_request(true, 3000, "abc123", None).unwrap();
+    assert_eq!(
+        req,
+        OpenRequest::Url("http://127.0.0.1:3000/api/sessions/abc123".into())
+    );
+    assert_eq!(
+        dashboard_session_url(3000, "abc123"),
+        "http://127.0.0.1:3000/api/sessions/abc123"
+    );
+}
+
+#[test]
+fn open_session_falls_back_to_workspace_path_when_dashboard_down() {
+    let ws = std::path::PathBuf::from("/tmp/demo");
+    let req = choose_session_open_request(false, 3000, "abc123", Some(ws.clone())).unwrap();
+    assert_eq!(req, OpenRequest::Path(ws));
+}
+
+#[test]
+fn open_session_without_workspace_errors_when_dashboard_down() {
+    let err = choose_session_open_request(false, 3000, "abc123", None)
+        .err()
+        .unwrap()
+        .to_string();
+    assert!(
+        err.contains("workspace"),
+        "expected workspace-related error, got: {err}"
+    );
 }
 
 fn fake_pr(number: u32) -> PullRequest {

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -155,7 +155,7 @@ fn open_dashboard_url_uses_localhost_port() {
 
 #[test]
 fn open_session_prefers_dashboard_when_alive() {
-    let req = choose_session_open_request(true, 3000, "abc123", None).unwrap();
+    let req = choose_session_open_request(true, 3000, "abc123", None, None).unwrap();
     assert_eq!(
         req,
         OpenRequest::Url("http://127.0.0.1:3000/api/sessions/abc123".into())
@@ -169,13 +169,29 @@ fn open_session_prefers_dashboard_when_alive() {
 #[test]
 fn open_session_falls_back_to_workspace_path_when_dashboard_down() {
     let ws = std::path::PathBuf::from("/tmp/demo");
-    let req = choose_session_open_request(false, 3000, "abc123", Some(ws.clone())).unwrap();
+    let req = choose_session_open_request(false, 3000, "abc123", None, Some(ws.clone())).unwrap();
     assert_eq!(req, OpenRequest::Path(ws));
 }
 
 #[test]
+fn open_session_falls_back_to_pr_url_when_dashboard_down_and_pr_known() {
+    let req = choose_session_open_request(
+        false,
+        3000,
+        "abc123",
+        Some("https://github.com/acme/widgets/pull/42"),
+        None,
+    )
+    .unwrap();
+    assert_eq!(
+        req,
+        OpenRequest::Url("https://github.com/acme/widgets/pull/42".into())
+    );
+}
+
+#[test]
 fn open_session_without_workspace_errors_when_dashboard_down() {
-    let err = choose_session_open_request(false, 3000, "abc123", None)
+    let err = choose_session_open_request(false, 3000, "abc123", None, None)
         .err()
         .unwrap()
         .to_string();

--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -262,7 +262,8 @@ impl Tracker for GitHubTracker {
             "api",
             &format!("repos/{}/{}/issues/{}", self.owner, self.repo, number),
         ])
-        .await {
+        .await
+        {
             Ok(j) => j,
             Err(e) => {
                 let msg = e.to_string();


### PR DESCRIPTION
## Summary
- Add `ao-rs open` command with `dashboard` (default) and `session <id>` targets.
- Implement best-effort OS open adapter with optional `--new-window`.
- `open session <id>` behavior:
  - If dashboard port is reachable: open `http://127.0.0.1:<port>/api/sessions/<id>`
  - Otherwise: open the session PR URL if detectable; else open the session workspace folder

## Test plan
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- Manual:
  - `cargo run -p ao-cli -- open`
  - `cargo run -p ao-cli -- open session <id>`

Closes #80.