### PR TITLE
feat(cli): add --rebuild flag to ao-rs dashboard (#94)

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -335,6 +335,15 @@ pub enum Command {
         /// Open the dashboard root URL in the default browser after a short delay.
         #[arg(long)]
         open: bool,
+
+        /// Reset stale lifecycle state before starting.
+        ///
+        /// Stops any previously-running `watch`/`dashboard` instance (SIGTERM
+        /// via the `~/.ao-rs/lifecycle.pid` file) and clears the pidfile if
+        /// its owner is already dead. Useful when a crashed prior instance
+        /// left behind a lock. No-op when nothing is running.
+        #[arg(long)]
+        rebuild: bool,
     },
 
     /// Open dashboard or session targets in your browser / file manager.

--- a/crates/ao-cli/src/commands/dashboard.rs
+++ b/crates/ao-cli/src/commands/dashboard.rs
@@ -15,6 +15,7 @@ use crate::cli::lifecycle_wiring::notifier_registry_from_config;
 use crate::cli::plugins::{select_runtime, MultiAgent};
 use crate::cli::printing::print_config_warnings;
 use crate::commands::doctor::preemptive_rate_limit_guard;
+use crate::commands::stop::stop as stop_lifecycle;
 
 fn build_dashboard_state() -> Result<ao_dashboard::state::AppState, Box<dyn std::error::Error>> {
     let sessions = Arc::new(SessionManager::with_default());
@@ -80,10 +81,21 @@ pub async fn dashboard_only(port: u16) -> Result<(), Box<dyn std::error::Error>>
 /// Reuses the same plugin wiring as `watch` and adds an axum HTTP server.
 /// Both run concurrently under `tokio::select!` so Ctrl-C stops them
 /// together.
+///
+/// When `rebuild` is true, any previously-running lifecycle instance
+/// (`watch` / `dashboard`) is stopped first, and a stale
+/// `~/.ao-rs/lifecycle.pid` is purged, so the new dashboard starts
+/// from a clean lock state.
 pub async fn dashboard(
     port: u16,
     interval_override: Option<Duration>,
+    rebuild: bool,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    if rebuild {
+        println!("→ rebuild: clearing stale lifecycle state...");
+        stop_lifecycle(false, false).await?;
+    }
+
     let pid_path = paths::lifecycle_pid_file();
     let _lock = match PidFile::acquire(&pid_path) {
         Ok(lock) => lock,

--- a/crates/ao-cli/src/commands/start.rs
+++ b/crates/ao-cli/src/commands/start.rs
@@ -204,7 +204,7 @@ pub async fn start(opts: StartOptions) -> Result<(), Box<dyn std::error::Error>>
             return dashboard_only(opts.port).await;
         }
 
-        return dashboard(opts.port, opts.interval_override).await;
+        return dashboard(opts.port, opts.interval_override, false).await;
     }
 
     if opts.rebuild && config_path.exists() && opts.interactive && !confirm_overwrite(&config_path)?
@@ -274,6 +274,6 @@ pub async fn start(opts: StartOptions) -> Result<(), Box<dyn std::error::Error>>
         }
         dashboard_only(opts.port).await
     } else {
-        dashboard(opts.port, opts.interval_override).await
+        dashboard(opts.port, opts.interval_override, false).await
     }
 }

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -169,11 +169,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             port,
             interval,
             open,
+            rebuild,
         } => {
             if open {
                 cli::browser::spawn_open_dashboard_browser(port);
             }
-            commands::dashboard::dashboard(port, interval.map(Duration::from_secs)).await
+            commands::dashboard::dashboard(port, interval.map(Duration::from_secs), rebuild).await
         }
         Command::Open {
             port,

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -253,6 +253,32 @@ fn verify_parses_list_without_target() {
 }
 
 #[test]
+fn dashboard_parses_rebuild_flag() {
+    let cli = Cli::try_parse_from(["ao-rs", "dashboard", "--rebuild", "--port", "4321"]).unwrap();
+    match cli.command {
+        Command::Dashboard {
+            port,
+            interval,
+            open,
+            rebuild,
+        } => {
+            assert_eq!(port, 4321);
+            assert!(interval.is_none());
+            assert!(!open);
+            assert!(rebuild);
+        }
+        _ => panic!("expected Dashboard command"),
+    }
+
+    // Default is false.
+    let cli = Cli::try_parse_from(["ao-rs", "dashboard"]).unwrap();
+    match cli.command {
+        Command::Dashboard { rebuild, .. } => assert!(!rebuild),
+        _ => panic!("expected Dashboard command"),
+    }
+}
+
+#[test]
 fn stop_parses_flags() {
     let cli = Cli::try_parse_from(["ao-rs", "stop", "--all", "--purge-session"]).unwrap();
     match cli.command {


### PR DESCRIPTION
## Summary
- Adds `--rebuild` to `ao-rs dashboard` for parity with ao-ts.
- Narrowly scoped: stops a previously-running `watch`/`dashboard` (SIGTERM via `~/.ao-rs/lifecycle.pid`) and purges a stale pidfile, so the dashboard starts from a clean lock state. No-op when nothing is running.
- ao-rs has no Next.js build artifacts to rebuild — the closest useful reset is stale lifecycle state.
- Default `--open` polarity kept as a deliberate divergence from ao-ts (optional per the issue).

Closes #94

## Test plan
- [x] `cargo fmt --all -- --check` (only pre-existing diffs unrelated to this PR)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo test --workspace` — all suites green
- [x] New `dashboard_parses_rebuild_flag` CLI parse test
- [x] `cargo run -p ao-cli -- dashboard --help` shows the new flag with clear semantics
- [x] Rebuild's pidfile cleanup path is exercised by existing `commands::stop::tests::*` (stop, stale, unparseable, live SIGTERM)

🤖 Generated with [Claude Code](https://claude.com/claude-code)