### PR TITLE
feat(core): orchestrator meta-agent with self-coordinating MVP (#165)

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -510,6 +510,17 @@ pub enum Command {
         action: SessionAction,
     },
 
+    /// Orchestrator (meta-agent) subcommands.
+    ///
+    /// An orchestrator session is a long-lived agent that coordinates other
+    /// agent sessions — reads the backlog, spawns workers via `ao-rs spawn`,
+    /// and handles review/CI routing. Each invocation creates a new numbered
+    /// orchestrator (`<project>-orchestrator-N`).
+    Orchestrator {
+        #[command(subcommand)]
+        action: OrchestratorAction,
+    },
+
     /// Lightweight local issue helper (non-GitHub workflows).
     ///
     /// Creates markdown files under `docs/issues/` inside the repo.
@@ -597,6 +608,52 @@ pub enum SessionAction {
         /// Skip the workspace existence check.
         #[arg(short, long)]
         force: bool,
+    },
+}
+
+#[derive(Subcommand)]
+pub enum OrchestratorAction {
+    /// Spawn a new orchestrator session for a project.
+    ///
+    /// Creates an isolated worktree on `orchestrator/<session-id>`, launches
+    /// the configured agent, and delivers the rendered orchestrator system
+    /// prompt so the agent knows it coordinates other sessions.
+    Spawn {
+        /// Path to the git repo. Defaults to the current directory.
+        #[arg(long)]
+        repo: Option<PathBuf>,
+
+        /// Default branch used as the worktree base.
+        #[arg(long, default_value = "main")]
+        default_branch: String,
+
+        /// Project id (defaults to the resolved repo directory name).
+        #[arg(long)]
+        project: Option<String>,
+
+        /// Dashboard port used in the orchestrator prompt and `AO_PORT` env.
+        #[arg(long, default_value_t = 3000)]
+        port: u16,
+
+        /// Override the agent plugin for the orchestrator role.
+        /// Supported: `claude-code`, `cursor`, `aider`, `codex`.
+        #[arg(long)]
+        agent: Option<String>,
+
+        /// Override the runtime plugin. Supported: `tmux`, `process`.
+        #[arg(long)]
+        runtime: Option<String>,
+
+        /// Skip sending the orchestrator system prompt after launch.
+        #[arg(long)]
+        no_prompt: bool,
+    },
+
+    /// List orchestrator sessions (filtered from all sessions on disk).
+    List {
+        /// Filter to a single project id.
+        #[arg(long)]
+        project: Option<String>,
     },
 }
 

--- a/crates/ao-cli/src/commands/doctor.rs
+++ b/crates/ao-cli/src/commands/doctor.rs
@@ -124,7 +124,11 @@ pub async fn doctor(fix: bool, test_notify: bool) -> Result<(), Box<dyn std::err
     if fix {
         println!();
         println!("Fixes:");
-        failures += apply_fixes(&paths::data_dir(), &paths::default_sessions_dir(), &config_path);
+        failures += apply_fixes(
+            &paths::data_dir(),
+            &paths::default_sessions_dir(),
+            &config_path,
+        );
     }
 
     // 7. --test-notify: route a synthetic payload through each priority.
@@ -168,7 +172,10 @@ fn apply_fixes(data_dir: &Path, sessions_dir: &Path, config_path: &Path) -> u32 
         match std::fs::create_dir_all(dir) {
             Ok(()) => println!("  FIX   {label:<10} created {}", dir.display()),
             Err(e) => {
-                println!("  FAIL  {label:<10} could not create {}: {e}", dir.display());
+                println!(
+                    "  FAIL  {label:<10} could not create {}: {e}",
+                    dir.display()
+                );
                 failures += 1;
             }
         }
@@ -543,9 +550,8 @@ mod tests {
     #[tokio::test]
     async fn test_notify_dispatches_payload_for_each_priority() {
         let (notifier, received) = CapturingNotifier::new("capture");
-        let mut registry = NotifierRegistry::new(routing_for_all_priorities(vec![
-            "capture".to_string()
-        ]));
+        let mut registry =
+            NotifierRegistry::new(routing_for_all_priorities(vec!["capture".to_string()]));
         registry.register("capture", Arc::new(notifier));
 
         let failures = run_test_notify(&registry).await;
@@ -580,9 +586,8 @@ mod tests {
 
     #[tokio::test]
     async fn test_notify_counts_send_errors_as_failures() {
-        let mut registry = NotifierRegistry::new(routing_for_all_priorities(vec![
-            "failing".to_string()
-        ]));
+        let mut registry =
+            NotifierRegistry::new(routing_for_all_priorities(vec!["failing".to_string()]));
         registry.register("failing", Arc::new(FailingNotifier));
 
         let failures = run_test_notify(&registry).await;

--- a/crates/ao-cli/src/commands/mod.rs
+++ b/crates/ao-cli/src/commands/mod.rs
@@ -6,6 +6,7 @@ pub mod dashboard;
 pub mod doctor;
 pub mod kill;
 pub mod open;
+pub mod orchestrator;
 pub mod plugin;
 pub mod pr;
 pub mod review_check;

--- a/crates/ao-cli/src/commands/orchestrator.rs
+++ b/crates/ao-cli/src/commands/orchestrator.rs
@@ -1,0 +1,156 @@
+//! `ao-rs orchestrator` subcommand (Slice 3 of issue #165).
+//!
+//! Thin CLI wrapper over `ao_core::spawn_orchestrator`: resolves repo +
+//! project config, selects the orchestrator role's agent/runtime, and
+//! hands everything to the core helper.
+//!
+//! Spawns and/or lists long-lived orchestrator sessions. A worker session
+//! is created via `ao-rs spawn`; this command is distinct because
+//! orchestrators are singletons per invocation (always a new `-N`), never
+//! own a PR, and get a rendered orchestrator system prompt instead of
+//! issue/task context.
+
+use std::path::PathBuf;
+
+use ao_core::{
+    is_orchestrator_session, spawn_orchestrator, AoConfig, LoadedConfig, OrchestratorSpawnConfig,
+    SessionManager,
+};
+use ao_plugin_workspace_worktree::WorktreeWorkspace;
+
+use crate::cli::agent_config::resolve_agent_config;
+use crate::cli::plugins::{select_agent, select_runtime};
+use crate::cli::printing::print_config_warnings;
+use crate::cli::project::{resolve_project_id, resolve_repo_root};
+
+#[allow(clippy::too_many_arguments)]
+pub async fn spawn(
+    repo: Option<PathBuf>,
+    default_branch: String,
+    project: Option<String>,
+    port: u16,
+    agent_override: Option<String>,
+    runtime_override: Option<String>,
+    no_prompt: bool,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let repo_path = resolve_repo_root(repo)?;
+    if !repo_path.join(".git").exists() {
+        return Err(format!("not a git repo: {}", repo_path.display()).into());
+    }
+
+    let config_path = AoConfig::path_in(&repo_path);
+    let LoadedConfig {
+        config: ao_config,
+        warnings,
+    } = AoConfig::load_from_or_default_with_warnings(&config_path)
+        .map_err(|e| format!("failed to load {}: {e}", config_path.display()))?;
+    print_config_warnings(&config_path, &warnings);
+
+    let project_id = resolve_project_id(&repo_path, &ao_config, project);
+    let project_config = ao_config
+        .projects
+        .get(&project_id)
+        .ok_or_else(|| format!("project '{project_id}' is not configured in ao-rs.yaml"))?
+        .clone();
+
+    // Agent resolution for orchestrator role: CLI --agent →
+    // `projects.*.orchestrator.agent` → `projects.*.agent` →
+    // `defaults.orchestrator.agent` → `defaults.agent` → claude-code.
+    let agent_name = agent_override
+        .or_else(|| {
+            project_config
+                .orchestrator
+                .as_ref()
+                .and_then(|r| r.agent.clone())
+                .or_else(|| project_config.agent.clone())
+        })
+        .or_else(|| {
+            ao_config
+                .defaults
+                .as_ref()
+                .and_then(|d| d.orchestrator.as_ref().and_then(|r| r.agent.clone()))
+        })
+        .or_else(|| ao_config.defaults.as_ref().map(|d| d.agent.clone()))
+        .unwrap_or_else(|| "claude-code".to_string());
+
+    let runtime_name = runtime_override
+        .or_else(|| project_config.runtime.clone())
+        .or_else(|| ao_config.defaults.as_ref().map(|d| d.runtime.clone()))
+        .unwrap_or_else(|| "tmux".to_string());
+
+    let agent_config = resolve_agent_config(project_config.agent_config.as_ref(), &repo_path);
+    let agent = select_agent(&agent_name, agent_config.as_ref());
+    let runtime = select_runtime(&runtime_name);
+    let workspace = WorktreeWorkspace::new();
+    let sessions = SessionManager::with_default();
+
+    println!("→ project:   {project_id}");
+    println!("→ agent:     {agent_name}");
+    println!("→ runtime:   {runtime_name}");
+    println!("→ port:      {port}");
+    println!();
+
+    let session = spawn_orchestrator(
+        OrchestratorSpawnConfig {
+            project_id: &project_id,
+            project_config: &project_config,
+            config: &ao_config,
+            config_path: Some(config_path.clone()),
+            port,
+            agent_name: &agent_name,
+            runtime_name: &runtime_name,
+            repo_path,
+            default_branch,
+            no_prompt,
+        },
+        &sessions,
+        &workspace,
+        agent.as_ref(),
+        runtime.as_ref(),
+    )
+    .await?;
+
+    let handle = session.runtime_handle.as_deref().unwrap_or(&session.id.0);
+    println!("───────────────────────────────────────────────");
+    println!("  ✓ orchestrator spawned & persisted");
+    println!();
+    println!("  session:  {}", session.id.0);
+    println!("  branch:   {}", session.branch);
+    if let Some(ref ws) = session.workspace_path {
+        println!("  worktree: {}", ws.display());
+    }
+    println!("  attach:   tmux attach -t {handle}");
+    println!("  send:     ao-rs send {} <message>", session.id.0);
+    println!("───────────────────────────────────────────────");
+
+    Ok(())
+}
+
+pub async fn list(project_filter: Option<String>) -> Result<(), Box<dyn std::error::Error>> {
+    let sessions = SessionManager::with_default();
+    let all = match project_filter.as_deref() {
+        Some(id) => sessions.list_for_project(id).await?,
+        None => sessions.list().await?,
+    };
+    let orchestrators: Vec<_> = all.into_iter().filter(is_orchestrator_session).collect();
+
+    if orchestrators.is_empty() {
+        println!("no orchestrator sessions found");
+        return Ok(());
+    }
+
+    println!(
+        "{:<32} {:<16} {:<12} BRANCH",
+        "SESSION", "PROJECT", "STATUS"
+    );
+    for s in orchestrators {
+        println!(
+            "{:<32} {:<16} {:<12} {}",
+            s.id.0,
+            s.project_id,
+            s.status.as_str(),
+            s.branch
+        );
+    }
+    Ok(())
+}

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -26,7 +26,8 @@ use std::time::Duration;
 use clap::Parser;
 
 use crate::cli::args::{
-    Cli, Command, IssueAction, OpenTarget, PluginAction, SessionAction, SetupAction,
+    Cli, Command, IssueAction, OpenTarget, OrchestratorAction, PluginAction, SessionAction,
+    SetupAction,
 };
 use crate::commands::start::StartOptions;
 
@@ -214,6 +215,29 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
         Command::Plugin { action } => match action {
             PluginAction::List => commands::plugin::list().await,
             PluginAction::Info { name } => commands::plugin::info(name).await,
+        },
+        Command::Orchestrator { action } => match action {
+            OrchestratorAction::Spawn {
+                repo,
+                default_branch,
+                project,
+                port,
+                agent,
+                runtime,
+                no_prompt,
+            } => {
+                commands::orchestrator::spawn(
+                    repo,
+                    default_branch,
+                    project,
+                    port,
+                    agent,
+                    runtime,
+                    no_prompt,
+                )
+                .await
+            }
+            OrchestratorAction::List { project } => commands::orchestrator::list(project).await,
         },
         Command::Session { action } => match action {
             SessionAction::Restore { session } => session::restore::restore(session).await,

--- a/crates/ao-core/src/cost_log.rs
+++ b/crates/ao-core/src/cost_log.rs
@@ -155,7 +155,7 @@ mod tests {
         assert_eq!(got.output_tokens, 50);
         assert_eq!(got.cache_read_tokens, 10);
         assert_eq!(got.cache_creation_tokens, 5);
-        assert!((got.cost_usd - 0.0012).abs() < 1e-9);
+        assert!((got.cost_usd.unwrap() - 0.0012).abs() < 1e-9);
     }
 
     #[test]
@@ -174,7 +174,7 @@ mod tests {
         assert_eq!(got.output_tokens, 150);
         assert_eq!(got.cache_read_tokens, 4);
         assert_eq!(got.cache_creation_tokens, 2);
-        assert!((got.cost_usd - 0.875).abs() < 1e-9);
+        assert!((got.cost_usd.unwrap() - 0.875).abs() < 1e-9);
     }
 
     #[test]

--- a/crates/ao-core/src/lib.rs
+++ b/crates/ao-core/src/lib.rs
@@ -10,6 +10,7 @@ pub mod notifier;
 pub mod notifier_resolution;
 pub mod opencode_session_id;
 pub mod orchestrator_prompt;
+pub mod orchestrator_spawn;
 pub mod parity_config_validation;
 pub mod parity_feedback_tools;
 pub mod parity_metadata;
@@ -43,6 +44,10 @@ pub use notifier::{
     NotificationPayload, NotificationRouting, Notifier, NotifierError, NotifierRegistry,
 };
 pub use orchestrator_prompt::{generate_orchestrator_prompt, OrchestratorPromptConfig};
+pub use orchestrator_spawn::{
+    is_orchestrator_session, reserve_orchestrator_identity, spawn_orchestrator,
+    OrchestratorSpawnConfig,
+};
 pub use parity_session_strategy::{OpencodeIssueSessionStrategy, OrchestratorSessionStrategy};
 pub use prompt_builder::build_prompt;
 pub use reaction_engine::{status_to_reaction_key, ReactionEngine};
@@ -52,11 +57,10 @@ pub use reactions::{
 };
 pub use restore::{restore_session, RestoreOutcome};
 pub use scm::{
-    AutomatedComment, AutomatedCommentSeverity, CheckRun, CheckStatus, CiStatus,
-    CreateIssueInput, Issue, IssueFilters, IssueState, IssueUpdate, MergeMethod, MergeReadiness,
-    PrState, PrSummary, PullRequest, Review, ReviewComment, ReviewDecision, ReviewState,
-    ScmWebhookEvent, ScmWebhookEventKind, ScmWebhookRepository, ScmWebhookRequest,
-    ScmWebhookVerificationResult,
+    AutomatedComment, AutomatedCommentSeverity, CheckRun, CheckStatus, CiStatus, CreateIssueInput,
+    Issue, IssueFilters, IssueState, IssueUpdate, MergeMethod, MergeReadiness, PrState, PrSummary,
+    PullRequest, Review, ReviewComment, ReviewDecision, ReviewState, ScmWebhookEvent,
+    ScmWebhookEventKind, ScmWebhookRepository, ScmWebhookRequest, ScmWebhookVerificationResult,
 };
 pub use scm_transitions::{derive_scm_status, ScmObservation};
 pub use session_manager::SessionManager;

--- a/crates/ao-core/src/orchestrator_prompt.rs
+++ b/crates/ao-core/src/orchestrator_prompt.rs
@@ -1,9 +1,17 @@
 //! Orchestrator prompt generator (TS `orchestrator-prompt.ts` equivalent).
 //!
-//! This is intended for an "orchestrator session" whose job is to manage
-//! worker sessions, not to implement code changes directly.
+//! Renders `prompts/orchestrator.md` with `{{placeholder}}` substitution
+//! and `{{SECTION_START}}…{{SECTION_END}}` conditional blocks so a single
+//! template handles repo-configured / not-configured / rules-present /
+//! reactions-present variants.
+//!
+//! Kept 1:1 with the TS rendering algorithm so ao-rs and ao-ts can share
+//! the same template file going forward.
 
 use crate::config::{AoConfig, ProjectConfig};
+use crate::reactions::ReactionAction;
+
+const ORCHESTRATOR_TEMPLATE: &str = include_str!("prompts/orchestrator.md");
 
 pub struct OrchestratorPromptConfig<'a> {
     pub config: &'a AoConfig,
@@ -12,100 +20,297 @@ pub struct OrchestratorPromptConfig<'a> {
     pub dashboard_port: u16,
 }
 
+/// Generate the orchestrator's system prompt from the bundled template.
+///
+/// Placeholder / block semantics mirror `packages/core/src/orchestrator-prompt.ts`:
+/// - `{{name}}` is unconditionally substituted; an unresolved one aborts.
+/// - `{{NAME_START}}...{{NAME_END}}` blocks are kept iff their section has content.
 pub fn generate_orchestrator_prompt(opts: OrchestratorPromptConfig<'_>) -> String {
-    let mut sections: Vec<String> = Vec::new();
+    let data = RenderData::from_opts(&opts);
+    let stripped = apply_optional_blocks(ORCHESTRATOR_TEMPLATE.trim(), &data);
+    let rendered = substitute_placeholders(&stripped, &data);
+    rendered.trim().to_string()
+}
 
-    sections.push(format!(
-        "# {} Orchestrator\n\n\
-You are the **orchestrator agent** for the `{}` project.\n\n\
-Your role is to coordinate and manage worker agent sessions. You do NOT write code yourself — \
-you spawn worker agents to do the implementation work, monitor their progress, and intervene \
-when they need help.",
-        opts.project_id, opts.project_id
-    ));
+// ---------------------------------------------------------------------------
+// Render data
+// ---------------------------------------------------------------------------
 
-    sections.push(
-        "## Non-Negotiable Rules\n\n\
-- Investigations from the orchestrator session are **read-only**. Inspect status, logs, metadata, PR state, and worker output, but do not edit repository files or implement fixes from the orchestrator session.\n\
-- Any code change, test run tied to implementation, git branch work, or PR takeover must be delegated to a **worker session**.\n\
-- The orchestrator session must never own a PR. Never claim a PR into the orchestrator session.\n\
-- If an investigation discovers follow-up work, either spawn a worker session or direct an existing worker session with clear instructions.\n\
-- **Always use `ao-rs send` to communicate with sessions** — never use raw `tmux send-keys` or `tmux capture-pane`.\n\
-- When a session might be busy, prefer sending a concise instruction and let the lifecycle loop + reactions drive follow-ups."
-            .to_string(),
-    );
+struct RenderData<'a> {
+    project_id: &'a str,
+    project_name: String,
+    project_repo: String,
+    project_default_branch: &'a str,
+    project_session_prefix: String,
+    project_path: &'a str,
+    dashboard_port: String,
+    automated_reactions_section: String,
+    project_specific_rules_section: String,
+    repo_configured: bool,
+    repo_not_configured: bool,
+    reactions_section_present: bool,
+    rules_section_present: bool,
+}
 
-    let rules = opts
+impl<'a> RenderData<'a> {
+    fn from_opts(opts: &'a OrchestratorPromptConfig<'a>) -> Self {
+        let has_repo = !opts.project.repo.trim().is_empty();
+        let repo_display = if has_repo {
+            opts.project.repo.clone()
+        } else {
+            "not configured".to_string()
+        };
+
+        let session_prefix = opts
+            .project
+            .session_prefix
+            .clone()
+            .unwrap_or_else(|| opts.project_id.to_string());
+
+        let project_name = opts
+            .project
+            .name
+            .clone()
+            .unwrap_or_else(|| opts.project_id.to_string());
+
+        let reactions = build_automated_reactions_section(opts);
+        let rules = build_project_specific_rules_section(opts);
+
+        Self {
+            project_id: opts.project_id,
+            project_name,
+            project_repo: repo_display,
+            project_default_branch: &opts.project.default_branch,
+            project_session_prefix: session_prefix,
+            project_path: &opts.project.path,
+            dashboard_port: opts.dashboard_port.to_string(),
+            reactions_section_present: !reactions.is_empty(),
+            rules_section_present: !rules.is_empty(),
+            automated_reactions_section: reactions,
+            project_specific_rules_section: rules,
+            repo_configured: has_repo,
+            repo_not_configured: !has_repo,
+        }
+    }
+
+    fn lookup_placeholder(&self, key: &str) -> Option<&str> {
+        Some(match key {
+            "projectId" => self.project_id,
+            "projectName" => self.project_name.as_str(),
+            "projectRepo" => self.project_repo.as_str(),
+            "projectDefaultBranch" => self.project_default_branch,
+            "projectSessionPrefix" => self.project_session_prefix.as_str(),
+            "projectPath" => self.project_path,
+            "dashboardPort" => self.dashboard_port.as_str(),
+            "automatedReactionsSection" => self.automated_reactions_section.as_str(),
+            "projectSpecificRulesSection" => self.project_specific_rules_section.as_str(),
+            _ => return None,
+        })
+    }
+
+    fn section_flag(&self, marker: &str) -> Option<bool> {
+        Some(match marker {
+            "REPO_CONFIGURED_SECTION" => self.repo_configured,
+            "REPO_NOT_CONFIGURED_SECTION" => self.repo_not_configured,
+            "AUTOMATED_REACTIONS_SECTION" => self.reactions_section_present,
+            "PROJECT_SPECIFIC_RULES_SECTION" => self.rules_section_present,
+            _ => return None,
+        })
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Section / placeholder helpers
+// ---------------------------------------------------------------------------
+
+fn build_automated_reactions_section(opts: &OrchestratorPromptConfig<'_>) -> String {
+    let mut lines = Vec::new();
+
+    // Project-level reactions win; fall back to global reactions for display.
+    let reactions = if !opts.project.reactions.is_empty() {
+        &opts.project.reactions
+    } else {
+        &opts.config.reactions
+    };
+
+    for (event, reaction) in reactions {
+        if !reaction.auto {
+            continue;
+        }
+        match &reaction.action {
+            ReactionAction::SendToAgent => {
+                let retries = reaction
+                    .retries
+                    .map(|n| n.to_string())
+                    .unwrap_or_else(|| "none".into());
+                let escalate = reaction
+                    .escalate_after
+                    .as_ref()
+                    .map(|v| match v {
+                        crate::reactions::EscalateAfter::Attempts(n) => n.to_string(),
+                        crate::reactions::EscalateAfter::Duration(s) => s.clone(),
+                    })
+                    .unwrap_or_else(|| "never".into());
+                lines.push(format!(
+                    "- **{event}**: Auto-sends instruction to agent (retries: {retries}, escalates after: {escalate})"
+                ));
+            }
+            ReactionAction::Notify => {
+                let priority = reaction
+                    .priority
+                    .map(|p| p.as_str().to_string())
+                    .unwrap_or_else(|| "info".into());
+                lines.push(format!(
+                    "- **{event}**: Notifies human (priority: {priority})"
+                ));
+            }
+            _ => {}
+        }
+    }
+
+    lines.join("\n")
+}
+
+fn build_project_specific_rules_section(opts: &OrchestratorPromptConfig<'_>) -> String {
+    let project_rules = opts
         .project
         .orchestrator_rules
         .as_deref()
-        .filter(|r| !r.trim().is_empty())
-        .or_else(|| {
-            opts.config
-                .defaults
-                .as_ref()
-                .and_then(|d| d.orchestrator_rules.as_deref())
-                .filter(|r| !r.trim().is_empty())
-        });
-    if let Some(rules) = rules {
-        sections.push(format!("## Orchestrator Rules (from config)\n\n{rules}"));
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    let default_rules = opts
+        .config
+        .defaults
+        .as_ref()
+        .and_then(|d| d.orchestrator_rules.as_deref())
+        .map(str::trim)
+        .filter(|s| !s.is_empty());
+
+    project_rules
+        .or(default_rules)
+        .map(str::to_string)
+        .unwrap_or_default()
+}
+
+// ---------------------------------------------------------------------------
+// Optional blocks: {{NAME_START}}...{{NAME_END}}
+// ---------------------------------------------------------------------------
+
+fn apply_optional_blocks(template: &str, data: &RenderData<'_>) -> String {
+    let mut out = template.to_string();
+
+    let markers = [
+        "REPO_CONFIGURED_SECTION",
+        "REPO_NOT_CONFIGURED_SECTION",
+        "AUTOMATED_REACTIONS_SECTION",
+        "PROJECT_SPECIFIC_RULES_SECTION",
+    ];
+
+    for marker in markers {
+        let start = format!("{{{{{marker}_START}}}}");
+        let end = format!("{{{{{marker}_END}}}}");
+        let keep = data.section_flag(marker).unwrap_or(false);
+        out = process_blocks(&out, &start, &end, keep);
     }
 
-    sections.push(format!(
-        "## Project Info\n\n\
-- **Project ID**: {}\n\
-- **Repository**: {}\n\
-- **Default Branch**: {}\n\
-- **Local Path**: {}\n\
-- **Dashboard URL**: http://127.0.0.1:{}",
-        opts.project_id,
-        opts.project.repo,
-        opts.project.default_branch,
-        opts.project.path,
-        opts.dashboard_port
-    ));
+    out
+}
 
-    sections.push(
-        "## Quick Start\n\n\
-```bash\n\
-# See all sessions\n\
-ao-rs status\n\
-\n\
-# Spawn a worker for a GitHub issue\n\
-ao-rs spawn --issue 123\n\
-\n\
-# Spawn multiple issues\n\
-ao-rs batch-spawn 1 2 3\n\
-\n\
-# Send instructions to a session\n\
-ao-rs send <session> \"Your message here\"\n\
-\n\
-# Run dashboard + orchestrator loop\n\
-ao-rs start --run --open\n\
-```\n"
-            .to_string(),
-    );
+fn process_blocks(source: &str, start: &str, end: &str, keep: bool) -> String {
+    let mut out = String::with_capacity(source.len());
+    let mut rest = source;
 
-    if !opts.config.reactions.is_empty() {
-        sections.push(format!(
-            "## Automated Reactions\n\n\
-This project has {} reaction(s) configured. Use `ao-rs watch` (or the dashboard event log) to observe when they fire.",
-            opts.config.reactions.len()
-        ));
+    while let Some(start_idx) = rest.find(start) {
+        out.push_str(&rest[..start_idx]);
+        let after_start = &rest[start_idx + start.len()..];
+        let Some(end_rel) = after_start.find(end) else {
+            // Malformed: missing end marker. Keep the literal text so tests
+            // notice instead of silently swallowing the remainder.
+            out.push_str(start);
+            out.push_str(after_start);
+            return out;
+        };
+        let inner = &after_start[..end_rel];
+        if keep {
+            out.push_str(inner);
+        } else {
+            collapse_gap(&mut out);
+        }
+        rest = &after_start[end_rel + end.len()..];
+        if !keep {
+            rest = rest.trim_start_matches('\n');
+        }
     }
+    out.push_str(rest);
+    out
+}
 
-    sections.join("\n\n")
+/// When removing a block, collapse any trailing blank lines from `out` and
+/// the block's original context so we don't leave a double-blank scar.
+fn collapse_gap(out: &mut String) {
+    while out.ends_with("\n\n") {
+        out.pop();
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Placeholder substitution: {{name}}
+// ---------------------------------------------------------------------------
+
+fn substitute_placeholders(template: &str, data: &RenderData<'_>) -> String {
+    let mut out = String::with_capacity(template.len());
+    let mut rest = template;
+
+    while let Some(open_idx) = rest.find("{{") {
+        out.push_str(&rest[..open_idx]);
+        let after_open = &rest[open_idx + 2..];
+        let Some(close_rel) = after_open.find("}}") else {
+            // No closing — emit literal and bail.
+            out.push_str("{{");
+            out.push_str(after_open);
+            return out;
+        };
+        let key = &after_open[..close_rel];
+        let after_close = &after_open[close_rel + 2..];
+
+        if is_valid_placeholder_key(key) {
+            match data.lookup_placeholder(key) {
+                Some(value) => out.push_str(value),
+                None => {
+                    // Unknown placeholder: panic loudly so template drift is caught in tests.
+                    panic!("unresolved orchestrator prompt placeholder: {{{{{key}}}}}");
+                }
+            }
+        } else {
+            // Preserve non-identifier braces (e.g. shell examples) verbatim.
+            out.push_str("{{");
+            out.push_str(key);
+            out.push_str("}}");
+        }
+
+        rest = after_close;
+    }
+    out.push_str(rest);
+    out
+}
+
+fn is_valid_placeholder_key(key: &str) -> bool {
+    !key.is_empty()
+        && key.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        && !key.ends_with("_START")
+        && !key.ends_with("_END")
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::config::{AgentConfig, DefaultsConfig};
+    use crate::reactions::{EscalateAfter, EventPriority, ReactionAction, ReactionConfig};
     use std::collections::HashMap;
 
-    #[test]
-    fn prompt_contains_read_only_rules_and_send_guidance() {
-        let cfg = AoConfig {
+    fn base_config() -> AoConfig {
+        AoConfig {
             port: 3000,
             ready_threshold_ms: 300_000,
             poll_interval: 10,
@@ -118,13 +323,16 @@ mod tests {
             notification_routing: Default::default(),
             notifiers: HashMap::new(),
             plugins: vec![],
-        };
-        let project = ProjectConfig {
+        }
+    }
+
+    fn base_project(repo: &str) -> ProjectConfig {
+        ProjectConfig {
             name: None,
-            repo: "org/my-app".into(),
+            repo: repo.into(),
             path: "/tmp/my-app".into(),
             default_branch: "main".into(),
-            session_prefix: None,
+            session_prefix: Some("my-app".into()),
             branch_namespace: None,
             runtime: None,
             agent: None,
@@ -142,7 +350,143 @@ mod tests {
             orchestrator_rules: None,
             orchestrator_session_strategy: None,
             opencode_issue_session_strategy: None,
+        }
+    }
+
+    #[test]
+    fn repo_configured_template_substitutes_placeholders() {
+        let cfg = base_config();
+        let project = base_project("acme/my-app");
+        let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+            config: &cfg,
+            project_id: "my-app",
+            project: &project,
+            dashboard_port: 4100,
+        });
+
+        assert!(prompt.contains("# my-app Orchestrator"));
+        assert!(prompt.contains("**Repository**: acme/my-app"));
+        assert!(prompt.contains("**Session Prefix**: my-app"));
+        assert!(prompt.contains("ao-rs send my-app-1"));
+        assert!(prompt.contains("http://localhost:4100"));
+        // Repo-configured block stays.
+        assert!(prompt.contains("batch-spawn"));
+        // Repo-not-configured block is stripped.
+        assert!(!prompt.contains("No repository remote is configured"));
+    }
+
+    #[test]
+    fn repo_not_configured_template_strips_pr_sections() {
+        let cfg = base_config();
+        let project = base_project("");
+        let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+            config: &cfg,
+            project_id: "my-app",
+            project: &project,
+            dashboard_port: 3000,
+        });
+
+        assert!(prompt.contains("**Repository**: not configured"));
+        assert!(prompt.contains("No repository remote is configured"));
+        // PR takeover section is repo-configured only.
+        assert!(!prompt.contains("PR Takeover"));
+        assert!(!prompt.contains("batch-spawn"));
+    }
+
+    #[test]
+    fn rules_block_present_when_project_rules_set() {
+        let cfg = base_config();
+        let mut project = base_project("acme/my-app");
+        project.orchestrator_rules = Some("Prefer small PRs.".into());
+        let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+            config: &cfg,
+            project_id: "my-app",
+            project: &project,
+            dashboard_port: 3000,
+        });
+        assert!(prompt.contains("## Project-Specific Rules"));
+        assert!(prompt.contains("Prefer small PRs."));
+    }
+
+    #[test]
+    fn rules_block_stripped_when_no_rules() {
+        let cfg = AoConfig {
+            defaults: None,
+            ..base_config()
         };
+        let project = base_project("acme/my-app");
+        let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+            config: &cfg,
+            project_id: "my-app",
+            project: &project,
+            dashboard_port: 3000,
+        });
+        assert!(!prompt.contains("## Project-Specific Rules"));
+    }
+
+    #[test]
+    fn reactions_section_rendered_when_auto_reactions_configured() {
+        let mut cfg = base_config();
+        cfg.reactions.insert(
+            "ci-failed".into(),
+            ReactionConfig {
+                auto: true,
+                action: ReactionAction::SendToAgent,
+                message: None,
+                priority: None,
+                retries: Some(3),
+                escalate_after: Some(EscalateAfter::Attempts(5)),
+                threshold: None,
+                include_summary: false,
+                merge_method: None,
+            },
+        );
+        cfg.reactions.insert(
+            "approved-and-green".into(),
+            ReactionConfig {
+                auto: true,
+                action: ReactionAction::Notify,
+                message: None,
+                priority: Some(EventPriority::Action),
+                retries: None,
+                escalate_after: None,
+                threshold: None,
+                include_summary: false,
+                merge_method: None,
+            },
+        );
+        let project = base_project("acme/my-app");
+        let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+            config: &cfg,
+            project_id: "my-app",
+            project: &project,
+            dashboard_port: 3000,
+        });
+        assert!(prompt.contains("## Automated Reactions"));
+        assert!(prompt.contains("**ci-failed**"));
+        assert!(prompt.contains("retries: 3"));
+        assert!(prompt.contains("escalates after: 5"));
+        assert!(prompt.contains("**approved-and-green**"));
+        assert!(prompt.contains("priority: action"));
+    }
+
+    #[test]
+    fn reactions_section_stripped_when_no_auto_reactions() {
+        let cfg = base_config();
+        let project = base_project("acme/my-app");
+        let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+            config: &cfg,
+            project_id: "my-app",
+            project: &project,
+            dashboard_port: 3000,
+        });
+        assert!(!prompt.contains("## Automated Reactions"));
+    }
+
+    #[test]
+    fn non_negotiable_rules_and_send_guidance_always_present() {
+        let cfg = base_config();
+        let project = base_project("acme/my-app");
         let prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
             config: &cfg,
             project_id: "my-app",

--- a/crates/ao-core/src/orchestrator_spawn.rs
+++ b/crates/ao-core/src/orchestrator_spawn.rs
@@ -1,0 +1,315 @@
+//! Orchestrator spawn helper (TS `spawnOrchestrator` equivalent).
+//!
+//! Slice 2 of issue #165 — creates a new orchestrator session in its own
+//! worktree (`orchestrator/<prefix>-orchestrator-N`) and launches the
+//! configured agent with a rendered orchestrator system prompt.
+//!
+//! Kept deliberately plugin-generic: callers pass plugin instances as trait
+//! objects so ao-core doesn't need to know about tmux, worktree,
+//! claude-code, ...
+//!
+//! Parity notes:
+//! - Identity reservation mirrors
+//!   `reserveNextOrchestratorIdentity` in
+//!   `packages/core/src/session-manager.ts` — smallest `N` not used by any
+//!   active or archived session (limit 10k).
+//! - Classification (`is_orchestrator_session`) mirrors
+//!   `isOrchestratorSessionRecord` with the Rust port's simpler session
+//!   shape (no `metadata.role` field yet, so the id pattern is the sole
+//!   signal).
+//! - Env vars follow the ao-ts orchestrator launch: `AO_CALLER_TYPE`,
+//!   `AO_SESSION`, `AO_DATA_DIR`, `AO_PROJECT_ID`, `AO_CONFIG_PATH`,
+//!   `AO_PORT`.
+
+use std::collections::HashSet;
+use std::path::PathBuf;
+use std::time::Duration;
+
+use crate::{
+    config::{AoConfig, ProjectConfig},
+    error::{AoError, Result},
+    orchestrator_prompt::{generate_orchestrator_prompt, OrchestratorPromptConfig},
+    session_manager::SessionManager,
+    traits::{Agent, Runtime, Workspace},
+    types::{now_ms, Session, SessionId, SessionStatus, WorkspaceCreateConfig},
+};
+
+/// Inputs for `spawn_orchestrator`. Borrows everything so callers can
+/// keep ownership of config/project structs across multiple spawns.
+pub struct OrchestratorSpawnConfig<'a> {
+    pub project_id: &'a str,
+    pub project_config: &'a ProjectConfig,
+    pub config: &'a AoConfig,
+    /// Path to the loaded `ao-rs.yaml`, passed through as `AO_CONFIG_PATH`.
+    pub config_path: Option<PathBuf>,
+    /// Dashboard port — rendered into the orchestrator prompt and exported as `AO_PORT`.
+    pub port: u16,
+    pub agent_name: &'a str,
+    pub runtime_name: &'a str,
+    pub repo_path: PathBuf,
+    pub default_branch: String,
+    /// Skip sending the rendered orchestrator prompt after launch.
+    pub no_prompt: bool,
+}
+
+/// Reserve the next unused `<prefix>-orchestrator-N` id for a project.
+///
+/// Scans `existing` (typically `list_for_project` ∪ `list_archived`) for
+/// ids matching the orchestrator pattern and returns the smallest `N`
+/// not already taken. Fails after 10k attempts — mirrors the TS cap.
+pub fn reserve_orchestrator_identity(project_prefix: &str, existing: &[Session]) -> Result<String> {
+    let orch_prefix = format!("{project_prefix}-orchestrator");
+    let search = format!("{orch_prefix}-");
+    let mut used: HashSet<u32> = HashSet::new();
+
+    for s in existing {
+        if let Some(rest) = s.id.0.strip_prefix(&search) {
+            if let Ok(n) = rest.parse::<u32>() {
+                used.insert(n);
+            }
+        }
+    }
+
+    for n in 1..=10_000u32 {
+        if !used.contains(&n) {
+            return Ok(format!("{orch_prefix}-{n}"));
+        }
+    }
+
+    Err(AoError::Runtime(format!(
+        "failed to reserve orchestrator id after 10000 attempts (prefix: {orch_prefix})"
+    )))
+}
+
+/// Classify a session as an orchestrator based on its id.
+///
+/// The Rust session YAML doesn't yet carry a `role` field, so we rely
+/// entirely on the id pattern — matches either a literal `-orchestrator`
+/// suffix or the standard `<prefix>-orchestrator-<digits>` form.
+pub fn is_orchestrator_session(s: &Session) -> bool {
+    let id = &s.id.0;
+    if id.ends_with("-orchestrator") {
+        return true;
+    }
+    if let Some(pos) = id.rfind("-orchestrator-") {
+        let suffix = &id[pos + "-orchestrator-".len()..];
+        return !suffix.is_empty() && suffix.chars().all(|c| c.is_ascii_digit());
+    }
+    false
+}
+
+/// Spawn a new orchestrator session: reserve id, create worktree, launch
+/// runtime, and deliver the rendered orchestrator prompt.
+///
+/// On error after the worktree is created, the worktree is destroyed
+/// (best-effort) so a failed spawn doesn't leave dangling state on disk.
+pub async fn spawn_orchestrator(
+    cfg: OrchestratorSpawnConfig<'_>,
+    sessions: &SessionManager,
+    workspace: &dyn Workspace,
+    agent: &dyn Agent,
+    runtime: &dyn Runtime,
+) -> Result<Session> {
+    let project_prefix = cfg
+        .project_config
+        .session_prefix
+        .as_deref()
+        .unwrap_or(cfg.project_id);
+
+    // Combine active + archived so a reused N can't collide with a historical
+    // session yaml sitting in `.archive/`.
+    let mut pool = sessions.list_for_project(cfg.project_id).await?;
+    pool.extend(
+        sessions
+            .list_archived(cfg.project_id)
+            .await
+            .unwrap_or_default(),
+    );
+    let session_id_str = reserve_orchestrator_identity(project_prefix, &pool)?;
+    let session_id = SessionId(session_id_str.clone());
+    let branch = format!("orchestrator/{session_id_str}");
+
+    let system_prompt = generate_orchestrator_prompt(OrchestratorPromptConfig {
+        config: cfg.config,
+        project_id: cfg.project_id,
+        project: cfg.project_config,
+        dashboard_port: cfg.port,
+    });
+
+    // Create the worktree. From this point on any failure must clean it up.
+    let workspace_cfg = WorkspaceCreateConfig {
+        project_id: cfg.project_id.to_string(),
+        session_id: session_id_str.clone(),
+        branch: branch.clone(),
+        repo_path: cfg.repo_path.clone(),
+        default_branch: cfg.default_branch.clone(),
+        symlinks: cfg.project_config.symlinks.clone(),
+        post_create: cfg.project_config.post_create.clone(),
+    };
+    let workspace_path = workspace.create(&workspace_cfg).await?;
+
+    let spawn_result = async {
+        let mut session = Session {
+            id: session_id.clone(),
+            project_id: cfg.project_id.to_string(),
+            status: SessionStatus::Spawning,
+            agent: cfg.agent_name.to_string(),
+            agent_config: cfg.project_config.agent_config.clone(),
+            branch: branch.clone(),
+            task: "orchestrator".to_string(),
+            workspace_path: Some(workspace_path.clone()),
+            runtime_handle: None,
+            runtime: cfg.runtime_name.to_string(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: Some(system_prompt.clone()),
+        };
+        sessions.save(&session).await?;
+
+        let launch_command = agent.launch_command(&session);
+        let mut env = agent.environment(&session);
+        env.push(("AO_CALLER_TYPE".into(), "orchestrator".into()));
+        env.push(("AO_SESSION".into(), session_id_str.clone()));
+        env.push(("AO_SESSION_NAME".into(), session_id_str.clone()));
+        env.push((
+            "AO_DATA_DIR".into(),
+            sessions.base_dir().to_string_lossy().into_owned(),
+        ));
+        env.push(("AO_PROJECT_ID".into(), cfg.project_id.to_string()));
+        if let Some(cp) = cfg.config_path.as_ref() {
+            env.push(("AO_CONFIG_PATH".into(), cp.to_string_lossy().into_owned()));
+        }
+        env.push(("AO_PORT".into(), cfg.port.to_string()));
+
+        let handle = runtime
+            .create(&session_id_str, &workspace_path, &launch_command, &env)
+            .await?;
+        session.runtime_handle = Some(handle.clone());
+        session.status = SessionStatus::Working;
+        sessions.save(&session).await?;
+
+        if !cfg.no_prompt {
+            tokio::time::sleep(Duration::from_millis(2500)).await;
+            runtime.send_message(&handle, &system_prompt).await?;
+        }
+
+        Ok::<Session, AoError>(session)
+    }
+    .await;
+
+    match spawn_result {
+        Ok(s) => Ok(s),
+        Err(e) => {
+            // Best-effort cleanup; swallow any secondary error so the user
+            // sees the original failure cause.
+            let _ = workspace.destroy(&workspace_path).await;
+            let _ = sessions.delete(cfg.project_id, &session_id).await;
+            Err(e)
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::types::{now_ms, SessionId, SessionStatus};
+
+    fn session_with_id(id: &str, project: &str) -> Session {
+        Session {
+            id: SessionId(id.into()),
+            project_id: project.into(),
+            status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: "orchestrator/x".into(),
+            task: "orchestrator".into(),
+            workspace_path: None,
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: None,
+        }
+    }
+
+    #[test]
+    fn reserve_starts_at_one_when_no_existing() {
+        let got = reserve_orchestrator_identity("app", &[]).unwrap();
+        assert_eq!(got, "app-orchestrator-1");
+    }
+
+    #[test]
+    fn reserve_skips_used_numbers_in_order() {
+        let existing = vec![
+            session_with_id("app-orchestrator-1", "app"),
+            session_with_id("app-orchestrator-3", "app"),
+        ];
+        let got = reserve_orchestrator_identity("app", &existing).unwrap();
+        assert_eq!(got, "app-orchestrator-2");
+
+        let existing_full = vec![
+            session_with_id("app-orchestrator-1", "app"),
+            session_with_id("app-orchestrator-2", "app"),
+        ];
+        let got = reserve_orchestrator_identity("app", &existing_full).unwrap();
+        assert_eq!(got, "app-orchestrator-3");
+    }
+
+    #[test]
+    fn reserve_ignores_other_projects_and_worker_ids() {
+        let existing = vec![
+            session_with_id("app-1", "app"), // worker with uuid-style id
+            session_with_id("other-orchestrator-1", "other"), // other project
+            session_with_id("app-orchestrator-abc", "app"), // non-numeric
+        ];
+        let got = reserve_orchestrator_identity("app", &existing).unwrap();
+        assert_eq!(got, "app-orchestrator-1");
+    }
+
+    #[test]
+    fn is_orchestrator_session_matches_numbered_pattern() {
+        assert!(is_orchestrator_session(&session_with_id(
+            "app-orchestrator-1",
+            "app"
+        )));
+        assert!(is_orchestrator_session(&session_with_id(
+            "my-project-orchestrator-42",
+            "my-project"
+        )));
+    }
+
+    #[test]
+    fn is_orchestrator_session_matches_suffix_only() {
+        assert!(is_orchestrator_session(&session_with_id(
+            "app-orchestrator",
+            "app"
+        )));
+    }
+
+    #[test]
+    fn is_orchestrator_session_rejects_workers_and_unrelated() {
+        assert!(!is_orchestrator_session(&session_with_id("app-1", "app")));
+        assert!(!is_orchestrator_session(&session_with_id(
+            "deadbeef-aaaa-bbbb",
+            "app"
+        )));
+        assert!(!is_orchestrator_session(&session_with_id(
+            "app-orchestrator-abc",
+            "app"
+        )));
+        assert!(!is_orchestrator_session(&session_with_id(
+            "app-orchestrator-",
+            "app"
+        )));
+    }
+}

--- a/crates/ao-core/src/prompts/orchestrator.md
+++ b/crates/ao-core/src/prompts/orchestrator.md
@@ -1,0 +1,216 @@
+# {{projectName}} Orchestrator
+
+You are the **orchestrator agent** for the {{projectName}} project.
+
+Your role is to coordinate and manage worker agent sessions. You do NOT write code yourself - you spawn worker agents to do the implementation work, monitor their progress, and intervene when they need help.
+
+## Non-Negotiable Rules
+
+- Investigations from the orchestrator session are **read-only**. Inspect status, logs, metadata, PR state, and worker output, but do not edit repository files or implement fixes from the orchestrator session.
+- Any code change, test run tied to implementation, git branch work, or PR takeover must be delegated to a **worker session**.
+- The orchestrator session must never own a PR. Never claim a PR into the orchestrator session, and never treat the orchestrator as the worker responsible for implementation.
+- If an investigation discovers follow-up work, either spawn a worker session or direct an existing worker session with clear instructions.
+- **Always use `ao-rs send` to communicate with sessions** - never use raw `tmux send-keys` or `tmux capture-pane`. Direct tmux access bypasses busy detection, retry logic, and input sanitization, and breaks multi-line input for some agents.
+- When a session might be busy, use `ao-rs send --no-wait <session> <message>` to send without waiting for the session to become idle.
+
+## Project Info
+
+- **Name**: {{projectName}}
+- **Repository**: {{projectRepo}}
+- **Default Branch**: {{projectDefaultBranch}}
+- **Session Prefix**: {{projectSessionPrefix}}
+- **Local Path**: {{projectPath}}
+- **Dashboard Port**: {{dashboardPort}}
+
+## Quick Start
+
+```bash
+# See all sessions at a glance
+ao-rs status
+
+{{REPO_CONFIGURED_SECTION_START}}# Spawn sessions for issues (GitHub: #123, Linear: INT-1234, etc.)
+ao-rs spawn --issue INT-1234
+ao-rs spawn --issue 123 --claim-pr 123
+ao-rs batch-spawn INT-1 INT-2 INT-3
+
+{{REPO_CONFIGURED_SECTION_END}}# Spawn a session without a tracker issue (prompt-driven)
+ao-rs spawn --task "Refactor the auth module to use JWT"
+
+# List sessions for this project
+ao-rs status --project {{projectId}}
+
+# Send message to a session
+ao-rs send {{projectSessionPrefix}}-1 "Your message here"
+
+{{REPO_CONFIGURED_SECTION_START}}# Claim an existing PR for a worker session
+ao-rs session claim-pr 123 {{projectSessionPrefix}}-1
+
+{{REPO_CONFIGURED_SECTION_END}}# Kill a session
+ao-rs kill {{projectSessionPrefix}}-1
+```
+
+{{REPO_NOT_CONFIGURED_SECTION_START}}
+> **Note:** No repository remote is configured. Issue tracking, PR, and CI features are unavailable.
+> Add a `repo` field (owner/repo) to `ao-rs.yaml` to enable them.
+{{REPO_NOT_CONFIGURED_SECTION_END}}
+
+## Available Commands
+
+- `ao-rs status`: Show all sessions{{REPO_CONFIGURED_SECTION_START}} with PR/CI/review status{{REPO_CONFIGURED_SECTION_END}}
+- `ao-rs spawn [--issue <id>] [--task <text>]{{REPO_CONFIGURED_SECTION_START}} [--claim-pr <pr>]{{REPO_CONFIGURED_SECTION_END}}`: Spawn a worker session{{REPO_CONFIGURED_SECTION_START}}; use `--issue` for issue-driven work or `--task` for freeform tasks{{REPO_CONFIGURED_SECTION_END}}{{REPO_NOT_CONFIGURED_SECTION_START}} with `--task` for freeform tasks{{REPO_NOT_CONFIGURED_SECTION_END}}
+{{REPO_CONFIGURED_SECTION_START}}- `ao-rs batch-spawn <issues...>`: Spawn multiple sessions in parallel (project auto-detected)
+{{REPO_CONFIGURED_SECTION_END}}- `ao-rs status --project <id>`: List all sessions for a specific project
+{{REPO_CONFIGURED_SECTION_START}}- `ao-rs session claim-pr <pr> [session]`: Attach an existing PR to a worker session
+{{REPO_CONFIGURED_SECTION_END}}- `ao-rs session attach <session>`: Attach to a session's tmux window
+- `ao-rs kill <session>`: Kill a specific session
+- `ao-rs cleanup [--project <id>]`: Archive completed/merged sessions
+- `ao-rs send <session> <message>`: Send a message to a running session
+- `ao-rs send --no-wait <session> <message>`: Send without waiting for session to become idle
+- `ao-rs dashboard`: Start the web dashboard (http://localhost:{{dashboardPort}})
+
+## Session Management
+
+### Spawning Sessions
+
+When you spawn a session:
+
+1. A git worktree is created from `{{projectDefaultBranch}}`
+2. A feature branch is created (e.g., `feat/INT-1234` for issues, `ao-<short-id>` for prompt-driven)
+3. A tmux session is started (e.g., `{{projectSessionPrefix}}-1`)
+4. The agent is launched with context about the issue or prompt
+5. Metadata is written to the project-specific sessions directory
+
+A tracker issue is **not required**. Use `--task` to spawn freeform sessions:
+
+```bash
+ao-rs spawn --task "Add rate limiting to the /api/upload endpoint"
+```
+
+### Monitoring Progress
+
+Use `ao-rs status` to see:
+
+- Current session status (working, pr_open, review_pending, etc.)
+{{REPO_CONFIGURED_SECTION_START}}- PR state (open/merged/closed)
+- CI status (passing/failing/pending)
+- Review decision (approved/changes_requested/pending)
+- Unresolved comments count
+{{REPO_CONFIGURED_SECTION_END}}
+
+### Sending Messages
+
+Send instructions to a running agent:
+
+```bash
+ao-rs send {{projectSessionPrefix}}-1 "Please address the review comments on your PR"
+```
+
+{{REPO_CONFIGURED_SECTION_START}}### PR Takeover
+
+If a worker session needs to continue work on an existing PR:
+
+```bash
+ao-rs session claim-pr 123 {{projectSessionPrefix}}-1
+# or do it at spawn time
+ao-rs spawn --issue 123 --claim-pr 123
+```
+
+This updates AO metadata, switches the worker worktree onto the PR branch, and lets lifecycle reactions keep routing CI and review feedback to that worker session.
+
+Never claim a PR into an orchestrator session. If a PR needs implementation or takeover, delegate it to a worker session instead.
+{{REPO_CONFIGURED_SECTION_END}}
+
+### Investigation Workflow
+
+When debugging or triaging from the orchestrator session:
+
+1. Inspect with read-only commands such as `ao-rs status`, `ao-rs session attach`, and SCM/tracker lookups.
+2. Decide whether a worker already owns the work or a new worker is needed.
+3. Delegate implementation, test execution, or PR claiming to that worker session.
+4. Return to monitoring and coordination once the worker has the task.
+
+### Cleanup
+
+Remove completed sessions:
+
+```bash
+ao-rs cleanup --project {{projectId}}  # Archive sessions where PR is merged or issue is closed
+```
+
+## Dashboard
+
+The web dashboard runs at **http://localhost:{{dashboardPort}}**.
+
+Features:
+
+- Live session cards with activity status
+- PR table with CI checks and review state
+- Attention zones (merge ready, needs response, working, done)
+- One-click actions (send message, kill, merge PR)
+- Real-time updates via Server-Sent Events
+
+{{AUTOMATED_REACTIONS_SECTION_START}}
+## Automated Reactions
+
+The system automatically handles these events:
+
+{{automatedReactionsSection}}
+{{AUTOMATED_REACTIONS_SECTION_END}}
+
+## Common Workflows
+
+{{REPO_CONFIGURED_SECTION_START}}### Bulk Issue Processing
+
+1. Get list of issues from tracker (GitHub/Linear/etc.)
+2. Use `ao-rs batch-spawn` to spawn sessions for each issue
+3. Monitor with `ao-rs status` or the dashboard
+4. Agents will fetch, implement, test, PR, and respond to reviews
+5. Use `ao-rs cleanup` when PRs are merged
+
+{{REPO_CONFIGURED_SECTION_END}}### Handling Stuck Agents
+
+1. Check `ao-rs status` for sessions in "stuck" or "needs_input" state
+2. Attach with `ao-rs session attach <session>` to see what they're doing
+3. Send clarification or instructions with `ao-rs send <session> '...'`
+4. Or kill and respawn with fresh context if needed
+
+{{REPO_CONFIGURED_SECTION_START}}### PR Review Flow
+
+1. Agent creates PR and pushes
+2. CI runs automatically
+3. If CI fails: reaction auto-sends fix instructions to agent
+4. If reviewers request changes: reaction auto-sends comments to agent
+5. When approved + green: notify human to merge (unless auto-merge enabled)
+
+{{REPO_CONFIGURED_SECTION_END}}### Manual Intervention
+
+When an agent needs human judgment:
+
+1. You'll get a notification (desktop/slack/webhook)
+2. Check the dashboard or `ao-rs status` for details
+3. Attach to the session if needed: `ao-rs session attach <session>`
+4. Send instructions: `ao-rs send <session> '...'`
+5. Or handle the human-only action yourself{{REPO_CONFIGURED_SECTION_START}} (merge PR, close issue, etc.){{REPO_CONFIGURED_SECTION_END}} while keeping implementation in worker sessions.
+
+## Tips
+
+{{REPO_CONFIGURED_SECTION_START}}- **Use batch-spawn for multiple issues** - Much faster than spawning one at a time.
+{{REPO_CONFIGURED_SECTION_END}}- **Check status before spawning** - Avoid creating duplicate sessions for issues already being worked on.
+
+- **Let reactions handle routine issues** - CI failures and review comments are auto-forwarded to agents.
+
+- **Trust the metadata** - Session metadata tracks branch, PR, status, and more for each session.
+
+- **Use the dashboard for overview** - Terminal for details, dashboard for at-a-glance status.
+
+- **Cleanup regularly** - `ao-rs cleanup` archives merged/closed sessions and keeps things tidy.
+
+- **Monitor the event log** - Full system activity is logged for debugging and auditing.
+
+- **Don't micro-manage** - Spawn agents, walk away, let notifications bring you back when needed.
+
+{{PROJECT_SPECIFIC_RULES_SECTION_START}}
+## Project-Specific Rules
+
+{{projectSpecificRulesSection}}
+{{PROJECT_SPECIFIC_RULES_SECTION_END}}

--- a/crates/ao-core/src/traits.rs
+++ b/crates/ao-core/src/traits.rs
@@ -567,6 +567,6 @@ mod tests {
         let cost = agent.cost_estimate(&session).await.unwrap().expect("some");
         assert_eq!(cost.input_tokens, 300);
         assert_eq!(cost.output_tokens, 125);
-        assert!((cost.cost_usd - 0.75).abs() < 1e-9);
+        assert!((cost.cost_usd.unwrap() - 0.75).abs() < 1e-9);
     }
 }

--- a/crates/ao-dashboard/src/lib.rs
+++ b/crates/ao-dashboard/src/lib.rs
@@ -55,6 +55,10 @@ pub fn router(state: AppState) -> Router {
         .route("/api/sessions/{id}/kill", post(routes::kill_session))
         .route("/api/sessions/{id}/restore", post(routes::restore_session))
         .route("/api/sessions/{id}/terminal", get(routes::terminal_ws))
+        .route(
+            "/api/orchestrators",
+            get(routes::list_orchestrators).post(routes::spawn_orchestrator_route),
+        )
         .route("/api/events", get(sse::event_stream))
         .layer(CorsLayer::permissive())
         .with_state(state)
@@ -71,7 +75,7 @@ pub async fn run_server(state: AppState, port: u16) -> std::io::Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use ao_core::{OrchestratorEvent, Scm, Session, SessionManager};
+    use ao_core::{OrchestratorEvent, Scm, Session, SessionManager, SessionStatus};
     use axum::body::Body;
     use axum::http::{Request, StatusCode};
     use serde_json::Value;
@@ -103,8 +107,13 @@ mod tests {
     }
 
     fn test_state_with_broadcast_capacity(capacity: usize) -> AppState {
-        // Use a unique temp dir per test invocation to avoid collision.
-        let dir = std::env::temp_dir().join(format!("ao-dashboard-test-{}", std::process::id()));
+        use std::sync::atomic::{AtomicU64, Ordering};
+        static COUNTER: AtomicU64 = AtomicU64::new(0);
+        let n = COUNTER.fetch_add(1, Ordering::Relaxed);
+        // Use a unique temp dir per test invocation to avoid collision between tests
+        // that write sessions to disk.
+        let dir =
+            std::env::temp_dir().join(format!("ao-dashboard-test-{}-{}", std::process::id(), n));
         let _ = std::fs::create_dir_all(&dir);
         let sessions = Arc::new(SessionManager::new(dir));
         let (events_tx, _) = broadcast::channel(capacity);
@@ -473,6 +482,110 @@ mod tests {
             .unwrap();
 
         assert_eq!(resp.status(), StatusCode::NOT_FOUND);
+    }
+
+    #[tokio::test]
+    async fn orchestrators_list_empty() {
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/orchestrators")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn orchestrators_list_filters_out_workers() {
+        use ao_core::{now_ms, SessionId};
+        let state = test_state();
+
+        // Worker session (uuid-style id) should be excluded.
+        let worker = Session {
+            id: SessionId("deadbeef-aaaa".into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: "ao-deadbeef".into(),
+            task: "work".into(),
+            workspace_path: None,
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: None,
+        };
+        // Orchestrator session should be included.
+        let orch = Session {
+            id: SessionId("demo-orchestrator-1".into()),
+            project_id: "demo".into(),
+            status: SessionStatus::Working,
+            agent: "claude-code".into(),
+            agent_config: None,
+            branch: "orchestrator/demo-orchestrator-1".into(),
+            task: "orchestrator".into(),
+            workspace_path: None,
+            runtime_handle: None,
+            runtime: "tmux".into(),
+            activity: None,
+            created_at: now_ms(),
+            cost: None,
+            issue_id: None,
+            issue_url: None,
+            claimed_pr_number: None,
+            claimed_pr_url: None,
+            initial_prompt_override: None,
+        };
+        state.sessions.save(&worker).await.unwrap();
+        state.sessions.save(&orch).await.unwrap();
+
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/orchestrators")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json.as_array().unwrap().len(), 1);
+        assert_eq!(json[0]["id"], "demo-orchestrator-1");
+    }
+
+    #[tokio::test]
+    async fn orchestrators_spawn_bad_repo_path_returns_422() {
+        let app = router(test_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/orchestrators")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"project_id":"demo","repo_path":"/tmp/ao-rs-not-a-repo"}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[tokio::test]

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -2,9 +2,10 @@
 
 use crate::state::AppState;
 use ao_core::{
-    now_ms, restore_session as restore_core_session, AoError, CiStatus, MergeReadiness, PrState,
-    PullRequest, ReviewDecision, Scm, Session, SessionId, SessionStatus, Workspace,
-    WorkspaceCreateConfig,
+    is_orchestrator_session, now_ms, restore_session as restore_core_session,
+    spawn_orchestrator as core_spawn_orchestrator, AoConfig, AoError, CiStatus, LoadedConfig,
+    MergeReadiness, OrchestratorSpawnConfig, PrState, PullRequest, ReviewDecision, Scm, Session,
+    SessionId, SessionStatus, Workspace, WorkspaceCreateConfig,
 };
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::{
@@ -673,6 +674,147 @@ async fn stream_tmux_pty(mut socket: WebSocket, handle: String) {
 
     // Best-effort cleanup
     let _ = child.kill();
+}
+
+// ---------------------------------------------------------------------------
+// Orchestrator routes (issue #165 Slice 4)
+// ---------------------------------------------------------------------------
+
+/// GET /api/orchestrators — list sessions that are classified as orchestrators.
+///
+/// Filtered from the full session list via `is_orchestrator_session` so the
+/// dashboard can show a separate panel for meta-agents without a dedicated
+/// session role field on disk.
+pub async fn list_orchestrators(
+    State(state): State<AppState>,
+) -> Result<Json<serde_json::Value>, StatusCode> {
+    let all = state
+        .sessions
+        .list()
+        .await
+        .map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
+    let orchestrators: Vec<Session> = all.into_iter().filter(is_orchestrator_session).collect();
+    Ok(Json(
+        serde_json::to_value(orchestrators).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?,
+    ))
+}
+
+#[derive(Debug, Deserialize)]
+pub struct SpawnOrchestratorBody {
+    pub project_id: String,
+    pub repo_path: String,
+    #[serde(default = "default_default_branch")]
+    pub default_branch: String,
+    #[serde(default)]
+    pub agent: Option<String>,
+    #[serde(default)]
+    pub runtime: Option<String>,
+    #[serde(default = "default_port")]
+    pub port: u16,
+    #[serde(default)]
+    pub no_prompt: bool,
+}
+
+fn default_port() -> u16 {
+    3000
+}
+
+/// POST /api/orchestrators — spawn a new orchestrator session.
+///
+/// Delegates to `ao_core::spawn_orchestrator` after loading `ao-rs.yaml`
+/// from `repo_path`. Returns the persisted `Session` as JSON.
+pub async fn spawn_orchestrator_route(
+    State(state): State<AppState>,
+    Json(body): Json<SpawnOrchestratorBody>,
+) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiErrorBody>)> {
+    let repo_path = PathBuf::from(&body.repo_path);
+    if !repo_path.join(".git").exists() {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiErrorBody {
+                error: format!("not a git repo: {}", repo_path.display()),
+            }),
+        ));
+    }
+
+    let config_path = AoConfig::path_in(&repo_path);
+    let LoadedConfig { config, .. } = AoConfig::load_from_or_default_with_warnings(&config_path)
+        .map_err(|e| {
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ApiErrorBody {
+                    error: format!("failed to load {}: {e}", config_path.display()),
+                }),
+            )
+        })?;
+
+    let project_config = config
+        .projects
+        .get(&body.project_id)
+        .cloned()
+        .ok_or_else(|| {
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ApiErrorBody {
+                    error: format!(
+                        "project '{}' is not configured in {}",
+                        body.project_id,
+                        config_path.display()
+                    ),
+                }),
+            )
+        })?;
+
+    let agent_name = body
+        .agent
+        .clone()
+        .or_else(|| {
+            project_config
+                .orchestrator
+                .as_ref()
+                .and_then(|r| r.agent.clone())
+                .or_else(|| project_config.agent.clone())
+        })
+        .or_else(|| config.defaults.as_ref().map(|d| d.agent.clone()))
+        .unwrap_or_else(|| "claude-code".to_string());
+    let runtime_name = body
+        .runtime
+        .clone()
+        .or_else(|| project_config.runtime.clone())
+        .or_else(|| config.defaults.as_ref().map(|d| d.runtime.clone()))
+        .unwrap_or_else(|| "tmux".to_string());
+
+    let workspace = ao_plugin_workspace_worktree::WorktreeWorkspace::new();
+
+    let session = core_spawn_orchestrator(
+        OrchestratorSpawnConfig {
+            project_id: &body.project_id,
+            project_config: &project_config,
+            config: &config,
+            config_path: Some(config_path.clone()),
+            port: body.port,
+            agent_name: &agent_name,
+            runtime_name: &runtime_name,
+            repo_path,
+            default_branch: body.default_branch,
+            no_prompt: body.no_prompt,
+        },
+        state.sessions.as_ref(),
+        &workspace,
+        state.agent.as_ref(),
+        state.runtime.as_ref(),
+    )
+    .await
+    .map_err(session_error_response)?;
+
+    serde_json::to_value(session).map(Json).map_err(|_| {
+        (
+            StatusCode::INTERNAL_SERVER_ERROR,
+            Json(ApiErrorBody {
+                error: "failed to serialize session".to_string(),
+            }),
+        )
+    })
 }
 
 #[cfg(test)]

--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -30,7 +30,9 @@
 //! one in its plugin registry per project. This matches how `Runtime`
 //! and `Agent` are already wired.
 
-use ao_core::{AoError, CreateIssueInput, Issue, IssueFilters, IssueState, IssueUpdate, Result, Tracker};
+use ao_core::{
+    AoError, CreateIssueInput, Issue, IssueFilters, IssueState, IssueUpdate, Result, Tracker,
+};
 use async_trait::async_trait;
 use serde::Deserialize;
 use std::collections::HashMap;
@@ -499,8 +501,8 @@ fn parse_issue(json: &str) -> Result<Issue> {
 }
 
 fn parse_issue_list(json: &str) -> Result<Vec<Issue>> {
-    let raws: Vec<RawIssue> = serde_json::from_str(json)
-        .map_err(|e| AoError::Scm(format!("parse issue list: {e}")))?;
+    let raws: Vec<RawIssue> =
+        serde_json::from_str(json).map_err(|e| AoError::Scm(format!("parse issue list: {e}")))?;
     Ok(raws.into_iter().map(raw_to_issue).collect())
 }
 


### PR DESCRIPTION
## Summary
- Port ao-ts's Orchestrator concept to ao-rs: a long-lived meta-agent session that reads the backlog and spawns/coordinates worker sub-agents through the CLI.
- Adds `ao-rs orchestrator spawn` / `orchestrator list` subcommands plus a matching `GET`/`POST /api/orchestrators` dashboard API. Identity follows the `<project>-orchestrator-N` pattern, with worktree branch `orchestrator/<id>`.
- Launches the orchestrator runtime with `AO_CALLER_TYPE=orchestrator` and the full prompt template (with repo-configured tip gating), so the meta-agent can invoke `ao-rs spawn` / `batch-spawn` / `send` / `status` itself.

## Scope
- **MVP (this PR)**: Slices 1-4 — prompt template, core `spawn_orchestrator`, CLI commands, dashboard routes.
- **Deferred**: Slices 5-6 (desktop UI surface, richer coordination signals) — tracked separately.

## Test plan
- [x] \`cargo test --workspace\` — all 500+ tests pass, includes 3 new dashboard route tests (empty list, filters out workers, bad repo returns 422) and 6 core unit tests in \`orchestrator_spawn\`.
- [x] \`cargo fmt --all -- --check\` clean.
- [x] \`cargo clippy --workspace --all-targets -- -D warnings\` clean.
- [x] \`cargo build --workspace\` clean.
- [ ] Manual smoke: run \`ao-rs orchestrator spawn --repo . --project demo --no-prompt\` against a real git repo and confirm the session appears in \`orchestrator list\` with the correct branch + env.

Closes #165

🤖 Generated with [Claude Code](https://claude.com/claude-code)