### PR TITLE
feat(cli): add missing start flags

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -33,6 +33,20 @@ pub enum Command {
         #[arg(long)]
         run: bool,
 
+        /// Don't start the dashboard HTTP server.
+        ///
+        /// Implies starting the orchestrator (lifecycle loop) after ensuring
+        /// `ao-rs.yaml` exists.
+        #[arg(long, conflicts_with = "no_orchestrator")]
+        no_dashboard: bool,
+
+        /// Don't start the orchestrator (lifecycle loop).
+        ///
+        /// Implies starting the dashboard HTTP server after ensuring `ao-rs.yaml`
+        /// exists. In this mode the dashboard is "read-only" (no lifecycle events).
+        #[arg(long, conflicts_with = "no_dashboard")]
+        no_orchestrator: bool,
+
         /// Port to listen on when `--run` is set.
         #[arg(long, default_value_t = 3000)]
         port: u16,
@@ -44,6 +58,20 @@ pub enum Command {
         /// Open the dashboard root URL in the default browser (requires `--run`).
         #[arg(long)]
         open: bool,
+
+        /// Re-generate `ao-rs.yaml` even if it already exists (overwrites).
+        ///
+        /// Also re-runs skill installation. Use `--interactive` to confirm before overwriting.
+        #[arg(long)]
+        rebuild: bool,
+
+        /// Enable verbose debug logging for this invocation (unless `RUST_LOG` is already set).
+        #[arg(long)]
+        dev: bool,
+
+        /// Prompt before destructive actions (currently only affects `--rebuild`).
+        #[arg(long)]
+        interactive: bool,
     },
 
     /// Spawn a new agent session in an isolated git worktree.

--- a/crates/ao-cli/src/commands/dashboard.rs
+++ b/crates/ao-cli/src/commands/dashboard.rs
@@ -4,14 +4,74 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use ao_core::{
-    paths, Agent, AoConfig, LifecycleManager, LoadedConfig, LockError, PidFile, ReactionEngine,
-    Scm, SessionManager,
+    paths, Agent, AoConfig, LifecycleManager, LoadedConfig, LockError, OrchestratorEvent, PidFile,
+    ReactionEngine, Scm, SessionManager,
 };
+use tokio::sync::broadcast;
 
 use crate::cli::auto_scm::AutoScm;
 use crate::cli::lifecycle_wiring::notifier_registry_from_config;
 use crate::cli::plugins::{select_runtime, MultiAgent};
 use crate::cli::printing::print_config_warnings;
+
+fn build_dashboard_state() -> Result<ao_dashboard::state::AppState, Box<dyn std::error::Error>> {
+    let sessions = Arc::new(SessionManager::with_default());
+    let agent: Arc<dyn Agent> = Arc::new(MultiAgent);
+    let scm: Arc<dyn Scm> = Arc::new(AutoScm::new());
+
+    // Dashboard handlers expect a broadcast sender even if no lifecycle loop is running.
+    // In "HTTP-only" mode this sender will never publish any events.
+    let (events_tx, _events_rx) = broadcast::channel::<OrchestratorEvent>(256);
+
+    let config_path = AoConfig::local_path();
+    let LoadedConfig { config, warnings } =
+        AoConfig::load_from_or_default_with_warnings(&config_path)
+            .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    print_config_warnings(&config_path, &warnings);
+
+    let runtime_name = config
+        .defaults
+        .as_ref()
+        .map(|d| d.runtime.as_str())
+        .unwrap_or("tmux")
+        .to_string();
+    let runtime = select_runtime(&runtime_name);
+
+    Ok(ao_dashboard::state::AppState {
+        sessions,
+        events_tx,
+        runtime,
+        scm,
+        agent,
+    })
+}
+
+/// Run just the dashboard HTTP server (no lifecycle loop).
+pub async fn dashboard_only(port: u16) -> Result<(), Box<dyn std::error::Error>> {
+    let dashboard_state = build_dashboard_state()?;
+
+    println!(
+        "→ dashboard listening on http://127.0.0.1:{port}/ (API under /api/, try /health) (no orchestrator)"
+    );
+
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    tokio::select! {
+        _ = &mut ctrl_c => {
+            println!();
+            println!("→ shutdown requested");
+        }
+        result = ao_dashboard::run_server(dashboard_state, port) => {
+            if let Err(e) = result {
+                eprintln!("dashboard server error: {e}");
+            }
+        }
+    }
+
+    println!("→ stopped.");
+    Ok(())
+}
 
 /// Run the dashboard API server alongside the lifecycle loop.
 ///

--- a/crates/ao-cli/src/commands/start.rs
+++ b/crates/ao-cli/src/commands/start.rs
@@ -1,5 +1,6 @@
 //! `ao-rs start` — generate or load project config.
 
+use std::io::{self, Write};
 use std::path::PathBuf;
 use std::time::Duration;
 
@@ -11,19 +12,35 @@ use ao_core::{
 use crate::cli::browser::spawn_open_dashboard_browser;
 use crate::cli::printing::print_config_warnings;
 use crate::cli::project::resolve_repo_root;
-use crate::commands::dashboard::dashboard;
+use crate::commands::dashboard::{dashboard, dashboard_only};
+use crate::commands::watch::watch;
 
-pub async fn start(
-    repo: Option<PathBuf>,
-    run: bool,
-    port: u16,
-    interval_override: Option<Duration>,
-    open: bool,
-) -> Result<(), Box<dyn std::error::Error>> {
-    let repo_root = resolve_repo_root(repo)?;
+pub struct StartOptions {
+    pub repo: Option<PathBuf>,
+    pub run: bool,
+    pub no_dashboard: bool,
+    pub no_orchestrator: bool,
+    pub port: u16,
+    pub interval_override: Option<Duration>,
+    pub open: bool,
+    pub rebuild: bool,
+    pub interactive: bool,
+}
+
+fn confirm_overwrite(path: &std::path::Path) -> io::Result<bool> {
+    eprint!("{} already exists. Overwrite? [y/N] ", path.display());
+    let _ = io::stderr().flush();
+    let mut line = String::new();
+    io::stdin().read_line(&mut line)?;
+    let answer = line.trim().to_ascii_lowercase();
+    Ok(matches!(answer.as_str(), "y" | "yes"))
+}
+
+pub async fn start(opts: StartOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let repo_root = resolve_repo_root(opts.repo)?;
     let config_path = AoConfig::path_in(&repo_root);
 
-    if config_path.exists() {
+    if config_path.exists() && !opts.rebuild {
         // Load existing config and print summary.
         let LoadedConfig {
             mut config,
@@ -164,12 +181,34 @@ pub async fn start(
         );
         println!();
         println!("Edit {} to customize.", config_path.display());
-        if run {
-            if open {
-                spawn_open_dashboard_browser(port);
-            }
-            return dashboard(port, interval_override).await;
+        let should_run = opts.run || opts.no_dashboard || opts.no_orchestrator;
+        if !should_run {
+            return Ok(());
         }
+
+        if opts.no_dashboard {
+            if opts.open {
+                eprintln!("(warn) --open ignored because --no-dashboard was set");
+            }
+            return watch(opts.interval_override).await;
+        }
+
+        if opts.open {
+            spawn_open_dashboard_browser(opts.port);
+        }
+
+        if opts.no_orchestrator {
+            if opts.interval_override.is_some() {
+                eprintln!("(warn) --interval ignored because --no-orchestrator was set");
+            }
+            return dashboard_only(opts.port).await;
+        }
+
+        return dashboard(opts.port, opts.interval_override).await;
+    }
+
+    if opts.rebuild && config_path.exists() && opts.interactive && !confirm_overwrite(&config_path)?
+    {
         return Ok(());
     }
 
@@ -213,12 +252,28 @@ pub async fn start(
     );
     println!();
     println!("Edit {} to customize.", config_path.display());
-    if run {
-        if open {
-            spawn_open_dashboard_browser(port);
+    let should_run = opts.run || opts.no_dashboard || opts.no_orchestrator;
+    if !should_run {
+        return Ok(());
+    }
+
+    if opts.no_dashboard {
+        if opts.open {
+            eprintln!("(warn) --open ignored because --no-dashboard was set");
         }
-        dashboard(port, interval_override).await
+        return watch(opts.interval_override).await;
+    }
+
+    if opts.open {
+        spawn_open_dashboard_browser(opts.port);
+    }
+
+    if opts.no_orchestrator {
+        if opts.interval_override.is_some() {
+            eprintln!("(warn) --interval ignored because --no-orchestrator was set");
+        }
+        dashboard_only(opts.port).await
     } else {
-        Ok(())
+        dashboard(opts.port, opts.interval_override).await
     }
 }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -26,28 +26,60 @@ use std::time::Duration;
 use clap::Parser;
 
 use crate::cli::args::{Cli, Command, IssueAction, OpenTarget, PluginAction, SessionAction};
+use crate::commands::start::StartOptions;
+
+fn init_tracing(dev: bool) {
+    // Cheap tracing setup — honours RUST_LOG. Without this, tracing calls in the
+    // lifecycle loop would be silent.
+    let _ = if std::env::var_os("RUST_LOG").is_some() {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .try_init()
+    } else if dev {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new(
+                "info,ao_cli=debug,ao_core=debug",
+            ))
+            .try_init()
+    } else {
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::new("warn,ao_core=info"))
+            .try_init()
+    };
+}
 
 #[tokio::main]
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
-    // Cheap tracing setup — honours RUST_LOG, defaults to warn for our crates.
-    // Without this, tracing::warn! calls in the lifecycle loop would be silent.
-    let _ = tracing_subscriber::fmt()
-        .with_env_filter(
-            tracing_subscriber::EnvFilter::try_from_default_env()
-                .unwrap_or_else(|_| tracing_subscriber::EnvFilter::new("warn,ao_core=info")),
-        )
-        .try_init();
-
     let cli = Cli::parse();
+    let dev = matches!(cli.command, Command::Start { dev: true, .. });
+    init_tracing(dev);
 
     match cli.command {
         Command::Start {
             repo,
             run,
+            no_dashboard,
+            no_orchestrator,
             port,
             interval,
             open,
-        } => commands::start::start(repo, run, port, interval.map(Duration::from_secs), open).await,
+            rebuild,
+            dev: _,
+            interactive,
+        } => {
+            commands::start::start(StartOptions {
+                repo,
+                run,
+                no_dashboard,
+                no_orchestrator,
+                port,
+                interval_override: interval.map(Duration::from_secs),
+                open,
+                rebuild,
+                interactive,
+            })
+            .await
+        }
         Command::Spawn {
             task,
             issue,

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -147,6 +147,52 @@ fn start_parses_run_flags() {
 }
 
 #[test]
+fn start_parses_component_toggles_without_run() {
+    let cli = Cli::try_parse_from(["ao-rs", "start", "--no-dashboard"]).unwrap();
+    match cli.command {
+        Command::Start {
+            run,
+            no_dashboard,
+            no_orchestrator,
+            ..
+        } => {
+            assert!(!run);
+            assert!(no_dashboard);
+            assert!(!no_orchestrator);
+        }
+        _ => panic!("expected Start command"),
+    }
+
+    let cli =
+        Cli::try_parse_from(["ao-rs", "start", "--no-orchestrator", "--port", "4001"]).unwrap();
+    match cli.command {
+        Command::Start {
+            run,
+            no_dashboard,
+            no_orchestrator,
+            port,
+            ..
+        } => {
+            assert!(!run);
+            assert!(!no_dashboard);
+            assert!(no_orchestrator);
+            assert_eq!(port, 4001);
+        }
+        _ => panic!("expected Start command"),
+    }
+}
+
+#[test]
+fn start_rejects_conflicting_component_toggles() {
+    let err = Cli::try_parse_from(["ao-rs", "start", "--no-dashboard", "--no-orchestrator"])
+        .err()
+        .expect("expected clap parse failure");
+    let msg = err.to_string();
+    assert!(msg.contains("--no-dashboard"));
+    assert!(msg.contains("--no-orchestrator"));
+}
+
+#[test]
 fn verify_requires_target_unless_list() {
     match Cli::try_parse_from(["ao-rs", "verify"]) {
         Ok(_) => panic!("expected clap parse failure"),


### PR DESCRIPTION
Fixes #86.

## Summary
- Add `ao-rs start` parity flags: `--no-dashboard`, `--no-orchestrator`, `--rebuild`, `--dev`, `--interactive`.
- Implement dashboard-only mode (HTTP server without lifecycle loop) and lifecycle-only mode (delegates to `watch`).
- Update tracing init so `start --dev` increases verbosity unless `RUST_LOG` is set.

## Behavior
- Default stays unchanged: `ao-rs start` only ensures `ao-rs.yaml` exists.
- `ao-rs start --no-dashboard` starts lifecycle only.
- `ao-rs start --no-orchestrator` starts dashboard HTTP only (no lifecycle events).
- `--rebuild` overwrites repo-local `ao-rs.yaml` and re-runs skill install; `--interactive` prompts before overwrite.

## Test plan
- `cargo test --all-features`
- `cargo clippy --all-targets --all-features -- -D warnings`

Made with [Cursor](https://cursor.com)