### PR TITLE
feat(ui): human-readable PR/CI status pills with tone colours

### DIFF
--- a/crates/ao-desktop/ui/src/components/SessionCard.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionCard.tsx
@@ -1,7 +1,7 @@
 import { memo, useState } from "react";
 import type { DashboardSession } from "../lib/types";
 import { getDashboardLane, isTerminalSession } from "../lib/types";
-import { getSessionTitle } from "../lib/format";
+import { formatCiStatus, formatReviewDecision, getSessionTitle } from "../lib/format";
 import { cn } from "../lib/cn";
 import { projectAccentStyle } from "../lib/projectColors";
 import { getSessionRepoUrl } from "../lib/repoUrl";
@@ -26,6 +26,8 @@ function SessionCardView({ session, onClick, onOpen, onRestore }: SessionCardPro
   const [restoring, setRestoring] = useState(false);
   const projectAccent = projectAccentStyle(session.projectId);
   const repoUrl = getSessionRepoUrl(session);
+  const ci = pr?.ciStatus ? formatCiStatus(pr.ciStatus) : null;
+  const review = pr?.reviewDecision ? formatReviewDecision(pr.reviewDecision) : null;
 
   return (
     <button
@@ -131,8 +133,16 @@ function SessionCardView({ session, onClick, onOpen, onRestore }: SessionCardPro
         {pr ? (
           <>
             <span className="mini-pill">PR #{pr.number}</span>
-            {pr.ciStatus ? <span className="mini-pill">CI: {pr.ciStatus}</span> : null}
-            {pr.reviewDecision ? <span className="mini-pill">Review: {pr.reviewDecision}</span> : null}
+            {ci ? (
+              <span className="mini-pill" data-tone={ci.tone}>
+                {ci.label}
+              </span>
+            ) : null}
+            {review ? (
+              <span className="mini-pill" data-tone={review.tone}>
+                {review.label}
+              </span>
+            ) : null}
             {typeof pr.mergeable === "boolean" ? (
               <span className="mini-pill">{pr.mergeable ? "mergeable" : "not mergeable"}</span>
             ) : null}

--- a/crates/ao-desktop/ui/src/components/SessionDetail.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.tsx
@@ -1,7 +1,7 @@
 import { useMemo, useState } from "react";
 import type { DashboardSession } from "../lib/types";
 import { getDashboardLane, isTerminalSession } from "../lib/types";
-import { getSessionTitle } from "../lib/format";
+import { formatCiStatus, formatReviewDecision, getSessionTitle } from "../lib/format";
 import { projectAccentStyle } from "../lib/projectColors";
 import { getSessionRepoUrl } from "../lib/repoUrl";
 import { ConfirmModal } from "./ConfirmModal";
@@ -49,6 +49,15 @@ export function SessionDetail({
     if (session.agent) items.push({ label: `agent: ${session.agent}` });
     return items;
   }, [lane, session.activity, session.status, session.agent]);
+
+  const ci = useMemo(
+    () => (session.pr?.ciStatus ? formatCiStatus(session.pr.ciStatus) : null),
+    [session.pr?.ciStatus],
+  );
+  const review = useMemo(
+    () => (session.pr?.reviewDecision ? formatReviewDecision(session.pr.reviewDecision) : null),
+    [session.pr?.reviewDecision],
+  );
 
   const isRestorable = useMemo(() => {
     const s = (session.status ?? "").toLowerCase();
@@ -212,8 +221,16 @@ export function SessionDetail({
                 PR #{session.pr.number}{session.pr.title ? `: ${session.pr.title}` : ""}
               </a>
               <div className="pr-head__pills">
-                {session.pr.ciStatus ? <span className="mini-pill">CI {session.pr.ciStatus}</span> : null}
-                {session.pr.reviewDecision ? <span className="mini-pill">Review {session.pr.reviewDecision}</span> : null}
+                {ci ? (
+                  <span className="mini-pill" data-tone={ci.tone}>
+                    {ci.label}
+                  </span>
+                ) : null}
+                {review ? (
+                  <span className="mini-pill" data-tone={review.tone}>
+                    {review.label}
+                  </span>
+                ) : null}
                 {typeof session.pr.mergeable === "boolean" ? (
                   <span className="mini-pill">{session.pr.mergeable ? "mergeable" : "not mergeable"}</span>
                 ) : null}

--- a/crates/ao-desktop/ui/src/lib/format.test.ts
+++ b/crates/ao-desktop/ui/src/lib/format.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from "vitest";
 
-import { getSessionTabLabel } from "./format";
+import { formatCiStatus, formatReviewDecision, getSessionTabLabel } from "./format";
 import type { DashboardSession } from "./types";
 
 describe("getSessionTabLabel", () => {
@@ -24,6 +24,65 @@ describe("getSessionTabLabel", () => {
     };
 
     expect(getSessionTabLabel(s)).toBe("ao-rs - #70: working");
+  });
+});
+
+describe("formatCiStatus", () => {
+  it("maps success to ok tone with check glyph", () => {
+    expect(formatCiStatus("SUCCESS")).toEqual({ label: "CI ✓", tone: "ok" });
+    expect(formatCiStatus("passing")).toEqual({ label: "CI ✓", tone: "ok" });
+  });
+
+  it("maps failure to bad tone with cross glyph", () => {
+    expect(formatCiStatus("failure")).toEqual({ label: "CI ✗", tone: "bad" });
+    expect(formatCiStatus("FAILING")).toEqual({ label: "CI ✗", tone: "bad" });
+    expect(formatCiStatus("error")).toEqual({ label: "CI ✗", tone: "bad" });
+  });
+
+  it("maps in-flight states to neutral tone with ellipsis", () => {
+    expect(formatCiStatus("pending")).toEqual({ label: "CI …", tone: "neutral" });
+    expect(formatCiStatus("queued")).toEqual({ label: "CI …", tone: "neutral" });
+    expect(formatCiStatus("RUNNING")).toEqual({ label: "CI …", tone: "neutral" });
+    expect(formatCiStatus("in_progress")).toEqual({ label: "CI …", tone: "neutral" });
+  });
+
+  it("falls back to neutral tone with raw label for unknown states", () => {
+    expect(formatCiStatus("stale")).toEqual({ label: "CI stale", tone: "neutral" });
+  });
+});
+
+describe("formatReviewDecision", () => {
+  it("maps approved to ok tone", () => {
+    expect(formatReviewDecision("APPROVED")).toEqual({ label: "Approved", tone: "ok" });
+  });
+
+  it("maps changes_requested to bad tone", () => {
+    expect(formatReviewDecision("CHANGES_REQUESTED")).toEqual({
+      label: "Changes requested",
+      tone: "bad",
+    });
+  });
+
+  it("maps review_required / pending / none to neutral tone", () => {
+    expect(formatReviewDecision("REVIEW_REQUIRED")).toEqual({
+      label: "Review required",
+      tone: "neutral",
+    });
+    expect(formatReviewDecision("pending")).toEqual({
+      label: "Review required",
+      tone: "neutral",
+    });
+    expect(formatReviewDecision("none")).toEqual({
+      label: "Review required",
+      tone: "neutral",
+    });
+  });
+
+  it("falls back to neutral tone with raw label for unknown states", () => {
+    expect(formatReviewDecision("dismissed")).toEqual({
+      label: "Review dismissed",
+      tone: "neutral",
+    });
   });
 });
 

--- a/crates/ao-desktop/ui/src/lib/format.ts
+++ b/crates/ao-desktop/ui/src/lib/format.ts
@@ -1,5 +1,46 @@
 import type { DashboardSession } from "./types";
 
+export type PillTone = "ok" | "bad" | "neutral";
+
+export interface PillFormat {
+  label: string;
+  tone: PillTone;
+}
+
+export function formatCiStatus(raw: string): PillFormat {
+  switch (raw.toLowerCase()) {
+    case "success":
+    case "passing":
+      return { label: "CI ✓", tone: "ok" };
+    case "failure":
+    case "failing":
+    case "error":
+      return { label: "CI ✗", tone: "bad" };
+    case "pending":
+    case "queued":
+    case "running":
+    case "in_progress":
+      return { label: "CI …", tone: "neutral" };
+    default:
+      return { label: `CI ${raw}`, tone: "neutral" };
+  }
+}
+
+export function formatReviewDecision(raw: string): PillFormat {
+  switch (raw.toLowerCase()) {
+    case "approved":
+      return { label: "Approved", tone: "ok" };
+    case "changes_requested":
+      return { label: "Changes requested", tone: "bad" };
+    case "review_required":
+    case "pending":
+    case "none":
+      return { label: "Review required", tone: "neutral" };
+    default:
+      return { label: `Review ${raw}`, tone: "neutral" };
+  }
+}
+
 export function humanizeBranch(branch: string): string {
   const withoutPrefix = branch.replace(
     /^(?:feat|fix|chore|refactor|docs|test|ci|session|release|hotfix|feature|bugfix|build|wip|improvement)\//,

--- a/crates/ao-desktop/ui/styles.css
+++ b/crates/ao-desktop/ui/styles.css
@@ -575,6 +575,38 @@ body[data-theme="dark"] .session-card:hover { border-color: rgba(255, 255, 255, 
   text-transform: uppercase;
 }
 
+/* Tone-based mini-pills (CI / review status). */
+.mini-pill[data-tone="ok"] {
+  background: rgba(34, 197, 94, 0.14);
+  border-color: rgba(34, 197, 94, 0.38);
+  color: rgba(200, 255, 220, 0.95);
+}
+.mini-pill[data-tone="bad"] {
+  background: rgba(239, 68, 68, 0.14);
+  border-color: rgba(239, 68, 68, 0.4);
+  color: rgba(255, 215, 215, 0.95);
+}
+.mini-pill[data-tone="neutral"] {
+  background: rgba(148, 163, 184, 0.14);
+  border-color: rgba(148, 163, 184, 0.35);
+  color: var(--text-secondary);
+}
+body[data-theme="light"] .mini-pill[data-tone="ok"] {
+  background: rgba(22, 163, 74, 0.12);
+  border-color: rgba(22, 163, 74, 0.3);
+  color: #14532d;
+}
+body[data-theme="light"] .mini-pill[data-tone="bad"] {
+  background: rgba(220, 38, 38, 0.1);
+  border-color: rgba(220, 38, 38, 0.3);
+  color: #7f1d1d;
+}
+body[data-theme="light"] .mini-pill[data-tone="neutral"] {
+  background: rgba(100, 116, 139, 0.1);
+  border-color: rgba(100, 116, 139, 0.25);
+  color: var(--text-secondary);
+}
+
 /* Project-based accent mini-pills (SessionDetail: lane/status/project/branch). */
 .mini-pill[data-project-accent="true"] {
   background: hsl(var(--project-h) 85% 55% / 0.12);


### PR DESCRIPTION
## Summary

- Adds pure `formatCiStatus` / `formatReviewDecision` helpers in `crates/ao-desktop/ui/src/lib/format.ts` that map GitHub status strings to `{ label, tone }`.
- `SessionCard` and `SessionDetail` now render those labels and forward `data-tone` on the `.mini-pill`, so a green pill means CI passed / PR approved, a red pill means failure / changes requested, and neutral = pending.
- Extends `styles.css` with `.mini-pill[data-tone="ok"|"bad"|"neutral"]` variants (plus light-mode overrides) to carry the colour without extra JS.

Closes #147.

## Test plan

- [x] `npm test` in `crates/ao-desktop/ui` (9 new assertions cover success / failure / pending / unknown for CI and review helpers, case-insensitive)
- [x] `npm run typecheck`
- [x] `npm run build`
- [ ] Manual smoke: open the Tauri dashboard, confirm CI/review pills render with friendly text and colour in both dark and light themes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)