### PR TITLE
fix(gh): share rate-limit cooldown and surface quota in doctor

### DIFF
--- a/crates/ao-cli/src/commands/dashboard.rs
+++ b/crates/ao-cli/src/commands/dashboard.rs
@@ -13,6 +13,7 @@ use crate::cli::auto_scm::AutoScm;
 use crate::cli::lifecycle_wiring::notifier_registry_from_config;
 use crate::cli::plugins::{select_runtime, MultiAgent};
 use crate::cli::printing::print_config_warnings;
+use crate::commands::doctor::preemptive_rate_limit_guard;
 
 fn build_dashboard_state() -> Result<ao_dashboard::state::AppState, Box<dyn std::error::Error>> {
     let sessions = Arc::new(SessionManager::with_default());
@@ -100,6 +101,11 @@ pub async fn dashboard(
             .into());
         }
     };
+
+    // Preemptively check GitHub quota — if it's nearly exhausted, enter
+    // cooldown before polling starts so the loop doesn't immediately burn
+    // the last calls and trip a secondary-rate-limit penalty.
+    preemptive_rate_limit_guard().await;
 
     let sessions = Arc::new(SessionManager::with_default());
     let agent: Arc<dyn Agent> = Arc::new(MultiAgent);

--- a/crates/ao-cli/src/commands/doctor.rs
+++ b/crates/ao-cli/src/commands/doctor.rs
@@ -1,6 +1,7 @@
 //! `ao-rs doctor` — environment checks.
 
 use ao_core::{paths, AoConfig, LoadedConfig, SessionManager};
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
 use crate::cli::printing::print_config_warnings;
 
@@ -43,7 +44,28 @@ pub async fn doctor() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // 3. Config file loads without error.
+    // 3. GitHub API rate-limit status. `gh api rate_limit` does NOT
+    // consume quota itself, so it's always safe to call.
+    match check_rate_limit().await {
+        Ok(Some(status)) => {
+            print_rate_limit_line("rate(REST)", &status.core);
+            print_rate_limit_line("rate(GQL)", &status.graphql);
+            if status.core.is_failure() || status.graphql.is_failure() {
+                failures += 1;
+            }
+        }
+        Ok(None) => {
+            println!(
+                "  WARN  {:<10} `gh api rate_limit` returned no data",
+                "rate"
+            );
+        }
+        Err(e) => {
+            println!("  WARN  {:<10} could not query rate limit: {e}", "rate");
+        }
+    }
+
+    // 4. Config file loads without error.
     let config_path = AoConfig::local_path();
     match AoConfig::load_from_or_default_with_warnings(&config_path) {
         Ok(LoadedConfig {
@@ -72,7 +94,7 @@ pub async fn doctor() -> Result<(), Box<dyn std::error::Error>> {
         }
     }
 
-    // 4. Sessions directory exists.
+    // 5. Sessions directory exists.
     let sessions_dir = paths::default_sessions_dir();
     if sessions_dir.is_dir() {
         let count = SessionManager::with_default()
@@ -121,5 +143,190 @@ pub(crate) async fn which(tool: &str) -> ToolStatus {
             ToolStatus::Found(path)
         }
         _ => ToolStatus::NotFound,
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Rate-limit visibility
+// ---------------------------------------------------------------------------
+
+/// Single resource's rate-limit snapshot (REST core or GraphQL).
+#[derive(Debug, Clone)]
+pub(crate) struct ResourceLimit {
+    pub remaining: u64,
+    pub limit: u64,
+    /// Unix timestamp (seconds) when the quota resets.
+    pub reset: u64,
+}
+
+impl ResourceLimit {
+    /// Seconds until quota resets, saturating at 0 for reset times in the past.
+    pub(crate) fn reset_in(&self) -> Duration {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_secs())
+            .unwrap_or(0);
+        Duration::from_secs(self.reset.saturating_sub(now))
+    }
+
+    fn ratio(&self) -> f32 {
+        if self.limit == 0 {
+            return 1.0;
+        }
+        self.remaining as f32 / self.limit as f32
+    }
+
+    pub(crate) fn is_warning(&self) -> bool {
+        (0.05..0.20).contains(&self.ratio())
+    }
+
+    pub(crate) fn is_failure(&self) -> bool {
+        self.ratio() < 0.05
+    }
+}
+
+/// Combined REST + GraphQL rate-limit snapshot.
+#[derive(Debug, Clone)]
+pub(crate) struct RateLimitStatus {
+    pub core: ResourceLimit,
+    pub graphql: ResourceLimit,
+}
+
+/// Query `gh api rate_limit` and parse the response.
+///
+/// Returns `Ok(None)` if the response is well-formed but missing the
+/// expected fields (defensive — shouldn't happen on GitHub.com).
+pub(crate) async fn check_rate_limit() -> Result<Option<RateLimitStatus>, String> {
+    let out = tokio::process::Command::new("gh")
+        .args(["api", "rate_limit"])
+        .output()
+        .await
+        .map_err(|e| format!("spawn failed: {e}"))?;
+    if !out.status.success() {
+        return Err(String::from_utf8_lossy(&out.stderr).trim().to_string());
+    }
+    let json: serde_json::Value = serde_json::from_slice(&out.stdout)
+        .map_err(|e| format!("invalid JSON from gh api rate_limit: {e}"))?;
+    let resources = json.get("resources").ok_or("missing resources field")?;
+    let core = parse_resource(resources.get("core"));
+    let graphql = parse_resource(resources.get("graphql"));
+    match (core, graphql) {
+        (Some(core), Some(graphql)) => Ok(Some(RateLimitStatus { core, graphql })),
+        _ => Ok(None),
+    }
+}
+
+fn parse_resource(v: Option<&serde_json::Value>) -> Option<ResourceLimit> {
+    let v = v?;
+    Some(ResourceLimit {
+        remaining: v.get("remaining")?.as_u64()?,
+        limit: v.get("limit")?.as_u64()?,
+        reset: v.get("reset")?.as_u64()?,
+    })
+}
+
+fn print_rate_limit_line(label: &str, r: &ResourceLimit) {
+    let verdict = if r.is_failure() {
+        "FAIL"
+    } else if r.is_warning() {
+        "WARN"
+    } else {
+        "PASS"
+    };
+    let reset_min = r.reset_in().as_secs() / 60;
+    println!(
+        "  {verdict}  {label:<10} {}/{} (resets in {}m)",
+        r.remaining, r.limit, reset_min
+    );
+}
+
+/// If the user's GitHub quota is critically low, print a warning and
+/// preemptively engage the shared cooldown so the lifecycle loop skips
+/// `gh` calls until the quota resets.
+///
+/// Called from `watch` and `dashboard` before starting `LifecycleManager`.
+/// Silent and non-fatal on any error — the loop still starts either way.
+pub(crate) async fn preemptive_rate_limit_guard() {
+    let Ok(Some(status)) = check_rate_limit().await else {
+        return;
+    };
+    for (label, resource) in [("REST", &status.core), ("GraphQL", &status.graphql)] {
+        if resource.is_failure() {
+            let reset_in = resource.reset_in();
+            let mins = reset_in.as_secs() / 60;
+            eprintln!(
+                "⚠ GitHub {label} rate limit low: {}/{} remaining (resets in {mins}m) — entering cooldown until reset.",
+                resource.remaining, resource.limit,
+            );
+            // Add a small slack so we don't start polling the instant
+            // the quota resets and re-trigger secondary limits.
+            let cooldown = reset_in.saturating_add(Duration::from_secs(10));
+            ao_core::rate_limit::enter_cooldown_for(cooldown);
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rl(remaining: u64, limit: u64) -> ResourceLimit {
+        ResourceLimit {
+            remaining,
+            limit,
+            reset: 0,
+        }
+    }
+
+    #[test]
+    fn thresholds_pass_warn_fail() {
+        // ≥20% remaining → PASS
+        let pass = rl(1000, 5000);
+        assert!(!pass.is_failure());
+        assert!(!pass.is_warning());
+
+        // 5–20% remaining → WARN
+        let warn = rl(500, 5000);
+        assert!(!warn.is_failure());
+        assert!(warn.is_warning());
+
+        // <5% remaining → FAIL
+        let fail = rl(100, 5000);
+        assert!(fail.is_failure());
+        assert!(!fail.is_warning());
+    }
+
+    #[test]
+    fn zero_limit_does_not_panic_and_is_pass() {
+        // Defensive: division-by-zero would be bad; ratio() returns 1.0.
+        let zero = rl(0, 0);
+        assert!(!zero.is_failure());
+        assert!(!zero.is_warning());
+    }
+
+    #[test]
+    fn reset_in_clamps_to_zero_for_past_reset() {
+        // A reset timestamp far in the past saturates to zero, not a
+        // backwards duration.
+        let past = ResourceLimit {
+            remaining: 1,
+            limit: 5000,
+            reset: 1,
+        };
+        assert_eq!(past.reset_in(), Duration::ZERO);
+    }
+
+    #[test]
+    fn parse_resource_handles_missing_fields() {
+        let full = serde_json::json!({"remaining": 42, "limit": 100, "reset": 1700000000});
+        let got = parse_resource(Some(&full)).unwrap();
+        assert_eq!(got.remaining, 42);
+        assert_eq!(got.limit, 100);
+        assert_eq!(got.reset, 1700000000);
+
+        // Missing any field → None, not panic.
+        let missing_reset = serde_json::json!({"remaining": 1, "limit": 2});
+        assert!(parse_resource(Some(&missing_reset)).is_none());
+        assert!(parse_resource(None).is_none());
     }
 }

--- a/crates/ao-cli/src/commands/watch.rs
+++ b/crates/ao-cli/src/commands/watch.rs
@@ -12,6 +12,7 @@ use crate::cli::auto_scm::AutoScm;
 use crate::cli::lifecycle_wiring::notifier_registry_from_config;
 use crate::cli::plugins::{select_runtime, MultiAgent};
 use crate::cli::printing::{print_config_warnings, print_event};
+use crate::commands::doctor::preemptive_rate_limit_guard;
 
 /// Run the lifecycle loop and pretty-print events as they arrive.
 ///
@@ -47,6 +48,11 @@ pub async fn watch(interval_override: Option<Duration>) -> Result<(), Box<dyn st
         }
     };
     println!("→ acquired lifecycle lock at {}", pid_path.display());
+
+    // Preemptively check GitHub quota — if it's nearly exhausted, enter
+    // cooldown before polling starts so the loop doesn't immediately burn
+    // the last calls and trip a secondary-rate-limit penalty.
+    preemptive_rate_limit_guard().await;
 
     let sessions = Arc::new(SessionManager::with_default());
     let agent: Arc<dyn Agent> = Arc::new(MultiAgent);

--- a/crates/ao-core/src/lib.rs
+++ b/crates/ao-core/src/lib.rs
@@ -18,6 +18,7 @@ pub mod parity_session_strategy;
 pub mod parity_utils;
 pub mod paths;
 pub mod prompt_builder;
+pub mod rate_limit;
 pub mod reaction_engine;
 pub mod reactions;
 pub mod restore;

--- a/crates/ao-core/src/rate_limit.rs
+++ b/crates/ao-core/src/rate_limit.rs
@@ -1,0 +1,142 @@
+//! Shared GitHub API rate-limit state.
+//!
+//! Both `scm-github` and `tracker-github` plugins invoke `gh` subprocesses.
+//! When either plugin observes a rate-limit error, all `gh` calls across
+//! the process should back off — otherwise the other plugin keeps firing
+//! requests into a 403 response, risking secondary-rate-limit penalties.
+//!
+//! This module owns the single cooldown instant used by both plugins.
+
+use std::sync::{Mutex, OnceLock};
+use std::time::{Duration, Instant};
+
+/// Default cooldown window when a plugin detects a rate-limit error.
+///
+/// Kept at 120s to match the previous per-plugin behavior. Callers that
+/// know the precise reset time (e.g. via `gh api rate_limit`) can pass a
+/// custom `Duration` to [`enter_cooldown_for`].
+pub const DEFAULT_COOLDOWN: Duration = Duration::from_secs(120);
+
+/// Returns true if the error message looks like a GitHub rate-limit
+/// response (REST or GraphQL, primary or secondary).
+pub fn is_rate_limited_error(msg: &str) -> bool {
+    let m = msg.to_lowercase();
+    m.contains("api rate limit")
+        || m.contains("secondary rate limit")
+        || m.contains("rate limit exceeded")
+        || m.contains("graphql: api rate limit")
+}
+
+fn cooldown_until() -> &'static Mutex<Option<Instant>> {
+    static COOLDOWN: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
+    COOLDOWN.get_or_init(|| Mutex::new(None))
+}
+
+/// Returns true if we are currently in a rate-limit cooldown window.
+///
+/// Clears the stored instant once it has elapsed so subsequent checks
+/// are cheap and logs accurately reflect recovery.
+pub fn in_cooldown_now() -> bool {
+    let Ok(mut guard) = cooldown_until().lock() else {
+        return false;
+    };
+    if let Some(until) = *guard {
+        if Instant::now() < until {
+            return true;
+        }
+        *guard = None;
+    }
+    false
+}
+
+/// Enter cooldown for the default 120s window.
+pub fn enter_cooldown() {
+    enter_cooldown_for(DEFAULT_COOLDOWN);
+}
+
+/// Enter cooldown for a specific duration.
+///
+/// If a cooldown is already active with a later expiry, this call is a
+/// no-op — we never shorten an existing cooldown. If `duration` is too
+/// large to represent as a future `Instant` (e.g. malformed upstream
+/// timestamps), we silently skip instead of panicking.
+pub fn enter_cooldown_for(duration: Duration) {
+    let Ok(mut guard) = cooldown_until().lock() else {
+        return;
+    };
+    let Some(new_until) = Instant::now().checked_add(duration) else {
+        return;
+    };
+    match *guard {
+        Some(existing) if existing >= new_until => {}
+        _ => *guard = Some(new_until),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::thread::sleep;
+
+    #[test]
+    fn detects_rate_limit_messages() {
+        assert!(is_rate_limited_error("API rate limit exceeded"));
+        assert!(is_rate_limited_error(
+            "You have exceeded a secondary rate limit"
+        ));
+        assert!(is_rate_limited_error("GraphQL: API rate limit exceeded"));
+        assert!(is_rate_limited_error("rate limit exceeded for app"));
+        assert!(!is_rate_limited_error("404 not found"));
+        assert!(!is_rate_limited_error(""));
+    }
+
+    // The cooldown state is process-global, so these scenarios share one
+    // test to keep them sequential. Running them as separate #[test]
+    // functions would race against each other under `cargo test`'s
+    // default parallel execution.
+    #[test]
+    fn cooldown_lifecycle() {
+        // Reset.
+        if let Ok(mut g) = cooldown_until().lock() {
+            *g = None;
+        }
+
+        // Short cooldown becomes active then expires.
+        enter_cooldown_for(Duration::from_millis(30));
+        assert!(in_cooldown_now());
+        sleep(Duration::from_millis(60));
+        assert!(!in_cooldown_now());
+
+        // A long cooldown is not shortened by a subsequent short one.
+        enter_cooldown_for(Duration::from_secs(60));
+        let first = *cooldown_until().lock().unwrap();
+        enter_cooldown_for(Duration::from_millis(10));
+        let after_short = *cooldown_until().lock().unwrap();
+        assert_eq!(
+            first, after_short,
+            "short cooldown must not shorten longer one"
+        );
+
+        // Clean up so other tests in the process start from a fresh slate.
+        if let Ok(mut g) = cooldown_until().lock() {
+            *g = None;
+        }
+    }
+
+    #[test]
+    fn enter_cooldown_for_ignores_overflowing_duration() {
+        // An absurdly large duration (e.g. from a spoofed reset timestamp)
+        // used to panic via `Instant::now() + duration`. After the fix it
+        // silently skips.
+        if let Ok(mut g) = cooldown_until().lock() {
+            *g = None;
+        }
+        enter_cooldown_for(Duration::MAX);
+        // No panic. Cooldown should NOT be set because the `Instant::now()
+        // + Duration::MAX` overflows.
+        assert!(
+            !in_cooldown_now(),
+            "overflowing duration must not activate cooldown"
+        );
+    }
+}

--- a/crates/plugins/scm-github/src/graphql_batch.rs
+++ b/crates/plugins/scm-github/src/graphql_batch.rs
@@ -623,7 +623,7 @@ fn ci_label(ci: CiStatus) -> &'static str {
 // ---------------------------------------------------------------------------
 
 async fn run_gh(args: &[&str]) -> Result<String> {
-    if crate::in_cooldown_now() {
+    if ao_core::rate_limit::in_cooldown_now() {
         return Err(ao_core::AoError::Scm(
             "GitHub rate-limit cooldown active; skipping gh subprocess".into(),
         ));
@@ -642,8 +642,8 @@ async fn run_gh(args: &[&str]) -> Result<String> {
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        if crate::is_rate_limited_error(stderr.as_ref()) {
-            crate::enter_cooldown();
+        if ao_core::rate_limit::is_rate_limited_error(stderr.as_ref()) {
+            ao_core::rate_limit::enter_cooldown();
         }
         return Err(ao_core::AoError::Scm(format!(
             "gh {} failed: {}",

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -73,36 +73,13 @@ const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 
 const PENDING_COMMENTS_TTL: Duration = Duration::from_secs(120);
 const PENDING_COMMENTS_CACHE_MAX: usize = 128;
-const GITHUB_RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(120);
 
 type PendingCommentsCacheMap = HashMap<String, (Instant, Vec<ReviewComment>)>;
 type PendingCommentsCacheLock = Mutex<PendingCommentsCacheMap>;
 
-pub(crate) fn is_rate_limited_error(msg: &str) -> bool {
-    let m = msg.to_lowercase();
-    m.contains("api rate limit")
-        || m.contains("secondary rate limit")
-        || m.contains("rate limit exceeded")
-        || m.contains("graphql: api rate limit")
-}
-
-fn cooldown_until() -> &'static Mutex<Option<Instant>> {
-    static COOLDOWN: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
-    COOLDOWN.get_or_init(|| Mutex::new(None))
-}
-
-pub(crate) fn in_cooldown_now() -> bool {
-    let Ok(guard) = cooldown_until().lock() else {
-        return false;
-    };
-    guard.is_some_and(|until| Instant::now() < until)
-}
-
-pub(crate) fn enter_cooldown() {
-    if let Ok(mut guard) = cooldown_until().lock() {
-        *guard = Some(Instant::now() + GITHUB_RATE_LIMIT_COOLDOWN);
-    }
-}
+// Rate-limit detection and cooldown live in ao-core so both GitHub
+// plugins share one cooldown instant — see `ao_core::rate_limit`.
+use ao_core::rate_limit::{enter_cooldown, in_cooldown_now, is_rate_limited_error};
 
 fn pending_comments_cache() -> &'static PendingCommentsCacheLock {
     static CACHE: OnceLock<PendingCommentsCacheLock> = OnceLock::new();

--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -49,40 +49,10 @@ const SUBPROCESS_TIMEOUT: Duration = Duration::from_secs(30);
 
 const ISSUE_STATE_TTL: Duration = Duration::from_secs(30);
 const ISSUE_STATE_CACHE_MAX: usize = 256;
-const RATE_LIMIT_COOLDOWN: Duration = Duration::from_secs(120);
 
-fn is_rate_limited_error(msg: &str) -> bool {
-    let m = msg.to_lowercase();
-    m.contains("api rate limit")
-        || m.contains("secondary rate limit")
-        || m.contains("rate limit exceeded")
-        || m.contains("graphql: api rate limit")
-}
-
-fn cooldown_until() -> &'static Mutex<Option<Instant>> {
-    static COOLDOWN: OnceLock<Mutex<Option<Instant>>> = OnceLock::new();
-    COOLDOWN.get_or_init(|| Mutex::new(None))
-}
-
-fn in_cooldown_now() -> bool {
-    let Ok(mut guard) = cooldown_until().lock() else {
-        return false;
-    };
-    if let Some(until) = *guard {
-        if Instant::now() < until {
-            return true;
-        }
-        // Cooldown expired — clear it so logs/state reflect recovery.
-        *guard = None;
-    }
-    false
-}
-
-fn enter_cooldown() {
-    if let Ok(mut guard) = cooldown_until().lock() {
-        *guard = Some(Instant::now() + RATE_LIMIT_COOLDOWN);
-    }
-}
+// Rate-limit detection and cooldown live in ao-core so both GitHub
+// plugins share one cooldown instant — see `ao_core::rate_limit`.
+use ao_core::rate_limit::{enter_cooldown, in_cooldown_now, is_rate_limited_error};
 
 fn issue_state_cache() -> &'static Mutex<HashMap<String, (Instant, IssueState)>> {
     static CACHE: OnceLock<Mutex<HashMap<String, (Instant, IssueState)>>> = OnceLock::new();


### PR DESCRIPTION
## Summary

- **Shared cooldown**: One `ao_core::rate_limit` module now owns the cooldown state. Both `scm-github` and `tracker-github` back off together when either plugin hits GitHub's primary or secondary rate limit — previously they had separate static cooldowns, so one plugin kept hammering `gh` after the other tripped.
- **`ao-rs doctor` quota visibility**: New REST + GraphQL rate-limit lines with PASS/WARN/FAIL thresholds (≥20% / 5–20% / <5% remaining) and the reset time. Uses `gh api rate_limit`, which does not consume quota.
- **Preemptive guard for `watch` + `dashboard`**: If REST or GraphQL quota is critically low at startup, warn the user and engage the shared cooldown until reset (+10s slack) so the polling loop doesn't burn the last calls and trip secondary-rate-limit penalties.
- **Panic-safe duration arithmetic**: `enter_cooldown_for(Duration)` uses `checked_add`, so a malformed upstream reset timestamp cannot overflow `Instant + Duration`.

## Why

User hit `GraphQL: API rate limit already exceeded` during `ao-rs watch`. Root causes:
1. Two separate per-plugin cooldowns — cross-plugin leakage kept firing `gh`.
2. No visibility via `doctor` into remaining quota.
3. No preemptive check before the loop started.

## Test plan

- [x] `cargo test --workspace` — unit tests for shared cooldown, threshold classification, resource parsing, and overflow-safe `enter_cooldown_for` all pass
- [x] `cargo clippy --workspace --tests -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean on branch-modified files (pre-existing diffs on `main.rs`/`tests.rs` are outside scope)
- [x] Manual: `cargo run -- doctor` emits `rate(REST)` and `rate(GQL)` lines
- [ ] Manual after merge: observe `watch` entering cooldown when quota is low

🤖 Generated with [Claude Code](https://claude.com/claude-code)