### PR TITLE
feat(core): upgrade Agent trait stub defaults (#97)

### DIFF
--- a/crates/ao-core/src/activity_log.rs
+++ b/crates/ao-core/src/activity_log.rs
@@ -99,6 +99,24 @@ pub fn check_actionable_state(
     (age <= ACTIVITY_INPUT_STALENESS_SECS).then_some(e.state)
 }
 
+/// Best-effort activity probe from `{workspace}/.ao/activity.jsonl`.
+///
+/// Surfaces only the states a stale log can still describe honestly:
+/// - `Exited` is terminal; staleness does not downgrade it.
+/// - `WaitingInput` / `Blocked` surface when within the staleness cap.
+///
+/// Everything else (including `Active` / `Ready` / `Idle` entries, stale
+/// actionable entries, and a missing or empty log) returns `None` so the
+/// caller can fall through to its own default — matching the
+/// `Agent::detect_activity` "no detection available" contract.
+pub fn detect_activity_from_log(workspace_path: &Path) -> Option<ActivityState> {
+    let (entry, _modified) = read_last_activity_entry(workspace_path).ok().flatten()?;
+    if entry.state == ActivityState::Exited {
+        return Some(ActivityState::Exited);
+    }
+    check_actionable_state(Some(&entry), std::time::SystemTime::now())
+}
+
 fn chrono_like_parse(s: &str) -> Option<std::time::SystemTime> {
     // Minimal ISO-ish parsing without pulling in chrono. Accepts RFC3339 via `DateTime::parse_from_rfc3339`
     // would be nicer, but keep deps minimal: only accept unix ms encoded strings as fallback.
@@ -111,6 +129,24 @@ fn chrono_like_parse(s: &str) -> Option<std::time::SystemTime> {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_workspace(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("ao-rs-activity-log-{label}-{nanos}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn now_ms() -> u64 {
+        SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_millis() as u64
+    }
 
     #[test]
     fn actionable_state_respects_staleness() {
@@ -133,5 +169,116 @@ mod tests {
             trigger: None,
         };
         assert_eq!(check_actionable_state(Some(&stale), now), None);
+    }
+
+    #[test]
+    fn detect_from_log_missing_returns_none() {
+        let ws = unique_workspace("missing");
+        assert!(detect_activity_from_log(&ws).is_none());
+    }
+
+    #[test]
+    fn detect_from_log_exited_always_wins() {
+        let ws = unique_workspace("exited");
+        // Even with a timestamp that's way past the staleness cap,
+        // an Exited entry should surface — terminal is one-way.
+        let ancient = ActivityLogEntry {
+            ts: "0".into(),
+            state: ActivityState::Exited,
+            source: "terminal".into(),
+            trigger: None,
+        };
+        append_activity_entry(&ws, &ancient).unwrap();
+        assert_eq!(
+            detect_activity_from_log(&ws),
+            Some(ActivityState::Exited),
+            "stale Exited entries should still surface",
+        );
+    }
+
+    #[test]
+    fn detect_from_log_fresh_waiting_input_surfaces() {
+        let ws = unique_workspace("fresh-waiting");
+        let entry = ActivityLogEntry {
+            ts: now_ms().to_string(),
+            state: ActivityState::WaitingInput,
+            source: "terminal".into(),
+            trigger: Some("approve?".into()),
+        };
+        append_activity_entry(&ws, &entry).unwrap();
+        assert_eq!(
+            detect_activity_from_log(&ws),
+            Some(ActivityState::WaitingInput)
+        );
+    }
+
+    #[test]
+    fn detect_from_log_fresh_blocked_surfaces() {
+        let ws = unique_workspace("fresh-blocked");
+        let entry = ActivityLogEntry {
+            ts: now_ms().to_string(),
+            state: ActivityState::Blocked,
+            source: "terminal".into(),
+            trigger: Some("error".into()),
+        };
+        append_activity_entry(&ws, &entry).unwrap();
+        assert_eq!(detect_activity_from_log(&ws), Some(ActivityState::Blocked));
+    }
+
+    #[test]
+    fn detect_from_log_stale_actionable_falls_through() {
+        let ws = unique_workspace("stale-actionable");
+        let stale_ms = now_ms().saturating_sub((ACTIVITY_INPUT_STALENESS_SECS + 60) * 1000);
+        let entry = ActivityLogEntry {
+            ts: stale_ms.to_string(),
+            state: ActivityState::WaitingInput,
+            source: "terminal".into(),
+            trigger: None,
+        };
+        append_activity_entry(&ws, &entry).unwrap();
+        assert!(detect_activity_from_log(&ws).is_none());
+    }
+
+    #[test]
+    fn detect_from_log_ignores_active_and_ready() {
+        let ws = unique_workspace("active-ready");
+        // A fresh Active should not surface from the default detector —
+        // Active is a noisy signal that belongs to the plugin's own logic.
+        let entry = ActivityLogEntry {
+            ts: now_ms().to_string(),
+            state: ActivityState::Active,
+            source: "terminal".into(),
+            trigger: None,
+        };
+        append_activity_entry(&ws, &entry).unwrap();
+        assert!(detect_activity_from_log(&ws).is_none());
+    }
+
+    #[test]
+    fn detect_from_log_uses_last_entry() {
+        let ws = unique_workspace("last-entry");
+        // First: blocked (actionable). Then: active (noisy).
+        // The last line wins — since it's Active, we return None.
+        append_activity_entry(
+            &ws,
+            &ActivityLogEntry {
+                ts: now_ms().to_string(),
+                state: ActivityState::Blocked,
+                source: "terminal".into(),
+                trigger: None,
+            },
+        )
+        .unwrap();
+        append_activity_entry(
+            &ws,
+            &ActivityLogEntry {
+                ts: now_ms().to_string(),
+                state: ActivityState::Active,
+                source: "terminal".into(),
+                trigger: None,
+            },
+        )
+        .unwrap();
+        assert!(detect_activity_from_log(&ws).is_none());
     }
 }

--- a/crates/ao-core/src/cost_log.rs
+++ b/crates/ao-core/src/cost_log.rs
@@ -1,0 +1,218 @@
+//! Workspace-local usage JSONL (one line per agent turn).
+//!
+//! Companion to `activity_log.rs`: lives at `{workspace}/.ao/usage.jsonl`
+//! and carries aggregated token usage for plugins that don't have a
+//! native JSONL source of their own. The default `Agent::cost_estimate`
+//! reads this file; plugins that override `cost_estimate` (e.g.
+//! `agent-claude-code` reading `~/.claude/projects/**`) ignore it.
+//!
+//! Distinct from `cost_ledger.rs`:
+//! - `cost_ledger` is the **daemon-side** monthly rotation under
+//!   `~/.ao-rs/cost-ledger/YYYY-MM.yaml` — keyed by session id across
+//!   workspaces.
+//! - `cost_log` is the **per-workspace** turn-level log — one file per
+//!   session's worktree.
+//!
+//! Format: newline-delimited JSON, one `UsageLogEntry` per line:
+//!
+//! ```json
+//! {"ts":"2026-04-17T03:07:00Z","input_tokens":500,"output_tokens":200,
+//!  "cache_read_tokens":10,"cache_creation_tokens":5,"cost_usd":0.0034}
+//! ```
+//!
+//! Every field is `#[serde(default)]` so partial writes contribute what
+//! they can. Unknown fields are ignored (forward compat).
+
+use crate::types::CostEstimate;
+use serde::{Deserialize, Serialize};
+use std::io::BufRead;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct UsageLogEntry {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub ts: Option<String>,
+    #[serde(default)]
+    pub input_tokens: u64,
+    #[serde(default)]
+    pub output_tokens: u64,
+    #[serde(default)]
+    pub cache_read_tokens: u64,
+    #[serde(default)]
+    pub cache_creation_tokens: u64,
+    #[serde(default)]
+    pub cost_usd: f64,
+}
+
+/// Canonical log path: `{workspace}/.ao/usage.jsonl`.
+pub fn usage_log_path(workspace_path: &Path) -> PathBuf {
+    workspace_path.join(".ao").join("usage.jsonl")
+}
+
+/// Aggregate every parseable line in `{workspace}/.ao/usage.jsonl`
+/// into a single `CostEstimate`.
+///
+/// Returns `None` when the file is missing, empty, unreadable, or
+/// aggregates to zero tokens — matching the "no data == no estimate"
+/// rule used by plugins with native parsers.
+pub fn parse_usage_jsonl(workspace_path: &Path) -> Option<CostEstimate> {
+    let path = usage_log_path(workspace_path);
+    let file = std::fs::File::open(&path).ok()?;
+    let reader = std::io::BufReader::new(file);
+
+    let mut input_tokens = 0u64;
+    let mut output_tokens = 0u64;
+    let mut cache_read_tokens = 0u64;
+    let mut cache_creation_tokens = 0u64;
+    let mut cost_usd = 0f64;
+
+    for line in reader.lines().map_while(std::result::Result::ok) {
+        if line.trim().is_empty() {
+            continue;
+        }
+        let Ok(e) = serde_json::from_str::<UsageLogEntry>(&line) else {
+            continue;
+        };
+        input_tokens = input_tokens.saturating_add(e.input_tokens);
+        output_tokens = output_tokens.saturating_add(e.output_tokens);
+        cache_read_tokens = cache_read_tokens.saturating_add(e.cache_read_tokens);
+        cache_creation_tokens = cache_creation_tokens.saturating_add(e.cache_creation_tokens);
+        cost_usd += e.cost_usd;
+    }
+
+    if input_tokens == 0 && output_tokens == 0 {
+        return None;
+    }
+
+    Some(CostEstimate {
+        input_tokens,
+        output_tokens,
+        cache_read_tokens,
+        cache_creation_tokens,
+        cost_usd,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    fn unique_workspace(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("ao-rs-cost-log-{label}-{nanos}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn write_log(workspace: &Path, lines: &[&str]) {
+        let path = usage_log_path(workspace);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut f = std::fs::File::create(&path).unwrap();
+        for line in lines {
+            writeln!(f, "{line}").unwrap();
+        }
+    }
+
+    #[test]
+    fn missing_file_returns_none() {
+        let ws = unique_workspace("missing");
+        assert!(parse_usage_jsonl(&ws).is_none());
+    }
+
+    #[test]
+    fn empty_file_returns_none() {
+        let ws = unique_workspace("empty");
+        write_log(&ws, &[]);
+        assert!(parse_usage_jsonl(&ws).is_none());
+    }
+
+    #[test]
+    fn zero_tokens_returns_none() {
+        let ws = unique_workspace("zero");
+        write_log(
+            &ws,
+            &[r#"{"input_tokens":0,"output_tokens":0,"cost_usd":0.0}"#],
+        );
+        assert!(parse_usage_jsonl(&ws).is_none());
+    }
+
+    #[test]
+    fn single_line_round_trip() {
+        let ws = unique_workspace("single");
+        write_log(
+            &ws,
+            &[
+                r#"{"input_tokens":100,"output_tokens":50,"cache_read_tokens":10,"cache_creation_tokens":5,"cost_usd":0.0012}"#,
+            ],
+        );
+        let got = parse_usage_jsonl(&ws).expect("some");
+        assert_eq!(got.input_tokens, 100);
+        assert_eq!(got.output_tokens, 50);
+        assert_eq!(got.cache_read_tokens, 10);
+        assert_eq!(got.cache_creation_tokens, 5);
+        assert!((got.cost_usd - 0.0012).abs() < 1e-9);
+    }
+
+    #[test]
+    fn multi_line_sums_all_fields() {
+        let ws = unique_workspace("multi");
+        write_log(
+            &ws,
+            &[
+                r#"{"input_tokens":100,"output_tokens":50,"cost_usd":0.5}"#,
+                r#"{"input_tokens":200,"output_tokens":75,"cache_read_tokens":4,"cost_usd":0.25}"#,
+                r#"{"input_tokens":50,"output_tokens":25,"cache_creation_tokens":2,"cost_usd":0.125}"#,
+            ],
+        );
+        let got = parse_usage_jsonl(&ws).expect("some");
+        assert_eq!(got.input_tokens, 350);
+        assert_eq!(got.output_tokens, 150);
+        assert_eq!(got.cache_read_tokens, 4);
+        assert_eq!(got.cache_creation_tokens, 2);
+        assert!((got.cost_usd - 0.875).abs() < 1e-9);
+    }
+
+    #[test]
+    fn garbage_lines_are_skipped() {
+        let ws = unique_workspace("garbage");
+        write_log(
+            &ws,
+            &[
+                "not json",
+                r#"{"input_tokens":100,"output_tokens":50}"#,
+                "{",
+                r#"{"input_tokens":10,"output_tokens":5}"#,
+                "",
+            ],
+        );
+        let got = parse_usage_jsonl(&ws).expect("some");
+        assert_eq!(got.input_tokens, 110);
+        assert_eq!(got.output_tokens, 55);
+    }
+
+    #[test]
+    fn unknown_fields_are_ignored() {
+        let ws = unique_workspace("unknown");
+        write_log(
+            &ws,
+            &[r#"{"input_tokens":10,"output_tokens":5,"model":"opus","unknown":"ok"}"#],
+        );
+        let got = parse_usage_jsonl(&ws).expect("some");
+        assert_eq!(got.input_tokens, 10);
+        assert_eq!(got.output_tokens, 5);
+    }
+
+    #[test]
+    fn usage_log_path_shape() {
+        let ws = PathBuf::from("/tmp/ao-ws");
+        assert_eq!(
+            usage_log_path(&ws),
+            PathBuf::from("/tmp/ao-ws/.ao/usage.jsonl")
+        );
+    }
+}

--- a/crates/ao-core/src/lib.rs
+++ b/crates/ao-core/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod activity_log;
 pub mod config;
 pub mod cost_ledger;
+pub mod cost_log;
 pub mod error;
 pub mod events;
 pub mod lifecycle;

--- a/crates/ao-core/src/traits.rs
+++ b/crates/ao-core/src/traits.rs
@@ -64,20 +64,45 @@ pub trait Agent: Send + Sync {
     /// terminal scrollback, pid probes, ...) and report its current
     /// activity state. Called once per lifecycle tick.
     ///
-    /// A default impl returns `Ready` so plugins can opt in gradually —
-    /// matches the TS "no detection available" fallback.
-    async fn detect_activity(&self, _session: &Session) -> Result<ActivityState> {
+    /// The default impl consults `{workspace}/.ao/activity.jsonl` via
+    /// `activity_log::detect_activity_from_log` and surfaces:
+    /// - `Exited` when the last entry is terminal (no staleness
+    ///   downgrade — exit is a one-way signal).
+    /// - `WaitingInput` / `Blocked` when the last entry is actionable
+    ///   and fresh (within `ACTIVITY_INPUT_STALENESS_SECS`).
+    ///
+    /// Falls back to `Ready` when there's no workspace, no log, or the
+    /// log only carries noisy signals (`Active` / `Ready` / `Idle` /
+    /// stale actionable). Plugins with richer native detection (JSONL
+    /// tailing, git-index mtime, ...) override this entirely.
+    async fn detect_activity(&self, session: &Session) -> Result<ActivityState> {
+        if let Some(ref ws) = session.workspace_path {
+            if let Some(state) = crate::activity_log::detect_activity_from_log(ws) {
+                return Ok(state);
+            }
+        }
         Ok(ActivityState::Ready)
     }
 
     /// Poll current aggregated token usage / cost from the agent's logs.
     ///
     /// Called by the lifecycle loop when a session's status changes (not
-    /// every tick). Returns `None` when cost tracking is unavailable or
-    /// the session has no log data yet. The default impl returns `None`
-    /// so agents that don't track cost just work.
-    async fn cost_estimate(&self, _session: &Session) -> Result<Option<CostEstimate>> {
-        Ok(None)
+    /// every tick). The default impl consults
+    /// `{workspace}/.ao/usage.jsonl` via `cost_log::parse_usage_jsonl`
+    /// and returns the aggregate when entries exist. Returns `None`
+    /// when cost tracking is unavailable — either because there's no
+    /// workspace, the file is missing, or it aggregates to zero tokens.
+    /// Plugins with native cost sources (e.g. `agent-claude-code`
+    /// reading `~/.claude/projects/**`) override this.
+    async fn cost_estimate(&self, session: &Session) -> Result<Option<CostEstimate>> {
+        let Some(ref ws) = session.workspace_path else {
+            return Ok(None);
+        };
+        let ws = ws.clone();
+        let estimate = tokio::task::spawn_blocking(move || crate::cost_log::parse_usage_jsonl(&ws))
+            .await
+            .unwrap_or(None);
+        Ok(estimate)
     }
 }
 
@@ -339,5 +364,193 @@ pub trait Tracker: Send + Sync {
         Err(AoError::Other(
             "tracker does not support creating issues".to_string(),
         ))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::activity_log::{
+        append_activity_entry, ActivityLogEntry, ACTIVITY_INPUT_STALENESS_SECS,
+    };
+    use crate::cost_log::usage_log_path;
+    use crate::types::{now_ms, SessionId, SessionStatus};
+    use std::io::Write;
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    /// Minimal `Agent` stub that keeps every default intact. Exists so
+    /// tests can exercise the trait defaults without depending on any
+    /// plugin crate.
+    struct StubAgent;
+
+    #[async_trait]
+    impl Agent for StubAgent {
+        fn launch_command(&self, _session: &Session) -> String {
+            String::new()
+        }
+        fn environment(&self, _session: &Session) -> Vec<(String, String)> {
+            Vec::new()
+        }
+        fn initial_prompt(&self, _session: &Session) -> String {
+            String::new()
+        }
+    }
+
+    fn unique_workspace(label: &str) -> PathBuf {
+        let nanos = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap()
+            .as_nanos();
+        let p = std::env::temp_dir().join(format!("ao-rs-trait-default-{label}-{nanos}"));
+        std::fs::create_dir_all(&p).unwrap();
+        p
+    }
+
+    fn session_with(workspace: Option<PathBuf>) -> Session {
+        Session {
+            id: SessionId("trait-default".into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Working,
+            agent: "stub".into(),
+            agent_config: None,
+            branch: "feat".into(),
+            task: "t".into(),
+            workspace_path: workspace,
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: None,
+        }
+    }
+
+    #[tokio::test]
+    async fn detect_activity_default_no_workspace_returns_ready() {
+        let agent = StubAgent;
+        let session = session_with(None);
+        assert_eq!(
+            agent.detect_activity(&session).await.unwrap(),
+            ActivityState::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_activity_default_no_log_returns_ready() {
+        let agent = StubAgent;
+        let ws = unique_workspace("no-log");
+        let session = session_with(Some(ws));
+        assert_eq!(
+            agent.detect_activity(&session).await.unwrap(),
+            ActivityState::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_activity_default_surfaces_exited_from_log() {
+        let agent = StubAgent;
+        let ws = unique_workspace("exited");
+        append_activity_entry(
+            &ws,
+            &ActivityLogEntry {
+                ts: now_ms().to_string(),
+                state: ActivityState::Exited,
+                source: "terminal".into(),
+                trigger: None,
+            },
+        )
+        .unwrap();
+        let session = session_with(Some(ws));
+        assert_eq!(
+            agent.detect_activity(&session).await.unwrap(),
+            ActivityState::Exited
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_activity_default_surfaces_fresh_waiting_input() {
+        let agent = StubAgent;
+        let ws = unique_workspace("waiting");
+        append_activity_entry(
+            &ws,
+            &ActivityLogEntry {
+                ts: now_ms().to_string(),
+                state: ActivityState::WaitingInput,
+                source: "terminal".into(),
+                trigger: Some("approve?".into()),
+            },
+        )
+        .unwrap();
+        let session = session_with(Some(ws));
+        assert_eq!(
+            agent.detect_activity(&session).await.unwrap(),
+            ActivityState::WaitingInput
+        );
+    }
+
+    #[tokio::test]
+    async fn detect_activity_default_stale_waiting_falls_back_to_ready() {
+        let agent = StubAgent;
+        let ws = unique_workspace("stale-waiting");
+        let stale_ms = now_ms().saturating_sub((ACTIVITY_INPUT_STALENESS_SECS + 60) * 1000);
+        append_activity_entry(
+            &ws,
+            &ActivityLogEntry {
+                ts: stale_ms.to_string(),
+                state: ActivityState::WaitingInput,
+                source: "terminal".into(),
+                trigger: None,
+            },
+        )
+        .unwrap();
+        let session = session_with(Some(ws));
+        assert_eq!(
+            agent.detect_activity(&session).await.unwrap(),
+            ActivityState::Ready
+        );
+    }
+
+    #[tokio::test]
+    async fn cost_estimate_default_no_workspace_returns_none() {
+        let agent = StubAgent;
+        let session = session_with(None);
+        assert!(agent.cost_estimate(&session).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn cost_estimate_default_no_log_returns_none() {
+        let agent = StubAgent;
+        let ws = unique_workspace("cost-missing");
+        let session = session_with(Some(ws));
+        assert!(agent.cost_estimate(&session).await.unwrap().is_none());
+    }
+
+    #[tokio::test]
+    async fn cost_estimate_default_reads_usage_log() {
+        let agent = StubAgent;
+        let ws = unique_workspace("cost-present");
+        let path = usage_log_path(&ws);
+        std::fs::create_dir_all(path.parent().unwrap()).unwrap();
+        let mut f = std::fs::File::create(&path).unwrap();
+        writeln!(
+            f,
+            r#"{{"input_tokens":100,"output_tokens":50,"cost_usd":0.5}}"#
+        )
+        .unwrap();
+        writeln!(
+            f,
+            r#"{{"input_tokens":200,"output_tokens":75,"cost_usd":0.25}}"#
+        )
+        .unwrap();
+
+        let session = session_with(Some(ws));
+        let cost = agent.cost_estimate(&session).await.unwrap().expect("some");
+        assert_eq!(cost.input_tokens, 300);
+        assert_eq!(cost.output_tokens, 125);
+        assert!((cost.cost_usd - 0.75).abs() < 1e-9);
     }
 }


### PR DESCRIPTION
## Summary

- `Agent::detect_activity` default now consults `{workspace}/.ao/activity.jsonl` and surfaces `Exited` (terminal — no staleness downgrade) and fresh `WaitingInput` / `Blocked`. Falls back to `Ready` when there's no workspace / no log / only noisy-signal entries.
- `Agent::cost_estimate` default now consults `{workspace}/.ao/usage.jsonl` via a new `cost_log` module and returns the aggregate `CostEstimate` when entries exist. Falls back to `None`.
- New helpers usable by plugins:
  - `activity_log::detect_activity_from_log(workspace)`
  - `cost_log::parse_usage_jsonl(workspace)` + `UsageLogEntry` type
- Plugin overrides (claude-code / codex / cursor / aider) stay authoritative — zero behaviour change for them; the four plugins build and test green with no edits.

Closes #97.

## Test plan

- [x] `cargo test -p ao-core --lib` (269 passed, 0 failed)
- [x] `cargo test --workspace` — full workspace green
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] New unit tests for `detect_activity_from_log` cover: missing file, exited-always-wins (stale OK), fresh waiting_input / blocked, stale actionable → None, noisy signals → None.
- [x] New unit tests for `parse_usage_jsonl` cover: missing / empty / zero-tokens / single-line / multi-line sum / garbage-line skip / unknown-field tolerance.
- [x] Integration-style tests inside `traits.rs` exercise both defaults via a minimal `StubAgent`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)