### PR TITLE
fix(ui): rename Merge lane label to Merged

### DIFF
--- a/crates/ao-desktop/ui/src/components/AttentionZone.tsx
+++ b/crates/ao-desktop/ui/src/components/AttentionZone.tsx
@@ -14,7 +14,7 @@ const zoneConfig: Record<DashboardLane, { label: string; emptyMessage: string }>
   working: { label: "Working", emptyMessage: "No agents running." },
   pending: { label: "Pending", emptyMessage: "Nothing pending." },
   review: { label: "Review", emptyMessage: "No code waiting for review." },
-  merge: { label: "Merge", emptyMessage: "Nothing ready to land yet." },
+  merge: { label: "Merged", emptyMessage: "No merged sessions." },
   killed: { label: "Killed", emptyMessage: "No killed sessions." },
 };
 

--- a/crates/ao-desktop/ui/src/components/Board.tsx
+++ b/crates/ao-desktop/ui/src/components/Board.tsx
@@ -23,7 +23,7 @@ const labels: Record<Lane, string> = {
   working: "Working",
   pending: "Pending",
   review: "Review",
-  merge: "Merge",
+  merge: "Merged",
   killed: "Killed",
 };
 


### PR DESCRIPTION
## Summary

- **Board.tsx**: `merge: "Merge"` → `merge: "Merged"`
- **AttentionZone.tsx**: label `"Merge"` → `"Merged"`, emptyMessage `"Nothing ready to land yet."` → `"No merged sessions."`

The internal lane ID `"merge"` is unchanged — only the display labels are updated.

## Why

"Merge" implies a pending action (something still needs to happen). Sessions in this lane have `status = merged/done/cleanup` — they are already finished. "Merged" correctly reflects the past-tense state.

Related: #153 (tmux not killed on merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)