### PR TITLE
feat(agent-codex): align launch flags with ao-ts and stop reporting $0.00 (#100)

### DIFF
--- a/crates/ao-cli/src/commands/status.rs
+++ b/crates/ao-cli/src/commands/status.rs
@@ -176,7 +176,7 @@ async fn render_table_snapshot(
                 "{:<10} ",
                 s.cost
                     .as_ref()
-                    .map(|c| format!("${:.2}", c.cost_usd))
+                    .and_then(|c| c.cost_usd.map(|usd| format!("${usd:.2}")))
                     .unwrap_or_else(|| "-".to_string())
             )
         } else {
@@ -219,7 +219,11 @@ struct StatusJsonCost {
     output_tokens: u64,
     cache_read_tokens: u64,
     cache_creation_tokens: u64,
-    cost_usd: f64,
+    /// `null` when the agent reports tokens without reliable USD pricing
+    /// (e.g. Codex). Emitting `null` rather than `0.0` keeps consumers
+    /// from confusing "unknown" with "free".
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cost_usd: Option<f64>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/crates/ao-core/src/cost_ledger.rs
+++ b/crates/ao-core/src/cost_ledger.rs
@@ -167,7 +167,7 @@ mod tests {
             output_tokens: 500,
             cache_read_tokens: 200,
             cache_creation_tokens: 100,
-            cost_usd: 0.05,
+            cost_usd: Some(0.05),
         };
 
         // Manually create ledger to test serialization.
@@ -201,7 +201,7 @@ mod tests {
             output_tokens: 50,
             cache_read_tokens: 0,
             cache_creation_tokens: 0,
-            cost_usd: 0.01,
+            cost_usd: Some(0.01),
         };
         ledger.entries.push(CostEntry {
             session_id: "s1".into(),
@@ -218,7 +218,7 @@ mod tests {
             output_tokens: 250,
             cache_read_tokens: 100,
             cache_creation_tokens: 50,
-            cost_usd: 0.05,
+            cost_usd: Some(0.05),
         };
         if let Some(entry) = ledger.entries.iter_mut().find(|e| e.session_id == "s1") {
             entry.cost = cost_v2.clone();

--- a/crates/ao-core/src/types.rs
+++ b/crates/ao-core/src/types.rs
@@ -316,15 +316,22 @@ fn default_runtime_name() -> String {
 pub struct CostEstimate {
     pub input_tokens: u64,
     pub output_tokens: u64,
+    #[serde(default)]
     pub cache_read_tokens: u64,
+    #[serde(default)]
     pub cache_creation_tokens: u64,
-    /// Estimated total cost in USD, computed from Anthropic's published
-    /// pricing at the time the tokens were consumed.
+    /// Estimated total cost in USD when the agent can compute it from
+    /// reliable published pricing.
     ///
-    /// `f64` is sufficient for reporting precision. Avoid exact equality
-    /// comparisons on this field — use the token counts for deterministic
-    /// checks instead.
-    pub cost_usd: f64,
+    /// `None` when pricing data isn't available (e.g. Codex, where we
+    /// aggregate tokens but don't have a stable provider pricing API).
+    /// Emitting `None` instead of a placeholder `0.0` keeps reporting
+    /// honest — consumers should display `-` for `None`.
+    ///
+    /// Avoid exact equality comparisons on this field — use the token
+    /// counts for deterministic checks instead.
+    #[serde(default)]
+    pub cost_usd: Option<f64>,
 }
 
 /// Input to `Workspace::create`. Carries everything the plugin needs to
@@ -608,11 +615,41 @@ created_at: 1700000000000
             output_tokens: 2000,
             cache_read_tokens: 1000,
             cache_creation_tokens: 500,
-            cost_usd: 0.06,
+            cost_usd: Some(0.06),
         };
         let yaml = serde_yaml::to_string(&cost).unwrap();
         let parsed: CostEstimate = serde_yaml::from_str(&yaml).unwrap();
         assert_eq!(parsed, cost);
+    }
+
+    #[test]
+    fn cost_estimate_without_usd_roundtrips() {
+        // Codex-style: tokens known but USD pricing unavailable. Must
+        // serialize with `cost_usd: null` and round-trip to `None` so
+        // reporting stays honest rather than defaulting to `$0.00`.
+        let cost = CostEstimate {
+            input_tokens: 100,
+            output_tokens: 50,
+            cache_read_tokens: 0,
+            cache_creation_tokens: 0,
+            cost_usd: None,
+        };
+        let yaml = serde_yaml::to_string(&cost).unwrap();
+        let parsed: CostEstimate = serde_yaml::from_str(&yaml).unwrap();
+        assert_eq!(parsed, cost);
+    }
+
+    #[test]
+    fn legacy_cost_estimate_without_cost_usd_field_parses() {
+        // Older ledger files written before cost_usd was optional are
+        // not expected in the wild (it's always been serialized), but
+        // make absence safe just in case — default to None.
+        let yaml =
+            "input_tokens: 10\noutput_tokens: 5\ncache_read_tokens: 0\ncache_creation_tokens: 0\n";
+        let parsed: CostEstimate = serde_yaml::from_str(yaml).unwrap();
+        assert_eq!(parsed.input_tokens, 10);
+        assert_eq!(parsed.output_tokens, 5);
+        assert!(parsed.cost_usd.is_none());
     }
 
     #[test]
@@ -635,7 +672,7 @@ created_at: 1700000000000
                 output_tokens: 50,
                 cache_read_tokens: 10,
                 cache_creation_tokens: 5,
-                cost_usd: 0.001,
+                cost_usd: Some(0.001),
             }),
             issue_id: None,
             issue_url: None,

--- a/crates/plugins/agent-claude-code/src/lib.rs
+++ b/crates/plugins/agent-claude-code/src/lib.rs
@@ -378,7 +378,7 @@ fn parse_cost_from_jsonl(path: &std::path::Path) -> Option<CostEstimate> {
         output_tokens,
         cache_read_tokens,
         cache_creation_tokens,
-        cost_usd,
+        cost_usd: Some(cost_usd),
     })
 }
 
@@ -778,7 +778,8 @@ mod tests {
         assert_eq!(cost.cache_creation_tokens, 100);
         // (3000*3 + 500*15 + 500*0.3 + 100*3.75) / 1_000_000
         let expected = (9000.0 + 7500.0 + 150.0 + 375.0) / 1_000_000.0;
-        assert!((cost.cost_usd - expected).abs() < 1e-10);
+        let usd = cost.cost_usd.expect("claude-code always reports USD");
+        assert!((usd - expected).abs() < 1e-10);
 
         std::fs::remove_dir_all(&dir).ok();
     }

--- a/crates/plugins/agent-codex/src/lib.rs
+++ b/crates/plugins/agent-codex/src/lib.rs
@@ -5,9 +5,19 @@
 //!
 //! ## Launch strategy
 //!
-//! We launch interactive `codex` rather than `codex exec` so the process stays
-//! alive for the orchestrator lifecycle. We also enable `--full-auto` so Codex
-//! can work with minimal interruptions in a supervised session.
+//! We launch the interactive `codex` TUI rather than `codex exec`: the
+//! orchestrator keeps the process alive across multiple turns and uses
+//! `Runtime::send_message` to feed follow-ups, which `codex exec` (a
+//! single-shot runner) cannot support.
+//!
+//! When an `AgentConfig` is available, the command mirrors
+//! `packages/plugins/agent-codex/src/index.ts` in ao-ts:
+//! permission-mode-specific approval flags (`--dangerously-bypass-
+//! approvals-and-sandbox`, `--ask-for-approval never|untrusted`), an
+//! optional `--model` flag, and `-c check_for_update_on_startup=false`
+//! so the TUI never stalls on an interactive update prompt. With no
+//! config we keep the historical `--full-auto` preset to avoid
+//! regressing existing users.
 //!
 //! ## Activity detection
 //!
@@ -19,6 +29,14 @@
 //! 4. fallback `Ready`
 //!
 //! This mirrors the other plugins' "artifact + git fallback" approach.
+//!
+//! ## Cost tracking
+//!
+//! Codex emits token counts in its JSONL logs but no USD figure, and
+//! the CLI doesn't expose a stable pricing API. We aggregate the tokens
+//! and leave `cost_usd` as `None` rather than emitting a placeholder
+//! `0.0` — the status command renders `-` for unknown cost, which is
+//! honest reporting vs. "this session was free".
 
 use ao_core::{ActivityState, Agent, AgentConfig, CostEstimate, Result, Session};
 use async_trait::async_trait;
@@ -33,11 +51,21 @@ pub struct CodexAgent {
     /// Rules prepended to the prompt. Codex supports project instructions via
     /// files, but the orchestrator's `AgentConfig` rules are delivered as text.
     rules: Option<String>,
+    /// When `Some`, drives permission-mode-specific approval flags to
+    /// match ao-ts. `None` keeps the historical `--full-auto` launch
+    /// (used by `CodexAgent::new()` and bare defaults).
+    permissions: Option<String>,
+    /// Model override, passed via `--model`. `None` lets codex pick.
+    model: Option<String>,
 }
 
 impl CodexAgent {
     pub fn new() -> Self {
-        Self { rules: None }
+        Self {
+            rules: None,
+            permissions: None,
+            model: None,
+        }
     }
 
     pub fn from_config(config: &AgentConfig) -> Self {
@@ -52,7 +80,11 @@ impl CodexAgent {
         } else {
             config.rules.clone()
         };
-        Self { rules }
+        Self {
+            rules,
+            permissions: Some(config.permissions.clone()),
+            model: config.model.clone(),
+        }
     }
 }
 
@@ -65,9 +97,7 @@ impl Default for CodexAgent {
 #[async_trait]
 impl Agent for CodexAgent {
     fn launch_command(&self, _session: &Session) -> String {
-        // Interactive TUI with low-friction automation preset.
-        // We intentionally avoid `codex exec` so the process remains alive.
-        "codex --full-auto".to_string()
+        build_launch_command(self.permissions.as_deref(), self.model.as_deref())
     }
 
     fn environment(&self, session: &Session) -> Vec<(String, String)> {
@@ -125,6 +155,94 @@ impl Agent for CodexAgent {
             .await
             .unwrap_or(Ok(None))
     }
+}
+
+// ---------------------------------------------------------------------------
+// Launch command assembly
+// ---------------------------------------------------------------------------
+
+/// Assemble the `codex` launch command.
+///
+/// When `permissions` is `Some`, mirrors the ao-ts `appendApprovalFlags`
+/// mapping:
+/// - `permissionless` → `--dangerously-bypass-approvals-and-sandbox`
+/// - `auto-edit`      → `--ask-for-approval never`
+/// - `suggest`        → `--ask-for-approval untrusted`
+/// - anything else (including `default`) → no approval flag, codex's
+///   built-in default applies.
+///
+/// Either branch also disables the startup update check
+/// (`-c check_for_update_on_startup=false`) so the TUI doesn't wedge on
+/// a "new version available" prompt, and appends `--model <name>` when
+/// the agent config supplies a model.
+///
+/// When `permissions` is `None` (i.e. `CodexAgent::new()` with no
+/// `AgentConfig`), keep the historical `codex --full-auto` string so
+/// existing users don't see a behaviour change.
+fn build_launch_command(permissions: Option<&str>, model: Option<&str>) -> String {
+    let Some(permissions) = permissions else {
+        return "codex --full-auto".to_string();
+    };
+
+    let mut parts: Vec<String> = vec![
+        "codex".to_string(),
+        "-c".to_string(),
+        "check_for_update_on_startup=false".to_string(),
+    ];
+
+    match permissions {
+        "permissionless" => parts.push("--dangerously-bypass-approvals-and-sandbox".to_string()),
+        "auto-edit" => {
+            parts.push("--ask-for-approval".to_string());
+            parts.push("never".to_string());
+        }
+        "suggest" => {
+            parts.push("--ask-for-approval".to_string());
+            parts.push("untrusted".to_string());
+        }
+        // `default` and unknown values: no approval flag, codex picks.
+        _ => {}
+    }
+
+    if let Some(model) = model {
+        parts.push("--model".to_string());
+        parts.push(shell_escape(model));
+        // Match ao-ts: auto-enable high reasoning effort for o-series
+        // models via the codex config override (no `--reasoning` flag
+        // exists; `model_reasoning_effort` is the supported key).
+        if is_o_series_model(model) {
+            parts.push("-c".to_string());
+            parts.push("model_reasoning_effort=high".to_string());
+        }
+    }
+
+    parts.join(" ")
+}
+
+/// Shell-escape a single argument for inclusion in a command string.
+///
+/// The runtime joins parts with a space and runs the result through a
+/// shell (tmux `new-window` or similar), so values with spaces or
+/// metacharacters need quoting. We use single-quote escaping — the
+/// classic `'\''` trick — to avoid shell expansion entirely.
+fn shell_escape(s: &str) -> String {
+    if s.is_empty() {
+        return "''".to_string();
+    }
+    if s.chars()
+        .all(|c| c.is_ascii_alphanumeric() || matches!(c, '_' | '-' | '.' | '/' | ':' | '='))
+    {
+        return s.to_string();
+    }
+    let escaped = s.replace('\'', "'\\''");
+    format!("'{escaped}'")
+}
+
+/// Detect OpenAI o-series reasoning models (o3, o3-mini, o4-mini, …).
+fn is_o_series_model(model: &str) -> bool {
+    let lower = model.to_ascii_lowercase();
+    let mut chars = lower.chars();
+    matches!(chars.next(), Some('o')) && matches!(chars.next(), Some('3' | '4'))
 }
 
 // ---------------------------------------------------------------------------
@@ -266,14 +384,16 @@ impl UsageAgg {
         if self.input_tokens == 0 && self.output_tokens == 0 {
             return None;
         }
-        // No stable pricing API available here; report tokens and omit USD by
-        // setting cost to 0.0. The orchestrator treats the estimate as optional.
+        // Codex JSONL carries token counts but no reliable USD figure,
+        // and we don't maintain a provider pricing table here. Emit
+        // `None` for USD so consumers render it as "unknown" instead of
+        // the misleading `$0.00` the previous hard-coded zero produced.
         Some(CostEstimate {
             input_tokens: self.input_tokens,
             output_tokens: self.output_tokens,
             cache_read_tokens: self.cache_read_tokens,
             cache_creation_tokens: self.cache_creation_tokens,
-            cost_usd: 0.0,
+            cost_usd: None,
         })
     }
 }
@@ -311,11 +431,151 @@ mod tests {
     }
 
     #[test]
-    fn launch_command_uses_full_auto() {
+    fn launch_command_uses_full_auto_without_config() {
+        // Backward compatibility: callers using `CodexAgent::new()` (no
+        // AgentConfig) keep the historical `--full-auto` preset. Users
+        // who don't opt into fine-grained permission modes shouldn't
+        // see a launch-flag change when they upgrade.
         let agent = CodexAgent::new();
         let cmd = agent.launch_command(&fake_session());
-        assert!(cmd.starts_with("codex"));
-        assert!(cmd.contains("--full-auto"));
+        assert_eq!(cmd, "codex --full-auto");
+    }
+
+    #[test]
+    fn launch_command_permissionless_bypasses_approvals_and_sandbox() {
+        let cfg = AgentConfig {
+            permissions: "permissionless".into(),
+            rules: None,
+            rules_file: None,
+            model: None,
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(cmd.starts_with("codex "));
+        assert!(cmd.contains("-c check_for_update_on_startup=false"));
+        assert!(cmd.contains("--dangerously-bypass-approvals-and-sandbox"));
+        assert!(!cmd.contains("--full-auto"));
+    }
+
+    #[test]
+    fn launch_command_auto_edit_sets_ask_for_approval_never() {
+        let cfg = AgentConfig {
+            permissions: "auto-edit".into(),
+            rules: None,
+            rules_file: None,
+            model: None,
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(cmd.contains("--ask-for-approval never"));
+        assert!(!cmd.contains("--dangerously-bypass-approvals-and-sandbox"));
+    }
+
+    #[test]
+    fn launch_command_suggest_sets_ask_for_approval_untrusted() {
+        let cfg = AgentConfig {
+            permissions: "suggest".into(),
+            rules: None,
+            rules_file: None,
+            model: None,
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(cmd.contains("--ask-for-approval untrusted"));
+    }
+
+    #[test]
+    fn launch_command_default_omits_approval_flag() {
+        // `default` permissions maps to codex's own default approval
+        // policy — i.e. no flag, matching ao-ts `appendApprovalFlags`.
+        let cfg = AgentConfig {
+            permissions: "default".into(),
+            rules: None,
+            rules_file: None,
+            model: None,
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(!cmd.contains("--ask-for-approval"));
+        assert!(!cmd.contains("--dangerously-bypass-approvals-and-sandbox"));
+        assert!(!cmd.contains("--full-auto"));
+        assert!(cmd.contains("-c check_for_update_on_startup=false"));
+    }
+
+    #[test]
+    fn launch_command_appends_model_flag() {
+        let cfg = AgentConfig {
+            permissions: "default".into(),
+            rules: None,
+            rules_file: None,
+            model: Some("gpt-5-codex".into()),
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(cmd.contains("--model gpt-5-codex"));
+        // Non-reasoning model should NOT pull in the reasoning config.
+        assert!(!cmd.contains("model_reasoning_effort"));
+    }
+
+    #[test]
+    fn launch_command_o_series_enables_high_reasoning_effort() {
+        // Auto-detect reasoning models (o3/o4…) and add the codex
+        // config override so reasoning effort is "high". Mirrors
+        // `appendModelFlags` in ao-ts.
+        let cfg = AgentConfig {
+            permissions: "default".into(),
+            rules: None,
+            rules_file: None,
+            model: Some("o4-mini".into()),
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(cmd.contains("--model o4-mini"));
+        assert!(cmd.contains("-c model_reasoning_effort=high"));
+    }
+
+    #[test]
+    fn launch_command_shell_escapes_model_with_special_chars() {
+        // Any characters outside the allow-list get single-quoted so a
+        // malformed or adversarial model name can't break out of the
+        // launch string.
+        let cfg = AgentConfig {
+            permissions: "default".into(),
+            rules: None,
+            rules_file: None,
+            model: Some("weird model with spaces".into()),
+            orchestrator_model: None,
+            opencode_session_id: None,
+        };
+        let cmd = CodexAgent::from_config(&cfg).launch_command(&fake_session());
+        assert!(cmd.contains("--model 'weird model with spaces'"));
+    }
+
+    #[test]
+    fn shell_escape_handles_single_quotes() {
+        // Locks in the classic `'\''` trick so a value like `a'b`
+        // round-trips without shell injection risk.
+        assert_eq!(shell_escape("a'b"), "'a'\\''b'");
+        assert_eq!(shell_escape(""), "''");
+        // Allow-listed values pass through untouched.
+        assert_eq!(shell_escape("gpt-5-codex"), "gpt-5-codex");
+    }
+
+    #[test]
+    fn is_o_series_model_matches_reasoning_models() {
+        assert!(is_o_series_model("o3"));
+        assert!(is_o_series_model("o3-mini"));
+        assert!(is_o_series_model("o4-mini"));
+        assert!(is_o_series_model("O4-MINI"));
+        assert!(!is_o_series_model("o1"));
+        assert!(!is_o_series_model("gpt-5-codex"));
+        assert!(!is_o_series_model(""));
     }
 
     #[test]
@@ -356,6 +616,8 @@ mod tests {
     fn initial_prompt_with_rules_prepends_rules() {
         let agent = CodexAgent {
             rules: Some("Always run tests.".into()),
+            permissions: None,
+            model: None,
         };
         let p = agent.initial_prompt(&fake_session());
         assert!(p.starts_with("Always run tests."));
@@ -424,7 +686,28 @@ mod tests {
         let cost = parse_cost_best_effort().unwrap().unwrap();
         assert_eq!(cost.input_tokens, 13);
         assert_eq!(cost.output_tokens, 12);
-        assert_eq!(cost.cost_usd, 0.0);
+        // Codex has no reliable pricing source, so USD stays unknown.
+        // Locking this in prevents a regression back to the misleading
+        // placeholder `0.0` that issue #100 flagged.
+        assert!(cost.cost_usd.is_none());
+
+        let _ = std::fs::remove_dir_all(&dir);
+        std::env::remove_var("CODEX_HOME");
+    }
+
+    #[test]
+    fn parse_cost_best_effort_returns_none_when_no_tokens() {
+        // An otherwise-empty JSONL shouldn't materialise a zero-cost
+        // estimate — the `cost` column stays `-` in status.
+        let _lock = ENV_LOCK.lock().unwrap();
+        let dir = std::env::temp_dir().join(format!("ao-codex-cost-empty-{}", std::process::id()));
+        let _ = std::fs::remove_dir_all(&dir);
+        std::fs::create_dir_all(dir.join("log")).unwrap();
+        std::env::set_var("CODEX_HOME", &dir);
+        std::fs::write(dir.join("history.jsonl"), "\n").unwrap();
+
+        let result = parse_cost_best_effort().unwrap();
+        assert!(result.is_none());
 
         let _ = std::fs::remove_dir_all(&dir);
         std::env::remove_var("CODEX_HOME");

--- a/docs/plans/remaining-to-port/5-3-agent-codex-gaps.md
+++ b/docs/plans/remaining-to-port/5-3-agent-codex-gaps.md
@@ -1,6 +1,6 @@
 # 5.3 agent-codex gaps
 
-Status: planned
+Status: done
 
 ## Why
 


### PR DESCRIPTION
Closes #100.

## Summary
- `CostEstimate.cost_usd` is now `Option<f64>` so agents without a reliable pricing source can report tokens honestly. Status CLI renders `-` for `None`; JSON snapshots skip the field. Claude-code keeps emitting `Some(value)` via its existing pricing table.
- CodexAgent composes its launch command from `AgentConfig` when present, matching `appendApprovalFlags`/`appendModelFlags` in ao-ts:
  - `permissionless` → `--dangerously-bypass-approvals-and-sandbox`
  - `auto-edit` → `--ask-for-approval never`
  - `suggest` → `--ask-for-approval untrusted`
  - `default` / unknown → no approval flag (codex's own default)
  - always includes `-c check_for_update_on_startup=false` so the TUI never stalls on an update prompt
  - `--model <name>` when set, with `-c model_reasoning_effort=high` auto-enabled for o-series reasoning models
  - `CodexAgent::new()` (no config) keeps the historical `codex --full-auto` launch for backward compatibility.
- `codex exec` is intentionally **not** adopted — it's single-shot and exits, which can't back the orchestrator's long-running session + `send_message` model. This limitation is documented in the module docstring.

## Design notes
- The type change is additive at the YAML layer: existing ledger files with `cost_usd: 0.05` still deserialize to `Some(0.05)`, and `#[serde(default)]` covers the rare case where the field is absent. A new test locks this in.
- Shell escaping for `--model` values uses single-quote escaping with the classic `'\''` trick, so an adversarial model name can't break out of the launch string.

## Test plan
- [x] `cargo build -p ao-core -p ao-plugin-agent-codex -p ao-plugin-agent-claude-code -p ao-cli`
- [x] `cargo test -p ao-plugin-agent-codex` — 17 tests pass, including new coverage for every permission mode, `--model` emission, o-series reasoning auto-enable, shell escaping, and `cost_usd: None` round-trip.
- [x] `cargo test --workspace` — no regressions.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)