### PR TITLE
feat(cli): add session remap command (#92)

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -551,6 +551,29 @@ pub enum SessionAction {
         #[arg(long, default_value_t = false)]
         assign_on_github: bool,
     },
+
+    /// Re-bind a session's workspace path and/or runtime handle.
+    ///
+    /// Updates the persisted session metadata without recreating the runtime.
+    /// Pair with `ao-rs session restore <id>` if you also need to respawn
+    /// the agent under the new values. Pass at least one of `--workspace`
+    /// or `--runtime-handle`.
+    Remap {
+        /// Session uuid or unambiguous prefix.
+        session: String,
+
+        /// New `workspace_path` to bind. Validated for existence unless `--force`.
+        #[arg(long, value_name = "PATH")]
+        workspace: Option<PathBuf>,
+
+        /// New `runtime_handle` to bind (free-form; no liveness probe).
+        #[arg(long = "runtime-handle", value_name = "NAME")]
+        runtime_handle: Option<String>,
+
+        /// Skip the workspace existence check.
+        #[arg(short, long)]
+        force: bool,
+    },
 }
 
 #[derive(Subcommand, Clone, Debug)]

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -222,6 +222,12 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 session,
                 assign_on_github,
             } => session::claim_pr::claim_pr(pr, session, assign_on_github).await,
+            SessionAction::Remap {
+                session,
+                workspace,
+                runtime_handle,
+                force,
+            } => session::remap::remap(session, workspace, runtime_handle, force).await,
         },
         Command::Issue { action } => match action {
             IssueAction::New { title, body, repo } => {

--- a/crates/ao-cli/src/session/claim_pr.rs
+++ b/crates/ao-cli/src/session/claim_pr.rs
@@ -133,10 +133,7 @@ mod tests {
     #[test]
     fn parse_url_trailing_slash() {
         let url = "https://github.com/owner/repo/pull/7/";
-        assert_eq!(
-            parse_pr_ref(url),
-            (Some(7), Some(url.to_string()))
-        );
+        assert_eq!(parse_pr_ref(url), (Some(7), Some(url.to_string())));
     }
 
     #[test]

--- a/crates/ao-cli/src/session/mod.rs
+++ b/crates/ao-cli/src/session/mod.rs
@@ -2,4 +2,5 @@
 
 pub mod attach;
 pub mod claim_pr;
+pub mod remap;
 pub mod restore;

--- a/crates/ao-cli/src/session/remap.rs
+++ b/crates/ao-cli/src/session/remap.rs
@@ -1,0 +1,268 @@
+//! `ao-rs session remap`.
+//!
+//! Updates a persisted session's `workspace_path` and/or `runtime_handle`
+//! fields in place. Does not recreate the runtime — callers who also need
+//! that should chain with `ao-rs session restore <id>`.
+
+use std::path::PathBuf;
+
+use ao_core::{Session, SessionManager};
+
+use crate::cli::printing::short_id;
+
+pub async fn remap(
+    id_or_prefix: String,
+    workspace: Option<PathBuf>,
+    runtime_handle: Option<String>,
+    force: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    if workspace.is_none() && runtime_handle.is_none() {
+        return Err("nothing to remap: pass --workspace and/or --runtime-handle".into());
+    }
+
+    if let Some(p) = workspace.as_deref() {
+        if !force && !p.exists() {
+            return Err(format!(
+                "workspace path does not exist: {} (use --force to override)",
+                p.display()
+            )
+            .into());
+        }
+    }
+
+    let sessions = SessionManager::with_default();
+    remap_with_manager(&sessions, &id_or_prefix, workspace, runtime_handle).await
+}
+
+async fn remap_with_manager(
+    sessions: &SessionManager,
+    id_or_prefix: &str,
+    workspace: Option<PathBuf>,
+    runtime_handle: Option<String>,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut session = sessions.find_by_prefix(id_or_prefix).await?;
+    let (old_workspace, old_handle) = session.apply_remap(workspace, runtime_handle);
+    print_diff(&session, &old_workspace, &old_handle);
+    sessions.save(&session).await?;
+    println!();
+    println!("  ✓ session remapped");
+    Ok(())
+}
+
+fn print_diff(session: &Session, old_workspace: &Option<PathBuf>, old_handle: &Option<String>) {
+    let short = short_id(&session.id);
+    println!();
+    println!("───────────────────────────────────────────────");
+    println!("  session: {} (short {short})", session.id);
+    println!();
+    println!("  workspace_path:");
+    print_field_diff(
+        old_workspace.as_ref().map(|p| p.display().to_string()),
+        session
+            .workspace_path
+            .as_ref()
+            .map(|p| p.display().to_string()),
+    );
+    println!();
+    println!("  runtime_handle:");
+    print_field_diff(old_handle.clone(), session.runtime_handle.clone());
+    println!("───────────────────────────────────────────────");
+}
+
+fn print_field_diff(old: Option<String>, new: Option<String>) {
+    let format = |v: &Option<String>| match v {
+        Some(s) => s.clone(),
+        None => "<none>".into(),
+    };
+    if old == new {
+        println!("    (unchanged: {})", format(&old));
+    } else {
+        println!("    - {}", format(&old));
+        println!("    + {}", format(&new));
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ao_core::{now_ms, SessionId, SessionStatus};
+    use std::path::{Path, PathBuf};
+    use std::sync::atomic::{AtomicUsize, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_temp_dir(label: &str) -> PathBuf {
+        static COUNTER: AtomicUsize = AtomicUsize::new(0);
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        std::env::temp_dir().join(format!("ao-rs-remap-{label}-{nanos}-{n}"))
+    }
+
+    async fn persist_session(
+        sm: &SessionManager,
+        id: &str,
+        workspace: Option<&Path>,
+        handle: Option<&str>,
+    ) -> Session {
+        let session = Session {
+            id: SessionId(id.into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Terminated,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: format!("ao-{id}"),
+            task: "remap subject".into(),
+            workspace_path: workspace.map(|p| p.to_path_buf()),
+            runtime_handle: handle.map(|h| h.to_string()),
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: Some("92".into()),
+            issue_url: None,
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: None,
+        };
+        sm.save(&session).await.unwrap();
+        session
+    }
+
+    #[tokio::test]
+    async fn remap_workspace_only_persists_new_path() {
+        let base = unique_temp_dir("ws-only");
+        let new_ws = base.join("new-ws");
+        std::fs::create_dir_all(&new_ws).unwrap();
+
+        let sm = SessionManager::new(base.clone());
+        persist_session(&sm, "remap-ws", Some(&base.join("old")), Some("handle-a")).await;
+
+        remap_with_manager(&sm, "remap-ws", Some(new_ws.clone()), None)
+            .await
+            .unwrap();
+
+        let reread = sm.find_by_prefix("remap-ws").await.unwrap();
+        assert_eq!(reread.workspace_path.as_deref(), Some(new_ws.as_path()));
+        assert_eq!(reread.runtime_handle.as_deref(), Some("handle-a"));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn remap_runtime_handle_only_persists_new_handle() {
+        let base = unique_temp_dir("handle-only");
+        let ws = base.join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let sm = SessionManager::new(base.clone());
+        persist_session(&sm, "remap-rh", Some(&ws), Some("old-name")).await;
+
+        remap_with_manager(&sm, "remap-rh", None, Some("new-name".into()))
+            .await
+            .unwrap();
+
+        let reread = sm.find_by_prefix("remap-rh").await.unwrap();
+        assert_eq!(reread.workspace_path.as_deref(), Some(ws.as_path()));
+        assert_eq!(reread.runtime_handle.as_deref(), Some("new-name"));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn remap_both_persists_both() {
+        let base = unique_temp_dir("both");
+        let new_ws = base.join("new-ws");
+        std::fs::create_dir_all(&new_ws).unwrap();
+
+        let sm = SessionManager::new(base.clone());
+        persist_session(&sm, "remap-both", Some(&base.join("old")), Some("old-h")).await;
+
+        remap_with_manager(
+            &sm,
+            "remap-both",
+            Some(new_ws.clone()),
+            Some("new-h".into()),
+        )
+        .await
+        .unwrap();
+
+        let reread = sm.find_by_prefix("remap-both").await.unwrap();
+        assert_eq!(reread.workspace_path.as_deref(), Some(new_ws.as_path()));
+        assert_eq!(reread.runtime_handle.as_deref(), Some("new-h"));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn remap_no_flags_errors_before_touching_store() {
+        // No session persisted — find_by_prefix would return SessionNotFound.
+        // We assert the no-flags error fires first (doesn't reach the store).
+        let base = unique_temp_dir("noflags");
+        let err = remap("missing".into(), None, None, false)
+            .await
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("nothing to remap"), "got: {msg}");
+        // Base dir must not have been created by our call.
+        assert!(!base.exists(), "store was touched: {base:?}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn remap_missing_workspace_without_force_errors() {
+        let bogus = PathBuf::from("/nonexistent/ao-rs/remap-target");
+        let err = remap("does-not-matter".into(), Some(bogus.clone()), None, false)
+            .await
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("workspace path does not exist"), "got: {msg}");
+        assert!(msg.contains(bogus.to_string_lossy().as_ref()));
+    }
+
+    #[tokio::test]
+    async fn remap_missing_workspace_with_force_succeeds() {
+        // --force bypasses Path::exists(); the surviving failure path is
+        // session lookup. We persist a session and then remap to a bogus
+        // path with force=true. apply_remap does not validate.
+        let base = unique_temp_dir("force");
+        let sm = SessionManager::new(base.clone());
+        persist_session(&sm, "remap-force", Some(&base.join("old")), Some("h-1")).await;
+
+        let bogus = PathBuf::from("/nonexistent/ao-rs/remap-target");
+        // Note: the public `remap()` entrypoint would use the default
+        // SessionManager path (~/.ao-rs/sessions). We exercise the
+        // force-accept path via the inner helper with our tempdir store.
+        remap_with_manager(&sm, "remap-force", Some(bogus.clone()), None)
+            .await
+            .unwrap();
+
+        let reread = sm.find_by_prefix("remap-force").await.unwrap();
+        assert_eq!(reread.workspace_path, Some(bogus));
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn remap_unknown_session_errors() {
+        let base = unique_temp_dir("unknown");
+        let sm = SessionManager::new(base.clone());
+        let err = remap_with_manager(&sm, "ghost", None, Some("anything".into()))
+            .await
+            .unwrap_err();
+        let msg = format!("{err}");
+        assert!(msg.contains("ghost"), "got: {msg}");
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn print_field_diff_unchanged_prints_one_line() {
+        // Smoke that the formatting helpers don't panic. Stdout output is
+        // not captured here; the assertion is purely that we don't crash.
+        print_field_diff(Some("same".into()), Some("same".into()));
+        print_field_diff(None, None);
+        print_field_diff(Some("a".into()), Some("b".into()));
+        print_field_diff(None, Some("b".into()));
+    }
+}

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -1365,7 +1365,10 @@ mod tests {
             Ok(PathBuf::from("/tmp/ws"))
         }
         async fn destroy(&self, workspace_path: &Path) -> Result<()> {
-            self.destroyed.lock().unwrap().push(workspace_path.to_path_buf());
+            self.destroyed
+                .lock()
+                .unwrap()
+                .push(workspace_path.to_path_buf());
             Ok(())
         }
     }
@@ -3402,7 +3405,11 @@ mod tests {
         assert_eq!(persisted[0].status, SessionStatus::Merged);
 
         let destroyed = workspace.destroyed_paths();
-        assert_eq!(destroyed, vec![ws_path], "destroy must be called with the session's workspace_path");
+        assert_eq!(
+            destroyed,
+            vec![ws_path],
+            "destroy must be called with the session's workspace_path"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/crates/ao-core/src/types.rs
+++ b/crates/ao-core/src/types.rs
@@ -266,6 +266,27 @@ impl Session {
     pub fn is_restorable(&self) -> bool {
         self.is_terminal() && self.status.is_restorable()
     }
+
+    /// Overwrite `workspace_path` and/or `runtime_handle` in place.
+    ///
+    /// Returns the previous `(workspace_path, runtime_handle)` so callers
+    /// can print a before/after diff before persisting. Fields whose
+    /// argument is `None` are left untouched — this is a partial update,
+    /// not a replace.
+    pub fn apply_remap(
+        &mut self,
+        workspace: Option<PathBuf>,
+        runtime_handle: Option<String>,
+    ) -> (Option<PathBuf>, Option<String>) {
+        let previous = (self.workspace_path.clone(), self.runtime_handle.clone());
+        if let Some(p) = workspace {
+            self.workspace_path = Some(p);
+        }
+        if let Some(h) = runtime_handle {
+            self.runtime_handle = Some(h);
+        }
+        previous
+    }
 }
 
 /// Current Unix time in milliseconds. Helper for `Session::created_at`.
@@ -457,6 +478,88 @@ mod tests {
         };
         assert!(merged.is_terminal());
         assert!(!merged.is_restorable());
+    }
+
+    fn sample_session() -> Session {
+        Session {
+            id: SessionId("remap-1".into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Terminated,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: "feat/remap".into(),
+            task: "t".into(),
+            workspace_path: Some(PathBuf::from("/old/ws")),
+            runtime_handle: Some("old-handle".into()),
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: 42,
+            cost: None,
+            issue_id: Some("92".into()),
+            issue_url: Some("https://example.test/i/92".into()),
+            claimed_pr_number: Some(7),
+            claimed_pr_url: Some("https://example.test/pr/7".into()),
+            initial_prompt_override: Some("resume please".into()),
+        }
+    }
+
+    #[test]
+    fn apply_remap_updates_workspace_only() {
+        let mut s = sample_session();
+        let before = s.clone();
+        let previous = s.apply_remap(Some(PathBuf::from("/new/ws")), None);
+        assert_eq!(
+            previous,
+            (Some(PathBuf::from("/old/ws")), Some("old-handle".into()))
+        );
+        assert_eq!(
+            s.workspace_path.as_deref(),
+            Some(std::path::Path::new("/new/ws"))
+        );
+        assert_eq!(s.runtime_handle.as_deref(), Some("old-handle"));
+        // Every other field untouched.
+        assert_eq!(s.id.0, before.id.0);
+        assert_eq!(s.project_id, before.project_id);
+        assert_eq!(s.status, before.status);
+        assert_eq!(s.agent, before.agent);
+        assert_eq!(s.branch, before.branch);
+        assert_eq!(s.issue_id, before.issue_id);
+        assert_eq!(s.claimed_pr_number, before.claimed_pr_number);
+    }
+
+    #[test]
+    fn apply_remap_updates_runtime_handle_only() {
+        let mut s = sample_session();
+        let previous = s.apply_remap(None, Some("new-handle".into()));
+        assert_eq!(previous.0, Some(PathBuf::from("/old/ws")));
+        assert_eq!(previous.1, Some("old-handle".into()));
+        assert_eq!(
+            s.workspace_path.as_deref(),
+            Some(std::path::Path::new("/old/ws"))
+        );
+        assert_eq!(s.runtime_handle.as_deref(), Some("new-handle"));
+    }
+
+    #[test]
+    fn apply_remap_updates_both() {
+        let mut s = sample_session();
+        s.apply_remap(Some(PathBuf::from("/new/ws")), Some("new-handle".into()));
+        assert_eq!(
+            s.workspace_path.as_deref(),
+            Some(std::path::Path::new("/new/ws"))
+        );
+        assert_eq!(s.runtime_handle.as_deref(), Some("new-handle"));
+    }
+
+    #[test]
+    fn apply_remap_none_is_noop() {
+        let mut s = sample_session();
+        let before = s.clone();
+        let previous = s.apply_remap(None, None);
+        assert_eq!(previous.0, before.workspace_path);
+        assert_eq!(previous.1, before.runtime_handle);
+        assert_eq!(s.workspace_path, before.workspace_path);
+        assert_eq!(s.runtime_handle, before.runtime_handle);
     }
 
     #[test]

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -274,6 +274,17 @@ ao-rs session attach <session>
 
 Execs `tmux attach-session -t <handle>` for the resolved session, replacing the current process.
 
+## `ao-rs session remap <id>` — re-bind workspace path / runtime handle
+
+```
+ao-rs session remap <session> [--workspace PATH] [--runtime-handle NAME] [--force]
+```
+
+Updates a persisted session's `workspace_path` and/or `runtime_handle` fields after the underlying resources drifted (e.g. worktree moved on disk, tmux session renamed out-of-band). Requires at least one of `--workspace` / `--runtime-handle`. Prints a before/after diff, then saves the session YAML atomically.
+
+- Without `--force`, a `--workspace` path that does not exist on disk is rejected before any save.
+- Remap only touches metadata; it does not recreate the runtime. Chain with `ao-rs session restore <id>` if you also need to respawn the agent under the new values.
+
 ## `ao-rs kill <id>` — stop runtime + remove worktree + archive
 
 ```


### PR DESCRIPTION
## Summary
- Add `ao-rs session remap <session> [--workspace PATH] [--runtime-handle NAME] [--force]` to re-bind a persisted session's workspace path and/or runtime handle without hand-editing YAML (#92).
- Introduce `Session::apply_remap` on `ao-core` as a pure partial-update helper that returns the previous values so callers can diff before persisting.
- Validate `--workspace` existence unless `--force`; reject the no-op invocation (no flags) before any I/O; print a before/after diff for both fields before saving.
- Fold in two pre-existing `cargo fmt --all` drifts in `claim_pr.rs` and `lifecycle.rs` so `cargo fmt --check` is clean on the branch.

Generalizes the ao-ts `session remap` command (which is OpenCode-specific — re-discovers an OpenCode session id by title) to the workspace/runtime metadata update use case called out in the issue; OpenCode agent re-discovery is a non-goal until an OpenCode agent ships in ao-rs.

## Test plan
- [x] `cargo fmt --all -- --check` clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo test --workspace` clean — 4 new `ao-core::types` tests for `apply_remap`, 8 new `ao-cli::session::remap` tests covering workspace-only / handle-only / both / no-flags / missing-path-without-force / missing-path-with-force / unknown session / diff formatter.
- [x] `./target/debug/ao-rs session remap --help` renders the documented flags.
- [ ] Manual smoke: spawn a session, rename its workspace on disk, run `ao-rs session remap <short> --workspace <new>`, confirm the YAML updates and `session restore` picks up the new path.

Closes #92.

🤖 Generated with [Claude Code](https://claude.com/claude-code)