### PR TITLE
feat(cli): add config-help command

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -121,6 +121,7 @@ dependencies = [
  "ao-plugin-workspace-worktree",
  "async-trait",
  "clap",
+ "insta",
  "libc",
  "semver",
  "tokio",
@@ -701,6 +702,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "bstr"
+version = "1.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "63044e1ae8e69f3b5a92c736ca6269b8d12fa7efe39bf34ddb06d102cf0e2cab"
+dependencies = [
+ "memchr",
+ "serde",
+]
+
+[[package]]
 name = "bumpalo"
 version = "3.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -918,6 +929,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
 dependencies = [
  "crossbeam-utils",
+]
+
+[[package]]
+name = "console"
+version = "0.16.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d64e8af5551369d19cf50138de61f1c42074ab970f74e99be916646777f8fc87"
+dependencies = [
+ "encode_unicode",
+ "libc",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -1324,6 +1346,12 @@ name = "embed_plist"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ef6b89e5b37196644d8796de5268852ff179b44e96276cf4290264843743bb7"
+
+[[package]]
+name = "encode_unicode"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "34aa73646ffb006b8f5147f3dc182bd4bcb190227ce861fc4a4844bf8e3cb2c0"
 
 [[package]]
 name = "endi"
@@ -1883,6 +1911,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
 
 [[package]]
+name = "globset"
+version = "0.4.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52dfc19153a48bde0cbd630453615c8151bce3a5adfac7a0aebfbf0a1e1f57e3"
+dependencies = [
+ "aho-corasick",
+ "bstr",
+ "log",
+ "regex-automata",
+ "regex-syntax",
+]
+
+[[package]]
 name = "gobject-sys"
 version = "0.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2317,6 +2358,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a588916bfdfd92e71cacef98a63d9b1f0d74d6599980d11894290e7ddefffcf7"
 dependencies = [
  "cfb",
+]
+
+[[package]]
+name = "insta"
+version = "1.47.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b4a6248eb93a4401ed2f37dfe8ea592d3cf05b7cf4f8efa867b6895af7e094e"
+dependencies = [
+ "console",
+ "globset",
+ "once_cell",
+ "similar",
+ "tempfile",
+ "walkdir",
 ]
 
 [[package]]
@@ -4338,6 +4393,12 @@ name = "simd-adler32"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "703d5c7ef118737c72f1af64ad2f6f8c5e1921f818cdcb97b8fe6fc69bf66214"
+
+[[package]]
+name = "similar"
+version = "2.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "siphasher"

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -36,3 +36,6 @@ tracing = { workspace = true }
 tracing-subscriber = { workspace = true }
 libc = { workspace = true }
 semver = "1"
+
+[dev-dependencies]
+insta = { version = "1", features = ["glob"] }

--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -336,6 +336,12 @@ pub enum Command {
     /// FAIL per check.
     Doctor,
 
+    /// Print a concise guide to configuring `ao-rs`.
+    ///
+    /// Includes config discovery rules, common keys, the example config file,
+    /// and links to the full docs.
+    ConfigHelp,
+
     /// Scan active sessions' PRs for new review comments.
     ///
     /// For each non-terminal session that has a PR, fetches pending comments

--- a/crates/ao-cli/src/commands/config_help.rs
+++ b/crates/ao-cli/src/commands/config_help.rs
@@ -1,0 +1,50 @@
+pub(crate) fn render_config_help() -> String {
+    // Keep this output stable for copy/paste and snapshot testing.
+    // No colors, no dynamic paths, no timestamps.
+    let s = r#"ao-rs config help
+
+Config file name
+  ao-rs.yaml
+
+Discovery
+  ao-rs searches for `ao-rs.yaml` by walking up from the current working directory.
+  The first match wins.
+
+Getting started
+  1) Copy the example config:
+       cp ao-rs.yaml.example ao-rs.yaml
+  2) Edit `ao-rs.yaml` for your repos, defaults, reactions, and notifier routing.
+  3) Validate your setup:
+       ao-rs doctor
+
+Example config file
+  ao-rs.yaml.example
+
+Common keys (high level)
+  port: dashboard port
+  defaults: runtime/agent/workspace/tracker defaults
+  projects: per-repo settings (repo, path, default branch, worker overrides)
+  reactions: automation rules (thresholds, actions, escalation)
+  notificationRouting / notification_routing: route notifications by priority
+
+Docs
+  docs/config.md
+  docs/reactions.md
+"#;
+    s.to_string()
+}
+
+pub async fn config_help() -> Result<(), Box<dyn std::error::Error>> {
+    print!("{}", render_config_help());
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn config_help_output_snapshot() {
+        insta::assert_snapshot!(render_config_help());
+    }
+}

--- a/crates/ao-cli/src/commands/mod.rs
+++ b/crates/ao-cli/src/commands/mod.rs
@@ -1,6 +1,7 @@
 //! Subcommand implementations (`ao-rs <cmd>`).
 
 pub mod cleanup;
+pub mod config_help;
 pub mod dashboard;
 pub mod doctor;
 pub mod kill;
@@ -12,6 +13,6 @@ pub mod spawn;
 pub mod start;
 pub mod status;
 pub mod stop;
-pub mod verify;
 pub mod update;
+pub mod verify;
 pub mod watch;

--- a/crates/ao-cli/src/commands/snapshots/ao_rs__commands__config_help__tests__config_help_output_snapshot.snap
+++ b/crates/ao-cli/src/commands/snapshots/ao_rs__commands__config_help__tests__config_help_output_snapshot.snap
@@ -1,0 +1,33 @@
+---
+source: crates/ao-cli/src/commands/config_help.rs
+expression: render_config_help()
+---
+ao-rs config help
+
+Config file name
+  ao-rs.yaml
+
+Discovery
+  ao-rs searches for `ao-rs.yaml` by walking up from the current working directory.
+  The first match wins.
+
+Getting started
+  1) Copy the example config:
+       cp ao-rs.yaml.example ao-rs.yaml
+  2) Edit `ao-rs.yaml` for your repos, defaults, reactions, and notifier routing.
+  3) Validate your setup:
+       ao-rs doctor
+
+Example config file
+  ao-rs.yaml.example
+
+Common keys (high level)
+  port: dashboard port
+  defaults: runtime/agent/workspace/tracker defaults
+  projects: per-repo settings (repo, path, default branch, worker overrides)
+  reactions: automation rules (thresholds, actions, escalation)
+  notificationRouting / notification_routing: route notifications by priority
+
+Docs
+  docs/config.md
+  docs/reactions.md

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -9,6 +9,7 @@
 //!   - `pr`              — inspect GitHub PR state + CI + review for a session
 //!   - `update`          — check for / perform CLI upgrade
 //!   - `doctor`          — check environment: required tools, auth, config
+//!   - `config-help`     — print a concise config guide
 //!   - `review-check`    — scan PRs for new comments and forward to agents
 //!   - `session restore` — respawn a terminated session in-place
 //!   - `issue new` / `issue list` / `issue show` — markdown issues under `docs/issues/`
@@ -134,6 +135,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             smoke_only,
         } => commands::update::update(check, skip_smoke, smoke_only).await,
         Command::Doctor => commands::doctor::doctor().await,
+        Command::ConfigHelp => commands::config_help::config_help().await,
         Command::ReviewCheck { project, dry_run } => {
             commands::review_check::review_check(project, dry_run).await
         }


### PR DESCRIPTION
## Summary
- Add `ao-rs config-help` to print a concise, stable config guide.
- Mentions config discovery (`ao-rs.yaml` walked up from CWD), points to `ao-rs.yaml.example`, and links `docs/config.md` + `docs/reactions.md`.

## Test plan
- `cargo test -p ao-cli`

Closes #85.

Made with [Cursor](https://cursor.com)