### PR TITLE
perf(tracker-github): minimal is_completed via gh issue view (#101)

### DIFF
--- a/crates/plugins/tracker-github/src/lib.rs
+++ b/crates/plugins/tracker-github/src/lib.rs
@@ -4,7 +4,8 @@
 //! surface the Rust `Tracker` trait actually needs:
 //!
 //! - `get_issue` → `gh api repos/{owner}/{repo}/issues/{n}`
-//! - `is_completed` → derived from `get_issue` (closed OR cancelled)
+//! - `is_completed` → `gh issue view <n> --json state,stateReason`
+//!   (minimal payload, cached 30s) — closed OR cancelled counts as done
 //! - `issue_url`, `branch_name` → pure string manipulation
 //!
 //! What TS has and we deliberately don't:
@@ -230,9 +231,20 @@ impl Tracker for GitHubTracker {
             number,
             self.repo_slug()
         );
+        // Mirrors ao-ts `gh issue view --json state` — minimal payload,
+        // but we also ask for `stateReason` so the shared state cache can
+        // distinguish `Closed` from `Cancelled` (consumed by get_issue
+        // callers on the same tick). Still one REST round-trip, but the
+        // response is two fields instead of the full issue envelope.
+        let slug = self.repo_slug();
         let json = match gh(&[
-            "api",
-            &format!("repos/{}/{}/issues/{}", self.owner, self.repo, number),
+            "issue",
+            "view",
+            &number,
+            "--repo",
+            &slug,
+            "--json",
+            "state,stateReason",
         ])
         .await
         {
@@ -691,6 +703,65 @@ mod tests {
         // Closed can cause premature session cleanup).
         assert_eq!(map_state("TRIAGED", None), IssueState::Open);
         assert_eq!(map_state("", None), IssueState::Open);
+    }
+
+    // ---------- parse_issue_state (minimal is_completed payload) ----------
+    //
+    // These fixtures mirror what `gh issue view <n> --repo <slug> --json
+    // state,stateReason` actually emits: a bare object with just the two
+    // fields, upper-cased state values, camelCase `stateReason`, and
+    // `null` when the reason is absent. Full-issue parsing is covered by
+    // the `parse_issue` tests below.
+
+    #[test]
+    fn parse_issue_state_open() {
+        let json = r#"{"state":"OPEN","stateReason":null}"#;
+        assert_eq!(parse_issue_state(json).unwrap(), IssueState::Open);
+    }
+
+    #[test]
+    fn parse_issue_state_closed_completed() {
+        let json = r#"{"state":"CLOSED","stateReason":"COMPLETED"}"#;
+        assert_eq!(parse_issue_state(json).unwrap(), IssueState::Closed);
+    }
+
+    #[test]
+    fn parse_issue_state_closed_not_planned_is_cancelled() {
+        let json = r#"{"state":"CLOSED","stateReason":"NOT_PLANNED"}"#;
+        assert_eq!(parse_issue_state(json).unwrap(), IssueState::Cancelled);
+    }
+
+    #[test]
+    fn parse_issue_state_missing_state_reason_defaults_to_closed() {
+        // Older `gh` versions (< 2.40) omit `stateReason` entirely.
+        // Missing field must not silently become Cancelled — it stays Closed.
+        let json = r#"{"state":"CLOSED"}"#;
+        assert_eq!(parse_issue_state(json).unwrap(), IssueState::Closed);
+    }
+
+    #[test]
+    fn parse_issue_state_accepts_snake_case_alias() {
+        // `gh api repos/.../issues/N` emits `state_reason` (REST snake_case)
+        // while `gh issue view --json stateReason` emits camelCase. The
+        // alias keeps one parser working for both entry points.
+        let json = r#"{"state":"CLOSED","state_reason":"NOT_PLANNED"}"#;
+        assert_eq!(parse_issue_state(json).unwrap(), IssueState::Cancelled);
+    }
+
+    #[test]
+    fn parse_issue_state_missing_state_errors() {
+        // If `gh` ever returns a payload with no `state` field we want to
+        // surface an error rather than defaulting to Open and masking a
+        // schema regression.
+        let json = r#"{"stateReason":"NOT_PLANNED"}"#;
+        let err = parse_issue_state(json).unwrap_err();
+        assert!(format!("{err}").contains("missing `state`"));
+    }
+
+    #[test]
+    fn parse_issue_state_garbage_errors() {
+        let err = parse_issue_state("not json").unwrap_err();
+        assert!(format!("{err}").contains("parse issue state"));
     }
 
     // ---------- parse_issue ----------

--- a/docs/plans/remaining-to-port/5-4-tracker-github-gaps.md
+++ b/docs/plans/remaining-to-port/5-4-tracker-github-gaps.md
@@ -1,6 +1,6 @@
 # 5.4 tracker-github gaps
 
-Status: planned
+Status: done
 
 ## Why
 
@@ -9,9 +9,14 @@ GitHub tracker is intentionally trimmed vs TS; some missing behaviors affect per
 ## Current state (ao-rs)
 
 - `crates/plugins/tracker-github/src/lib.rs`
-  - Missing TS APIs: list/update/create issues, generatePrompt (moved to trait default)
-  - No older-`gh` `stateReason` retry dance (requires newer `gh`)
-  - `TODO(perf)`: `is_completed` may re-fetch full issue
+  - `list_issues`, `update_issue`, `create_issue` implemented via the
+    expanded `Tracker` trait (4.2).
+  - `is_completed` now hits `gh issue view <n> --repo <slug> --json
+    state,stateReason` instead of the full REST API — minimal payload,
+    same 30s cache, same rate-limit cooldown behavior.
+  - `generatePrompt` lives on the trait default (unchanged).
+  - No older-`gh` `stateReason` retry dance — we require `gh >= 2.40`
+    and document it rather than growing the shell-out matrix.
 
 ## Target behavior (ao-ts parity)
 


### PR DESCRIPTION
## Summary

- Closes the `is_completed` gap from #101 by swapping the full `gh api repos/.../issues/N` fetch for `gh issue view <n> --repo <slug> --json state,stateReason` — same one REST round-trip, but the response is two fields instead of the full issue envelope.
- Keeps the existing 30s state cache, cooldown fallback, and closed-vs-cancelled distinction (the `stateReason` alias in `RawIssueState` already understands both snake_case REST payloads and the camelCase emitted by `gh issue view --json`).
- Other 5.4 items (`list_issues` / `update_issue` / `create_issue`) were already delivered with the 4.2 trait expansion, so this PR only lands the `is_completed` performance fix and refreshes the plan doc to mark the gap closed.
- No retry dance for pre-2.40 `gh` — we keep the current minimum and document it, matching the preferred option in the issue.

## Test plan

- [x] `cargo test -p ao-plugin-tracker-github --lib` (39 tests, +7 new `parse_issue_state` fixture cases)
- [x] `cargo clippy -p ao-plugin-tracker-github --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`
- [x] `cargo build --workspace`

Refs #101

🤖 Generated with [Claude Code](https://claude.com/claude-code)