### PR TITLE
feat(cli): add send missing flags (#89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -127,6 +127,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml",
+ "tempfile",
  "tokio",
  "tracing",
  "tracing-subscriber",

--- a/crates/ao-cli/Cargo.toml
+++ b/crates/ao-cli/Cargo.toml
@@ -42,3 +42,4 @@ serde_json = { workspace = true }
 
 [dev-dependencies]
 insta = { version = "1", features = ["glob"] }
+tempfile = "3"

--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -288,8 +288,25 @@ pub enum Command {
     Send {
         /// Session uuid or unambiguous prefix (e.g. an 8-char short id).
         session: String,
-        /// Message to deliver. Whitespace preserved verbatim.
-        message: String,
+        /// Message words to deliver; multiple words are joined with a space.
+        /// Required unless `--file` is provided.
+        #[arg(required_unless_present = "file")]
+        message: Vec<String>,
+        /// Send the contents of a file as the message body.
+        ///
+        /// When combined with inline words, the file content is appended after
+        /// the inline text (separated by a newline).
+        #[arg(short, long, value_name = "PATH")]
+        file: Option<PathBuf>,
+        /// Skip waiting for the session to become idle before sending.
+        ///
+        /// Accepted for parity with ao-ts; idle detection is not yet implemented
+        /// in the Rust runtime so this flag is currently a no-op.
+        #[arg(long)]
+        no_wait: bool,
+        /// Maximum seconds to allow for the send operation before timing out.
+        #[arg(long, default_value_t = 600)]
+        timeout: u64,
     },
 
     /// Show PR state, CI, review decision, and merge readiness for a session.

--- a/crates/ao-cli/src/commands/send.rs
+++ b/crates/ao-cli/src/commands/send.rs
@@ -1,14 +1,44 @@
 //! `ao-rs send` — message to a running session.
 
+use std::path::PathBuf;
+use std::time::Duration;
+
 use ao_core::SessionManager;
+use tokio::time::timeout;
 
 use crate::cli::plugins::select_runtime;
 use crate::cli::printing::short_id;
 
+/// Assemble the final message string from optional inline words and an optional file.
+fn assemble_message(parts: &[String], file: Option<&PathBuf>) -> Result<String, String> {
+    let inline = parts.join(" ");
+    let file_content = match file {
+        Some(path) => Some(
+            std::fs::read_to_string(path)
+                .map_err(|e| format!("cannot read file {}: {e}", path.display()))?,
+        ),
+        None => None,
+    };
+
+    let message = match (inline.is_empty(), file_content) {
+        (true, Some(content)) => content,
+        (false, Some(content)) => format!("{inline}\n{content}"),
+        (false, None) => inline,
+        (true, None) => return Err("no message to send (provide message words or --file)".into()),
+    };
+
+    Ok(message)
+}
+
 pub async fn send(
     session_id_or_prefix: String,
-    message: String,
+    message_parts: Vec<String>,
+    file: Option<PathBuf>,
+    _no_wait: bool,
+    timeout_secs: u64,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    let message = assemble_message(&message_parts, file.as_ref())?;
+
     let sessions = SessionManager::with_default();
     let session = sessions.find_by_prefix(&session_id_or_prefix).await?;
 
@@ -39,7 +69,57 @@ pub async fn send(
         .into());
     }
 
-    runtime.send_message(handle, &message).await?;
+    timeout(
+        Duration::from_secs(timeout_secs),
+        runtime.send_message(handle, &message),
+    )
+    .await
+    .map_err(|_| format!("send timed out after {timeout_secs}s"))??;
+
     println!("→ sent {} bytes to {handle}", message.len());
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn inline_words_joined_with_space() {
+        let parts = vec!["hello".into(), "world".into()];
+        let msg = assemble_message(&parts, None).unwrap();
+        assert_eq!(msg, "hello world");
+    }
+
+    #[test]
+    fn file_content_used_when_no_inline() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("msg.txt");
+        std::fs::write(&path, "file body\n").unwrap();
+        let msg = assemble_message(&[], Some(&path)).unwrap();
+        assert_eq!(msg, "file body\n");
+    }
+
+    #[test]
+    fn inline_and_file_combined() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("msg.txt");
+        std::fs::write(&path, "from file").unwrap();
+        let parts = vec!["prefix:".into()];
+        let msg = assemble_message(&parts, Some(&path)).unwrap();
+        assert_eq!(msg, "prefix:\nfrom file");
+    }
+
+    #[test]
+    fn missing_file_returns_error() {
+        let path = PathBuf::from("/tmp/ao-rs-nonexistent-file-xyz.txt");
+        let err = assemble_message(&[], Some(&path)).unwrap_err();
+        assert!(err.contains("cannot read file"), "got: {err}");
+    }
+
+    #[test]
+    fn no_message_no_file_returns_error() {
+        let err = assemble_message(&[], None).unwrap_err();
+        assert!(err.contains("no message to send"), "got: {err}");
+    }
 }

--- a/crates/ao-cli/src/commands/status.rs
+++ b/crates/ao-cli/src/commands/status.rs
@@ -388,6 +388,9 @@ mod tests {
             cost: None,
             issue_id: Some("87".into()),
             issue_url: Some("https://github.com/duonghb53/ao-rs/issues/87".into()),
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: None,
         };
 
         let opts = StatusOptions {

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -181,7 +181,9 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             target,
         } => commands::open::open(port, new_window, target.unwrap_or(OpenTarget::Dashboard)).await,
         Command::Stop { all, purge_session } => commands::stop::stop(all, purge_session).await,
-        Command::Send { session, message } => commands::send::send(session, message).await,
+        Command::Send { session, message, file, no_wait, timeout } => {
+            commands::send::send(session, message, file, no_wait, timeout).await
+        }
         Command::Pr { session } => commands::pr::pr(session).await,
         Command::Kill { session } => commands::kill::kill(session).await,
         Command::Cleanup { project, dry_run } => commands::cleanup::cleanup(project, dry_run).await,

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -838,3 +838,51 @@ fn resolve_local_issue_for_show_finds_by_id() {
     assert!(p.ends_with("0002-b.md"));
     let _ = std::fs::remove_dir_all(&root);
 }
+
+#[test]
+fn send_parses_missing_flags() {
+    // variadic message words
+    let cli = Cli::try_parse_from(["ao-rs", "send", "abc123", "hello", "world"]).unwrap();
+    match cli.command {
+        Command::Send {
+            session,
+            message,
+            file,
+            no_wait,
+            timeout,
+        } => {
+            assert_eq!(session, "abc123");
+            assert_eq!(message, vec!["hello", "world"]);
+            assert!(file.is_none());
+            assert!(!no_wait);
+            assert_eq!(timeout, 600);
+        }
+        _ => panic!("expected Send command"),
+    }
+
+    // --file flag, no inline message
+    let cli =
+        Cli::try_parse_from(["ao-rs", "send", "abc123", "--file", "/tmp/msg.txt"]).unwrap();
+    match cli.command {
+        Command::Send { file, message, .. } => {
+            assert_eq!(file.as_deref(), Some(std::path::Path::new("/tmp/msg.txt")));
+            assert!(message.is_empty());
+        }
+        _ => panic!("expected Send command"),
+    }
+
+    // --no-wait and --timeout flags
+    let cli = Cli::try_parse_from([
+        "ao-rs", "send", "abc123", "hi", "--no-wait", "--timeout", "30",
+    ])
+    .unwrap();
+    match cli.command {
+        Command::Send {
+            no_wait, timeout, ..
+        } => {
+            assert!(no_wait);
+            assert_eq!(timeout, 30);
+        }
+        _ => panic!("expected Send command"),
+    }
+}


### PR DESCRIPTION
## Summary

- Adds variadic `[message...]` positional args; multiple words are joined with a space (ao-ts parity)
- Adds `--file <path>` to send file contents as the message body; combinable with inline words (file content appended after a newline)
- Adds `--timeout <seconds>` (default 600) — wraps `runtime.send_message` in `tokio::time::timeout` so the operation never hangs indefinitely
- Adds `--no-wait` — accepted flag for parity with ao-ts; documented as no-op until idle detection is implemented in the Rust runtime
- Also fixes a pre-existing compile error in `commands/status.rs` test (missing `claimed_pr_number`, `claimed_pr_url`, `initial_prompt_override` fields added to `Session` struct)

## Test plan

- [x] Unit tests for `assemble_message`: inline-only, file-only, combined, missing file error, empty error
- [x] CLI arg parsing test: variadic words, `--file`, `--no-wait`, `--timeout`
- [x] `cargo test -p ao-cli` — 67 tests pass
- [x] `cargo clippy -p ao-cli` — clean

Closes #89

🤖 Generated with [Claude Code](https://claude.com/claude-code)