### PR TITLE
feat(ui): send message on Cmd+Enter / Ctrl+Enter in SessionDetail

### DIFF
--- a/crates/ao-desktop/ui/src/components/SessionDetail.test.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.test.tsx
@@ -1,0 +1,92 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+import type { DashboardSession } from "../lib/types";
+import { SessionDetail } from "./SessionDetail";
+
+function makeSession(partial: Partial<DashboardSession> = {}): DashboardSession {
+  return {
+    id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+    projectId: "ao-rs",
+    status: "working",
+    activity: "idle working",
+    agent: null,
+    branch: "ao-fb01ba28-feat-issue-77",
+    summary: null,
+    summaryIsFallback: false,
+    issueTitle: null,
+    issueId: null,
+    issueUrl: null,
+    userPrompt: null,
+    pr: null,
+    attentionLevel: "working",
+    metadata: {},
+    ...partial,
+  };
+}
+
+function renderDetail(overrides: Partial<Parameters<typeof SessionDetail>[0]> = {}) {
+  const onSendMessage = vi.fn().mockResolvedValue(undefined);
+  const onKill = vi.fn().mockResolvedValue(undefined);
+  const onRestore = vi.fn().mockResolvedValue(undefined);
+  const utils = render(
+    <SessionDetail
+      session={makeSession()}
+      onSendMessage={onSendMessage}
+      onKill={onKill}
+      onRestore={onRestore}
+      {...overrides}
+    />,
+  );
+  return { ...utils, onSendMessage, onKill, onRestore };
+}
+
+describe("SessionDetail message shortcut", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("sends the message on Cmd+Enter", () => {
+    const { onSendMessage } = renderDetail();
+    const textarea = screen.getByPlaceholderText("Type a message to the agent…") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "hello agent" } });
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onSendMessage).toHaveBeenCalledWith("hello agent");
+  });
+
+  it("sends the message on Ctrl+Enter", () => {
+    const { onSendMessage } = renderDetail();
+    const textarea = screen.getByPlaceholderText("Type a message to the agent…") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "ship it" } });
+    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+
+    expect(onSendMessage).toHaveBeenCalledTimes(1);
+    expect(onSendMessage).toHaveBeenCalledWith("ship it");
+  });
+
+  it("does not send on plain Enter", () => {
+    const { onSendMessage } = renderDetail();
+    const textarea = screen.getByPlaceholderText("Type a message to the agent…") as HTMLTextAreaElement;
+
+    fireEvent.change(textarea, { target: { value: "multi\nline" } });
+    fireEvent.keyDown(textarea, { key: "Enter" });
+
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+
+  it("does not send when message is empty or whitespace", () => {
+    const { onSendMessage } = renderDetail();
+    const textarea = screen.getByPlaceholderText("Type a message to the agent…") as HTMLTextAreaElement;
+
+    fireEvent.keyDown(textarea, { key: "Enter", metaKey: true });
+    expect(onSendMessage).not.toHaveBeenCalled();
+
+    fireEvent.change(textarea, { target: { value: "   " } });
+    fireEvent.keyDown(textarea, { key: "Enter", ctrlKey: true });
+    expect(onSendMessage).not.toHaveBeenCalled();
+  });
+});

--- a/crates/ao-desktop/ui/src/components/SessionDetail.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.tsx
@@ -243,6 +243,12 @@ export function SessionDetail({
         <textarea
           value={message}
           onChange={(e) => setMessage(e.target.value)}
+          onKeyDown={(e) => {
+            if ((e.metaKey || e.ctrlKey) && e.key === "Enter") {
+              e.preventDefault();
+              void send();
+            }
+          }}
           placeholder="Type a message to the agent…"
           style={{ width: "100%" }}
         />


### PR DESCRIPTION
## Summary
- Add `onKeyDown` handler to the message textarea in `SessionDetail` so `Cmd+Enter` (macOS) or `Ctrl+Enter` (Windows/Linux) triggers `send()`.
- Preserves existing guards: ignored while sending and for empty/whitespace messages (handled inside `send()`).
- New vitest coverage for Cmd/Ctrl+Enter, plain Enter, and empty/whitespace cases.

Closes #144

## Test plan
- [x] `npm run typecheck` (crates/ao-desktop/ui)
- [x] `npm test` (5 files, 13 tests passing)
- [x] `npm run build`
- [ ] Manual smoke in the desktop UI: type a message, press Cmd+Enter (macOS) / Ctrl+Enter (Linux), confirm send fires and textarea clears; Enter alone inserts a newline.

🤖 Generated with [Claude Code](https://claude.com/claude-code)