### PR TITLE
feat(ui): add dismiss (×) button to toast notifications

### DIFF
--- a/crates/ao-desktop/ui/src/test/setup.ts
+++ b/crates/ao-desktop/ui/src/test/setup.ts
@@ -1,4 +1,10 @@
 import "@testing-library/jest-dom/vitest";
+import { cleanup } from "@testing-library/react";
+import { afterEach } from "vitest";
+
+afterEach(() => {
+  cleanup();
+});
 
 if (!("matchMedia" in window)) {
   // Minimal matchMedia polyfill for libraries like xterm.

--- a/crates/ao-desktop/ui/src/ui/App.test.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from "vitest";
-import { render, screen, within } from "@testing-library/react";
+import { act, render, screen, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 
 import { App } from "./App";
@@ -12,6 +12,9 @@ vi.mock("../components/TerminalView", () => {
   };
 });
 
+type EventHandlers = { onEvent?: (evt: unknown) => void; onOpen?: () => void };
+const sseHandlers: { current: EventHandlers } = { current: {} };
+
 vi.mock("../api/client", () => {
   const sessions = [
     { id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa", project_id: "my-app", issue_id: "42", status: "pr_open", activity: "work" },
@@ -19,7 +22,10 @@ vi.mock("../api/client", () => {
   ];
 
   return {
-    connectEvents: () => ({ close() {} }),
+    connectEvents: (_url: string, handlers: EventHandlers) => {
+      sseHandlers.current = handlers;
+      return { close() {} };
+    },
     getSessions: async () => sessions,
     killSession: async () => {},
     restoreSession: async () => sessions[0],
@@ -50,6 +56,37 @@ describe("App session tabs", () => {
     expect(heroMono).not.toBeNull();
     expect(heroMono).toHaveTextContent("aaaaaaaa");
     expect(heroMono).not.toHaveTextContent("bbbbbbbb");
+  });
+});
+
+describe("toast dismiss", () => {
+  it("removes the toast when the × button is clicked without opening the session", async () => {
+    const user = userEvent.setup();
+    render(<App />);
+
+    await screen.findAllByText("terminal");
+
+    act(() => {
+      sseHandlers.current.onEvent?.({
+        type: "ui_notification",
+        notification: {
+          id: "aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa",
+          reaction_key: "needs-review",
+          action: "review_pr",
+          priority: "action",
+          message: "PR ready for review",
+        },
+      });
+    });
+
+    const dismiss = await screen.findByRole("button", { name: "Dismiss" });
+    expect(screen.getByText("needs-review")).toBeInTheDocument();
+
+    await user.click(dismiss);
+
+    expect(screen.queryByText("needs-review")).not.toBeInTheDocument();
+    // Clicking dismiss must NOT open the session tab for that id.
+    expect(screen.queryByRole("button", { name: "my-app - #42: pr_open" })).toBeNull();
   });
 });
 

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -406,25 +406,46 @@ export function App() {
     <div className="app">
       {toasts.length ? (
         <div className="toast-stack" aria-live="polite" aria-relevant="additions">
-          {toasts.map((t) => (
-            <button
-              key={t.key}
-              type="button"
-              className={`toast ${t.priority ? `toast--${t.priority}` : ""}`}
-              onClick={() => {
-                setSelectedSessionId(t.sessionId);
-                setActiveTab({ sessionId: t.sessionId });
-                setSessionTabs((prev) => (prev.includes(t.sessionId) ? prev : [t.sessionId, ...prev]));
-              }}
-              title="Open session"
-            >
-              <div className="toast__title">
-                <span className="mono">{t.reactionKey}</span>
-                {t.action ? <span className="toast__meta">{t.action}</span> : null}
+          {toasts.map((t) => {
+            const openToast = () => {
+              setSelectedSessionId(t.sessionId);
+              setActiveTab({ sessionId: t.sessionId });
+              setSessionTabs((prev) => (prev.includes(t.sessionId) ? prev : [t.sessionId, ...prev]));
+            };
+            return (
+              <div
+                key={t.key}
+                role="button"
+                tabIndex={0}
+                className={`toast ${t.priority ? `toast--${t.priority}` : ""}`}
+                onClick={openToast}
+                onKeyDown={(e) => {
+                  if (e.key === "Enter" || e.key === " ") {
+                    e.preventDefault();
+                    openToast();
+                  }
+                }}
+                title="Open session"
+              >
+                <div className="toast__title">
+                  <span className="mono">{t.reactionKey}</span>
+                  {t.action ? <span className="toast__meta">{t.action}</span> : null}
+                </div>
+                {t.message ? <div className="toast__body">{t.message}</div> : null}
+                <button
+                  type="button"
+                  className="toast__close"
+                  aria-label="Dismiss"
+                  onClick={(e) => {
+                    e.stopPropagation();
+                    setToasts((prev) => prev.filter((x) => x.key !== t.key));
+                  }}
+                >
+                  ×
+                </button>
               </div>
-              {t.message ? <div className="toast__body">{t.message}</div> : null}
-            </button>
-          ))}
+            );
+          })}
         </div>
       ) : null}
       <div className="topbar">

--- a/crates/ao-desktop/ui/styles.css
+++ b/crates/ao-desktop/ui/styles.css
@@ -161,9 +161,10 @@ body[data-theme="dark"]::before {
   width: min(420px, calc(100vw - 28px));
 }
 .toast {
+  position: relative;
   text-align: left;
   border-radius: 14px;
-  padding: 10px 12px;
+  padding: 10px 32px 10px 12px;
   background: rgba(255, 255, 255, 0.88);
   border: 1px solid rgba(9, 30, 66, 0.16);
   box-shadow: var(--shadow-float);
@@ -196,6 +197,30 @@ body[data-theme="dark"] .toast__body { color: rgba(229, 231, 235, 0.78); }
 .toast--action { border-color: rgba(255, 200, 0, 0.55); }
 .toast--warning { border-color: rgba(255, 160, 0, 0.45); }
 .toast--info { border-color: rgba(120, 170, 255, 0.45); }
+.toast__close {
+  position: absolute;
+  top: 6px;
+  right: 8px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  width: 22px;
+  height: 22px;
+  padding: 0;
+  border-radius: 6px;
+  border: none;
+  background: transparent;
+  font-size: 16px;
+  font-weight: 700;
+  line-height: 1;
+  color: var(--text-secondary);
+  cursor: pointer;
+  user-select: none;
+  opacity: 0.7;
+}
+.toast__close:hover { opacity: 1; background: rgba(9, 30, 66, 0.08); }
+body[data-theme="dark"] .toast__close:hover { background: rgba(255, 255, 255, 0.1); }
+.toast__close:focus-visible { outline: 2px solid var(--accent); outline-offset: 2px; }
 
 input, button, textarea { font: inherit; }
 input, textarea {


### PR DESCRIPTION
## Summary
- Adds a × close button to each toast so users can dismiss it manually instead of waiting 12s.
- Refactored the toast container from `<button>` to `<div role="button">` so the inner dismiss is a proper semantic `<button>` (no nested-button invalid HTML); keyboard activation (Enter/Space) is preserved on the toast body.
- New CSS for `.toast__close` (top-right placement, hover/focus states, dark-mode aware) plus a small change to `.toast` padding to make room for the close affordance.

## Test plan
- [x] `npm run typecheck` in `crates/ao-desktop/ui` passes.
- [x] `npm test` passes — added a new case covering that clicking × removes the toast **without** opening the session tab. Also added `afterEach(cleanup)` in the vitest setup so rendered state doesn't leak between tests.
- [x] `npm run build` produces a clean bundle.
- [x] Verified the outer toast still opens the session via click / Enter / Space.

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)