### PR TITLE
feat(lifecycle): notify parent orchestrator on worker state changes (#169)

### DIFF
--- a/crates/ao-cli/src/cli/args.rs
+++ b/crates/ao-cli/src/cli/args.rs
@@ -178,6 +178,17 @@ pub enum Command {
         /// - `test`
         #[arg(long)]
         template: Option<String>,
+
+        /// Parent session id for orchestrator → worker linking.
+        ///
+        /// When set, lifecycle state changes on this session (PR opened,
+        /// CI failed, merged, killed, ...) are delivered as a runtime
+        /// message to the parent session's agent, so an orchestrator can
+        /// react without manual prodding. Defaults to `$AO_SESSION_ID`
+        /// if that env var is set (i.e. when `ao-rs spawn` is invoked
+        /// from inside a session's own shell).
+        #[arg(long, value_name = "SESSION_ID")]
+        spawned_by: Option<String>,
     },
 
     /// Spawn multiple sessions from a list of GitHub issue numbers.

--- a/crates/ao-cli/src/commands/kill.rs
+++ b/crates/ao-cli/src/commands/kill.rs
@@ -122,6 +122,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/ao-cli/src/commands/spawn.rs
+++ b/crates/ao-cli/src/commands/spawn.rs
@@ -7,6 +7,7 @@ use ao_core::{
     build_prompt, now_ms, Agent, AoConfig, LoadedConfig, Session, SessionId, SessionManager,
     SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
+use std::env;
 use ao_plugin_tracker_github::GitHubTracker;
 use ao_plugin_tracker_linear::LinearTracker;
 use ao_plugin_workspace_worktree::WorktreeWorkspace;
@@ -40,7 +41,17 @@ pub async fn spawn(
     agent_name: Option<String>,
     runtime_name: Option<String>,
     template: Option<String>,
+    spawned_by: Option<String>,
 ) -> Result<(), Box<dyn std::error::Error>> {
+    // Auto-detect parent orchestrator from `AO_SESSION_ID` when the CLI
+    // flag wasn't provided. Set by the agent plugins when they launch,
+    // so `ao-rs spawn` invoked from inside an orchestrator's own shell
+    // links workers back to it automatically.
+    let resolved_spawned_by = spawned_by
+        .or_else(|| env::var("AO_SESSION_ID").ok())
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+        .map(SessionId);
     // ---- 1. Resolve repo path ----
     let repo_path = resolve_repo_root(repo)?;
     if !repo_path.join(".git").exists() {
@@ -281,6 +292,7 @@ pub async fn spawn(
             claimed_pr_number,
             claimed_pr_url,
             initial_prompt_override: prompt.clone(),
+            spawned_by: resolved_spawned_by.clone(),
         };
 
         let manager = SessionManager::with_default();
@@ -494,6 +506,7 @@ pub async fn batch_spawn(
             agent_name.clone(),
             runtime_name.clone(),
             template.clone(),
+            None,
         )
         .await
         {

--- a/crates/ao-cli/src/commands/status.rs
+++ b/crates/ao-cli/src/commands/status.rs
@@ -391,6 +391,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         };
 
         let opts = StatusOptions {

--- a/crates/ao-cli/src/commands/verify.rs
+++ b/crates/ao-cli/src/commands/verify.rs
@@ -304,6 +304,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/ao-cli/src/main.rs
+++ b/crates/ao-cli/src/main.rs
@@ -98,6 +98,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
             agent,
             runtime,
             template,
+            spawned_by,
         } => {
             commands::spawn::spawn(
                 task,
@@ -115,6 +116,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
                 agent,
                 runtime,
                 template,
+                spawned_by,
             )
             .await
         }

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -106,6 +106,7 @@ fn session_display_title_prefixes_issue_sessions() {
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
+        spawned_by: None,
     };
     assert_eq!(
         session_display_title(&s),
@@ -514,6 +515,7 @@ fn fake_session() -> Session {
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
+        spawned_by: None,
     }
 }
 

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -801,6 +801,14 @@ impl LifecycleManager {
             to: persisted_to,
         });
 
+        // Issue #169: notify the parent orchestrator (if any) so it can
+        // react to worker state changes without manual human prodding.
+        // Only fires for transitions the orchestrator actually needs to
+        // see; best-effort, never fails the transition.
+        if is_orchestrator_notifiable(persisted_to) {
+            self.notify_orchestrator(session, persisted_to).await;
+        }
+
         if let Some(engine) = self.reaction_engine.as_ref() {
             // Leaving a reaction-triggering status? Clear its tracker so
             // the next entry (e.g. new CI failure after a fix) gets a
@@ -811,6 +819,39 @@ impl LifecycleManager {
         }
 
         Ok(())
+    }
+
+    /// Best-effort delivery of a worker state-change notification to the
+    /// parent orchestrator via `Runtime::send_message`. Silent when the
+    /// worker has no `spawned_by`, the parent yaml is gone, or the
+    /// parent has no live runtime handle — any of those mean "no one to
+    /// tell", not "error".
+    async fn notify_orchestrator(&self, worker: &Session, to: SessionStatus) {
+        let Some(orch_id) = worker.spawned_by.as_ref() else {
+            return;
+        };
+        let parent = match self.sessions.find_by_prefix(&orch_id.0).await {
+            Ok(p) => p,
+            Err(e) => {
+                tracing::debug!(
+                    session = %worker.id,
+                    parent = %orch_id.0,
+                    "orchestrator session lookup failed: {e}"
+                );
+                return;
+            }
+        };
+        let Some(handle) = parent.runtime_handle.as_deref() else {
+            return;
+        };
+        let msg = format_orchestrator_notification(worker, to);
+        if let Err(e) = self.runtime.send_message(handle, &msg).await {
+            tracing::warn!(
+                session = %worker.id,
+                parent = %parent.id,
+                "failed to deliver orchestrator notification: {e}"
+            );
+        }
     }
 
     /// Phase H agent-stuck detection. Called from `poll_one` as the
@@ -1048,6 +1089,47 @@ const fn is_review_stable(status: SessionStatus) -> bool {
     )
 }
 
+/// Transitions that warrant notifying the parent orchestrator (issue #169).
+///
+/// Chosen so the orchestrator only gets messages that require a decision
+/// or at least a "status FYI" — not every intermediate tick. Noisy or
+/// purely-informational states (e.g. `Working`, `Spawning`, intermediate
+/// review flips) are intentionally excluded; the human/CLI can still see
+/// them via `ao-rs status` or the SSE event stream.
+const fn is_orchestrator_notifiable(status: SessionStatus) -> bool {
+    matches!(
+        status,
+        SessionStatus::PrOpen
+            | SessionStatus::ReviewPending
+            | SessionStatus::CiFailed
+            | SessionStatus::ChangesRequested
+            | SessionStatus::Approved
+            | SessionStatus::Merged
+            | SessionStatus::MergeFailed
+            | SessionStatus::Killed
+            | SessionStatus::Terminated
+            | SessionStatus::Errored
+            | SessionStatus::NeedsInput
+            | SessionStatus::Stuck
+    )
+}
+
+/// Render the notification message the orchestrator sees in its
+/// terminal. Kept short and parseable — the orchestrator is usually an
+/// LLM agent that re-reads its scrollback.
+fn format_orchestrator_notification(worker: &Session, to: SessionStatus) -> String {
+    let short: String = worker.id.0.chars().take(8).collect();
+    let pr = worker
+        .claimed_pr_url
+        .as_deref()
+        .or(worker.issue_url.as_deref())
+        .unwrap_or("none");
+    format!(
+        "[ao-rs] worker {short} is now {to} — branch: {branch}, url: {pr}",
+        branch = worker.branch,
+    )
+}
+
 const fn is_stuck_eligible(status: SessionStatus) -> bool {
     match status {
         // Stuck-eligible: active work or PR-track where progress is expected.
@@ -1159,6 +1241,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 
@@ -3250,6 +3333,120 @@ mod tests {
         assert!(
             saw_status_change,
             "background loop never emitted StatusChanged"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // ---------- Orchestrator notification (issue #169) ---------- //
+
+    #[tokio::test]
+    async fn transition_notifies_parent_orchestrator_via_runtime() {
+        // Worker points at a parent session via `spawned_by`. Transitioning
+        // the worker into `PrOpen` should deliver one runtime message to
+        // the parent's handle — the mechanism the orchestrator relies on
+        // to learn its worker changed state.
+        let base = unique_temp_dir("orchestrator-notify");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let lifecycle = Arc::new(LifecycleManager::new(
+            sessions.clone(),
+            runtime.clone() as Arc<dyn Runtime>,
+            agent,
+        ));
+
+        let mut parent = fake_session("orch1", "demo");
+        parent.runtime_handle = Some("orch-handle".into());
+        sessions.save(&parent).await.unwrap();
+
+        let mut worker = fake_session("work1", "demo");
+        worker.status = SessionStatus::Working;
+        worker.spawned_by = Some(parent.id.clone());
+        sessions.save(&worker).await.unwrap();
+
+        lifecycle
+            .transition(&mut worker, SessionStatus::PrOpen)
+            .await
+            .unwrap();
+
+        let sends = runtime.sends();
+        assert_eq!(
+            sends.len(),
+            1,
+            "expected one notification to parent, got {sends:?}"
+        );
+        assert_eq!(sends[0].0, "orch-handle");
+        assert!(
+            sends[0].1.contains("pr_open"),
+            "message should mention new status, got {:?}",
+            sends[0].1
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn transition_without_spawned_by_sends_no_message() {
+        let base = unique_temp_dir("orchestrator-notify-none");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let lifecycle = Arc::new(LifecycleManager::new(
+            sessions.clone(),
+            runtime.clone() as Arc<dyn Runtime>,
+            agent,
+        ));
+
+        let mut worker = fake_session("lone1", "demo");
+        worker.status = SessionStatus::Working;
+        assert!(worker.spawned_by.is_none());
+        sessions.save(&worker).await.unwrap();
+
+        lifecycle
+            .transition(&mut worker, SessionStatus::PrOpen)
+            .await
+            .unwrap();
+
+        assert!(
+            runtime.sends().is_empty(),
+            "workers without spawned_by must not trigger a send"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn transition_into_non_notifiable_status_sends_no_message() {
+        // Working is a non-notifiable status (noise-reduction policy);
+        // even with a parent, no message should go out on Spawning→Working.
+        let base = unique_temp_dir("orchestrator-notify-filter");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let lifecycle = Arc::new(LifecycleManager::new(
+            sessions.clone(),
+            runtime.clone() as Arc<dyn Runtime>,
+            agent,
+        ));
+
+        let mut parent = fake_session("orch2", "demo");
+        parent.runtime_handle = Some("orch-handle".into());
+        sessions.save(&parent).await.unwrap();
+
+        let mut worker = fake_session("work2", "demo");
+        worker.status = SessionStatus::Spawning;
+        worker.spawned_by = Some(parent.id.clone());
+        sessions.save(&worker).await.unwrap();
+
+        lifecycle
+            .transition(&mut worker, SessionStatus::Working)
+            .await
+            .unwrap();
+
+        assert!(
+            runtime.sends().is_empty(),
+            "transition to Working should not notify orchestrator"
         );
 
         let _ = std::fs::remove_dir_all(&base);

--- a/crates/ao-core/src/prompt_builder.rs
+++ b/crates/ao-core/src/prompt_builder.rs
@@ -245,6 +245,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/ao-core/src/reaction_engine.rs
+++ b/crates/ao-core/src/reaction_engine.rs
@@ -1155,6 +1155,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/ao-core/src/restore.rs
+++ b/crates/ao-core/src/restore.rs
@@ -284,6 +284,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         };
         manager.save(&session).await.unwrap();
         session

--- a/crates/ao-core/src/session_manager.rs
+++ b/crates/ao-core/src/session_manager.rs
@@ -257,6 +257,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/ao-core/src/types.rs
+++ b/crates/ao-core/src/types.rs
@@ -250,6 +250,12 @@ pub struct Session {
     /// composing layers from session/project/issue context.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub initial_prompt_override: Option<String>,
+    /// If this session was spawned by another session (orchestrator →
+    /// worker), the parent session's id. The lifecycle loop uses this to
+    /// route state-change notifications back to the parent so it can react
+    /// without manual human prodding. See issue #169.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub spawned_by: Option<SessionId>,
 }
 
 impl Session {
@@ -418,6 +424,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         };
         assert!(!base.is_terminal());
 
@@ -454,6 +461,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         };
         assert!(merged.is_terminal());
         assert!(!merged.is_restorable());
@@ -539,6 +547,7 @@ created_at: 1700000000000
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         };
         let yaml = serde_yaml::to_string(&session).unwrap();
         let parsed: Session = serde_yaml::from_str(&yaml).unwrap();
@@ -588,6 +597,7 @@ created_at: 0
             claimed_pr_number: Some(88),
             claimed_pr_url: Some("https://github.com/o/r/pull/88".into()),
             initial_prompt_override: Some("CUSTOM PROMPT BODY".into()),
+            spawned_by: None,
         };
         let yaml = serde_yaml::to_string(&session).unwrap();
         let parsed: Session = serde_yaml::from_str(&yaml).unwrap();

--- a/crates/ao-core/tests/notification_flow.rs
+++ b/crates/ao-core/tests/notification_flow.rs
@@ -60,6 +60,7 @@ fn fake_session(short: &str, project: &str) -> Session {
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
+        spawned_by: None,
     }
 }
 

--- a/crates/ao-core/tests/parity_test_utils.rs
+++ b/crates/ao-core/tests/parity_test_utils.rs
@@ -35,5 +35,6 @@ pub fn fake_session(id: &str) -> Session {
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
+        spawned_by: None,
     }
 }

--- a/crates/ao-core/tests/reaction_engine_issue24_retry_escalation.rs
+++ b/crates/ao-core/tests/reaction_engine_issue24_retry_escalation.rs
@@ -61,6 +61,7 @@ fn fake_session(id: &str, project: &str) -> Session {
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
+        spawned_by: None,
     }
 }
 

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -83,6 +83,10 @@ pub struct SpawnSessionBody {
     pub agent: String,
     #[serde(default)]
     pub no_prompt: bool,
+    /// If set, records the parent orchestrator session id so the lifecycle
+    /// loop can notify it when this worker changes state. See issue #169.
+    #[serde(default)]
+    pub spawned_by: Option<String>,
 }
 
 fn default_default_branch() -> String {
@@ -147,6 +151,7 @@ pub async fn spawn_session(
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
+        spawned_by: body.spawned_by.clone().map(ao_core::SessionId),
     };
 
     state
@@ -700,6 +705,7 @@ mod attention_tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/plugins/agent-aider/src/lib.rs
+++ b/crates/plugins/agent-aider/src/lib.rs
@@ -186,6 +186,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/plugins/agent-claude-code/src/lib.rs
+++ b/crates/plugins/agent-claude-code/src/lib.rs
@@ -396,6 +396,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/plugins/agent-codex/src/lib.rs
+++ b/crates/plugins/agent-codex/src/lib.rs
@@ -307,6 +307,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 

--- a/crates/plugins/agent-cursor/src/lib.rs
+++ b/crates/plugins/agent-cursor/src/lib.rs
@@ -310,6 +310,7 @@ mod tests {
             claimed_pr_number: None,
             claimed_pr_url: None,
             initial_prompt_override: None,
+            spawned_by: None,
         }
     }
 


### PR DESCRIPTION
Adds an orchestrator → worker link via a new `Session::spawned_by` field.
When a worker transitions into a status an orchestrator needs to know
about (PrOpen, CiFailed, Merged, Killed, Stuck, ...), the lifecycle loop
sends a short runtime message to the parent's handle so an LLM-based
orchestrator can react without manual human prodding.

- `ao-rs spawn --spawned-by <id>` records the parent; when omitted, the
  parent id is picked up from `AO_SESSION_ID` so workers spawned from
  inside an orchestrator's own shell link back automatically.
- `POST /api/sessions/spawn` accepts an optional `spawned_by` field.
- Notification is best-effort: a missing parent, missing runtime handle,
  or send failure logs and moves on; the transition itself never fails.