### PR TITLE
feat(cli): status --json and --watch/--interval

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -124,6 +124,8 @@ dependencies = [
  "insta",
  "libc",
  "semver",
+ "serde",
+ "serde_json",
  "serde_yaml",
  "tokio",
  "tracing",

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -37,6 +37,8 @@ tracing-subscriber = { workspace = true }
 libc = { workspace = true }
 semver = "1"
 serde_yaml = { workspace = true }
+serde = { workspace = true }
+serde_json = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1", features = ["glob"] }

--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -227,6 +227,18 @@ pub enum Command {
         /// Include killed/terminated sessions in the output.
         #[arg(long)]
         all: bool,
+
+        /// Output machine-readable JSON to stdout (array of sessions).
+        #[arg(long)]
+        json: bool,
+
+        /// Re-print status snapshots until interrupted (Ctrl-C).
+        #[arg(long)]
+        watch: bool,
+
+        /// Polling interval in seconds when `--watch` is set.
+        #[arg(long, default_value_t = 2, requires = "watch")]
+        interval: u64,
     },
 
     /// Run the lifecycle loop and stream events to stdout.

--- a/crates/ao-cli/src/commands/status.rs
+++ b/crates/ao-cli/src/commands/status.rs
@@ -1,70 +1,177 @@
 //! `ao-rs status` — list sessions with optional PR column.
 
+use std::io::Write;
+use std::time::Duration;
+
 use ao_core::{CiStatus, PrState, PullRequest, Scm, Session, SessionManager};
+use serde::Serialize;
+use tokio::time::sleep;
 
 use crate::cli::auto_scm::AutoScm;
 use crate::cli::printing::{session_display_title, truncate};
 use crate::commands::pr::{ci_status_label, pr_state_label};
 
-pub async fn status(
-    project_filter: Option<String>,
-    with_pr: bool,
-    with_cost: bool,
-    show_all: bool,
+#[derive(Clone, Debug)]
+pub struct StatusOptions {
+    pub project_filter: Option<String>,
+    pub with_pr: bool,
+    pub with_cost: bool,
+    pub show_all: bool,
+    pub json: bool,
+    pub watch: bool,
+    pub interval_secs: u64,
+}
+
+pub async fn status(opts: StatusOptions) -> Result<(), Box<dyn std::error::Error>> {
+    let mut out = std::io::stdout();
+    status_with_writer(opts, &mut out, None).await
+}
+
+async fn status_with_writer(
+    opts: StatusOptions,
+    mut out: impl Write,
+    #[allow(unused_variables)] max_iterations: Option<usize>,
 ) -> Result<(), Box<dyn std::error::Error>> {
     let manager = SessionManager::with_default();
-    let mut sessions = match &project_filter {
+
+    let interval = Duration::from_secs(opts.interval_secs.max(1));
+    run_status_loop(
+        &mut out,
+        opts.watch,
+        interval,
+        max_iterations,
+        !cfg!(test),
+        || render_snapshot(&manager, &opts),
+    )
+    .await
+}
+
+fn write_snapshot(out: &mut impl Write, s: &str) -> Result<(), Box<dyn std::error::Error>> {
+    out.write_all(s.as_bytes())?;
+    if !s.ends_with('\n') {
+        out.write_all(b"\n")?;
+    }
+    out.flush()?;
+    Ok(())
+}
+
+async fn run_status_loop<F, Fut>(
+    out: &mut impl Write,
+    watch: bool,
+    interval: Duration,
+    #[allow(unused_variables)] max_iterations: Option<usize>,
+    enable_ctrl_c: bool,
+    mut render: F,
+) -> Result<(), Box<dyn std::error::Error>>
+where
+    F: FnMut() -> Fut,
+    Fut: std::future::Future<Output = Result<String, Box<dyn std::error::Error>>>,
+{
+    let mut iterations = 0usize;
+    let ctrl_c = tokio::signal::ctrl_c();
+    tokio::pin!(ctrl_c);
+
+    loop {
+        let snapshot = render().await?;
+        write_snapshot(out, &snapshot)?;
+
+        if !watch {
+            break;
+        }
+
+        if cfg!(test) {
+            if let Some(max) = max_iterations {
+                iterations += 1;
+                if iterations >= max {
+                    break;
+                }
+            }
+        }
+
+        if enable_ctrl_c {
+            tokio::select! {
+                _ = &mut ctrl_c => break,
+                _ = sleep(interval) => {},
+            }
+        } else {
+            sleep(interval).await;
+        }
+    }
+
+    Ok(())
+}
+
+async fn render_snapshot(
+    manager: &SessionManager,
+    opts: &StatusOptions,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let mut sessions = match &opts.project_filter {
         Some(p) => manager.list_for_project(p).await?,
         None => manager.list().await?,
     };
 
-    if !show_all {
+    if !opts.show_all {
         sessions.retain(|s| !s.is_terminal());
     }
 
     if sessions.is_empty() {
-        match project_filter {
-            Some(p) => println!("no sessions in project '{p}'"),
-            None => println!("no sessions (use --all to include killed)"),
-        }
-        return Ok(());
+        return Ok(match &opts.project_filter {
+            Some(p) => format!("no sessions in project '{p}'\n"),
+            None => "no sessions (use --all to include killed)\n".to_string(),
+        });
     }
 
+    if opts.json {
+        render_json_snapshot(&sessions, opts).await
+    } else {
+        render_table_snapshot(&sessions, opts).await
+    }
+}
+
+async fn render_table_snapshot(
+    sessions: &[Session],
+    opts: &StatusOptions,
+) -> Result<String, Box<dyn std::error::Error>> {
     // Columns wide enough for the longest status (`changes_requested` = 17
     // chars) and the longest activity (`waiting_input` = 13 chars). Trying
     // to autosize is not worth it for a tool that prints ~10 rows max.
     //
     // Header and row formatting adapt to the --pr and --cost flags.
-    let cost_hdr = if with_cost {
+    let cost_hdr = if opts.with_cost {
         format!("{:<10} ", "COST")
     } else {
         String::new()
     };
-    if with_pr {
-        println!(
-            "{:<10} {:<14} {:<18} {:<14} {:<18} {:<24} {}TASK",
+
+    let mut buf = String::new();
+    if opts.with_pr {
+        buf.push_str(&format!(
+            "{:<10} {:<14} {:<18} {:<14} {:<18} {:<24} {}TASK\n",
             "ID", "PROJECT", "STATUS", "ACTIVITY", "BRANCH", "PR", cost_hdr
-        );
+        ));
     } else {
-        println!(
-            "{:<10} {:<14} {:<18} {:<14} {:<18} {}TASK",
+        buf.push_str(&format!(
+            "{:<10} {:<14} {:<18} {:<14} {:<18} {}TASK\n",
             "ID", "PROJECT", "STATUS", "ACTIVITY", "BRANCH", cost_hdr
-        );
+        ));
     }
 
-    // Build the SCM plugin once up front if `--pr` is on, rather than
-    // per-row. `AutoScm` delegates based on the detected PR URL shape.
-    let scm = if with_pr { Some(AutoScm::new()) } else { None };
+    // Build the SCM plugin once up front if `--pr` is on, rather than per-row.
+    let scm = if opts.with_pr {
+        Some(AutoScm::new())
+    } else {
+        None
+    };
 
     for s in sessions {
         let short_id: String = s.id.0.chars().take(8).collect();
-        let title = session_display_title(&s);
+        let title = session_display_title(s);
         let task = truncate(&title, 60);
         let activity = s
             .activity
             .map(|a| a.as_str().to_string())
             .unwrap_or_else(|| "-".to_string());
-        let cost_cell = if with_cost {
+        let cost_cell = if opts.with_cost {
             format!(
                 "{:<10} ",
                 s.cost
@@ -77,9 +184,9 @@ pub async fn status(
         };
 
         if let Some(scm) = scm.as_ref() {
-            let pr_cell = fetch_pr_column(scm, &s).await;
-            println!(
-                "{:<10} {:<14} {:<18} {:<14} {:<18} {:<24} {}{}",
+            let pr_cell = fetch_pr_column(scm, s).await;
+            buf.push_str(&format!(
+                "{:<10} {:<14} {:<18} {:<14} {:<18} {:<24} {}{}\n",
                 short_id,
                 s.project_id,
                 s.status.as_str(),
@@ -88,10 +195,10 @@ pub async fn status(
                 pr_cell,
                 cost_cell,
                 task,
-            );
+            ));
         } else {
-            println!(
-                "{:<10} {:<14} {:<18} {:<14} {:<18} {}{}",
+            buf.push_str(&format!(
+                "{:<10} {:<14} {:<18} {:<14} {:<18} {}{}\n",
                 short_id,
                 s.project_id,
                 s.status.as_str(),
@@ -99,10 +206,118 @@ pub async fn status(
                 s.branch,
                 cost_cell,
                 task,
-            );
+            ));
         }
     }
-    Ok(())
+
+    Ok(buf)
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StatusJsonCost {
+    input_tokens: u64,
+    output_tokens: u64,
+    cache_read_tokens: u64,
+    cache_creation_tokens: u64,
+    cost_usd: f64,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StatusJsonPr {
+    number: u32,
+    url: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    state: Option<PrState>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ci_status: Option<CiStatus>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+struct StatusJsonSession {
+    id: String,
+    short_id: String,
+    project: String,
+    status: String,
+    activity: Option<String>,
+    branch: String,
+    task: String,
+    created_at: u64,
+    agent: String,
+    runtime: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    workspace_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issue_id: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    issue_url: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pr: Option<StatusJsonPr>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost: Option<StatusJsonCost>,
+}
+
+async fn render_json_snapshot(
+    sessions: &[Session],
+    opts: &StatusOptions,
+) -> Result<String, Box<dyn std::error::Error>> {
+    let scm = if opts.with_pr {
+        Some(AutoScm::new())
+    } else {
+        None
+    };
+
+    let mut out: Vec<StatusJsonSession> = Vec::with_capacity(sessions.len());
+    for s in sessions {
+        let short_id: String = s.id.0.chars().take(8).collect();
+        let pr = if let Some(scm) = scm.as_ref() {
+            fetch_pr_json(scm, s).await
+        } else {
+            None
+        };
+        let cost = if opts.with_cost {
+            s.cost.as_ref().map(|c| StatusJsonCost {
+                input_tokens: c.input_tokens,
+                output_tokens: c.output_tokens,
+                cache_read_tokens: c.cache_read_tokens,
+                cache_creation_tokens: c.cache_creation_tokens,
+                cost_usd: c.cost_usd,
+            })
+        } else {
+            None
+        };
+        out.push(StatusJsonSession {
+            id: s.id.0.clone(),
+            short_id,
+            project: s.project_id.clone(),
+            status: s.status.as_str().to_string(),
+            activity: s.activity.map(|a| a.as_str().to_string()),
+            branch: s.branch.clone(),
+            task: s.task.clone(),
+            created_at: s.created_at,
+            agent: s.agent.clone(),
+            runtime: s.runtime.clone(),
+            workspace_path: s.workspace_path.as_ref().map(|p| p.display().to_string()),
+            issue_id: s.issue_id.clone(),
+            issue_url: s.issue_url.clone(),
+            pr,
+            cost,
+        });
+    }
+
+    Ok(format!("{}\n", serde_json::to_string(&out)?))
+}
+
+async fn fetch_pr_json(scm: &dyn Scm, session: &Session) -> Option<StatusJsonPr> {
+    let Ok(Some(pr)) = scm.detect_pr(session).await else {
+        return None;
+    };
+    let (state, ci) = tokio::join!(scm.pr_state(&pr), scm.ci_status(&pr));
+    Some(StatusJsonPr {
+        number: pr.number,
+        url: pr.url,
+        state: state.ok(),
+        ci_status: ci.ok(),
+    })
 }
 
 /// Best-effort PR column for `ao-rs status --pr`.
@@ -149,4 +364,98 @@ pub(crate) fn pr_column(
     }
     let ci_label = ci.map(ci_status_label).unwrap_or("?");
     format!("#{} {state_label}/{ci_label}", pr.number)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn json_snapshot_is_valid_json_array() {
+        let s = Session {
+            id: ao_core::SessionId("abc".into()),
+            project_id: "demo".into(),
+            status: ao_core::SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: "feat-x".into(),
+            task: "do work".into(),
+            workspace_path: None,
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: Some(ao_core::ActivityState::Ready),
+            created_at: 123,
+            cost: None,
+            issue_id: Some("87".into()),
+            issue_url: Some("https://github.com/duonghb53/ao-rs/issues/87".into()),
+        };
+
+        let opts = StatusOptions {
+            project_filter: None,
+            with_pr: false,
+            with_cost: false,
+            show_all: true,
+            json: true,
+            watch: false,
+            interval_secs: 2,
+        };
+
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let rendered = rt.block_on(async { render_json_snapshot(&[s], &opts).await.unwrap() });
+
+        let v: serde_json::Value = serde_json::from_str(rendered.trim()).unwrap();
+        assert!(v.is_array());
+        assert_eq!(v.as_array().unwrap().len(), 1);
+    }
+
+    #[test]
+    fn clap_watch_interval_is_required_by_watch_only() {
+        use clap::Parser;
+
+        // `--interval` requires `--watch`.
+        let parsed = crate::cli::args::Cli::try_parse_from(["ao-rs", "status", "--interval", "2"]);
+        assert!(parsed.is_err());
+
+        // With `--watch`, default interval applies.
+        let parsed = crate::cli::args::Cli::try_parse_from(["ao-rs", "status", "--watch"]);
+        assert!(parsed.is_ok());
+    }
+
+    #[tokio::test]
+    async fn watch_loops_at_least_twice_in_tests() {
+        let opts = StatusOptions {
+            project_filter: None,
+            with_pr: false,
+            with_cost: false,
+            show_all: true,
+            json: true,
+            watch: true,
+            interval_secs: 1,
+        };
+
+        let mut buf: Vec<u8> = Vec::new();
+        let mut n = 0usize;
+        run_status_loop(
+            &mut buf,
+            opts.watch,
+            Duration::from_millis(1),
+            Some(2),
+            false,
+            || {
+                n += 1;
+                async move { Ok(format!("[{{\"n\":{n}}}]\n")) }
+            },
+        )
+        .await
+        .unwrap();
+
+        let s = String::from_utf8(buf).unwrap();
+        // Two snapshots, each on its own line.
+        assert!(s.lines().count() >= 2);
+        // And each line is valid JSON.
+        for line in s.lines() {
+            let v: serde_json::Value = serde_json::from_str(line).unwrap();
+            assert!(v.is_array());
+        }
+    }
 }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -139,7 +139,21 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             pr,
             cost,
             all,
-        } => commands::status::status(project, pr, cost, all).await,
+            json,
+            watch,
+            interval,
+        } => {
+            commands::status::status(commands::status::StatusOptions {
+                project_filter: project,
+                with_pr: pr,
+                with_cost: cost,
+                show_all: all,
+                json,
+                watch,
+                interval_secs: interval,
+            })
+            .await
+        }
         Command::Watch { interval } => {
             commands::watch::watch(interval.map(Duration::from_secs)).await
         }


### PR DESCRIPTION
## Summary
- Add `ao-rs status --json` for machine-readable status snapshots.
- Add `ao-rs status --watch --interval <secs>` to repeat snapshots until interrupted.
- Keep existing human table output unchanged when `--json` is not set.

## Test plan
- `cargo test`
- Manual:
  - `ao-rs status --json | jq .`
  - `ao-rs status --watch --interval 2`

Closes #87.

Made with [Cursor](https://cursor.com)