### PR TITLE
docs(parity): classify parity_* modules and add staleness guard (#105)

### DIFF
--- a/crates/ao-core/src/parity_config_validation.rs
+++ b/crates/ao-core/src/parity_config_validation.rs
@@ -1,3 +1,13 @@
+//! TS orchestrator-config validation rules
+//! (ported from `packages/core/src/config.ts`, validation section).
+//!
+//! Parity status: test-only.
+//!
+//! The production config loader in `crates/ao-core/src/config.rs` has its
+//! own (stricter) validator. This module exists only as a regression harness
+//! against the TS behavior. See `docs/ts-core-parity-report.md` →
+//! "Parity-only modules".
+
 use std::collections::{HashMap, HashSet};
 use std::path::Path;
 

--- a/crates/ao-core/src/parity_feedback_tools.rs
+++ b/crates/ao-core/src/parity_feedback_tools.rs
@@ -1,3 +1,11 @@
+//! TS feedback tooling (ported from `packages/core/src/feedback-tools.ts`).
+//!
+//! Parity status: test-only.
+//!
+//! No runtime consumer. Uses `parity_metadata` for atomic file writes and
+//! key/value parsing. See `docs/ts-core-parity-report.md` →
+//! "Parity-only modules".
+
 use crate::parity_metadata::{atomic_write_file, parse_key_value_content};
 use std::hash::{Hash, Hasher};
 use std::path::PathBuf;

--- a/crates/ao-core/src/parity_metadata.rs
+++ b/crates/ao-core/src/parity_metadata.rs
@@ -1,3 +1,13 @@
+//! TS session metadata persistence (ported from
+//! `packages/core/src/metadata.ts`, `key-value.ts`, `atomic-write.ts`).
+//!
+//! Parity status: test-only.
+//!
+//! Consumed only by other parity modules (`parity_observability`,
+//! `parity_feedback_tools`) and their tests. Production persistence lives
+//! in `session_manager.rs` and related runtime modules. See
+//! `docs/ts-core-parity-report.md` → "Parity-only modules".
+
 use std::collections::HashMap;
 use std::fs;
 use std::io::Write;

--- a/crates/ao-core/src/parity_observability.rs
+++ b/crates/ao-core/src/parity_observability.rs
@@ -1,3 +1,11 @@
+//! TS observability helpers (ported from `packages/core/src/observability.ts`).
+//!
+//! Parity status: test-only.
+//!
+//! No runtime consumer. Depends on `parity_metadata::atomic_write_file` for
+//! snapshot persistence during tests. See
+//! `docs/ts-core-parity-report.md` → "Parity-only modules".
+
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 use std::path::{Path, PathBuf};

--- a/crates/ao-core/src/parity_plugin_registry.rs
+++ b/crates/ao-core/src/parity_plugin_registry.rs
@@ -1,3 +1,12 @@
+//! TS plugin registry (ported from `packages/core/src/plugin-registry.ts`).
+//!
+//! Parity status: test-only.
+//!
+//! The real ao-rs plugin wiring lives at the workspace level (per-slot
+//! crates and explicit registration in `ao-cli`). This module only mirrors
+//! the TS registry shape for parity comparison. See
+//! `docs/ts-core-parity-report.md` → "Parity-only modules".
+
 use std::collections::HashMap;
 use std::sync::Arc;
 

--- a/crates/ao-core/src/parity_session_strategy.rs
+++ b/crates/ao-core/src/parity_session_strategy.rs
@@ -1,3 +1,15 @@
+//! Orchestrator session-strategy enums and helpers
+//! (ported from `packages/core/src/orchestrator-session-strategy.ts`).
+//!
+//! Parity status: mixed.
+//!
+//! The two enums (`OrchestratorSessionStrategy`, `OpencodeIssueSessionStrategy`)
+//! are re-exported from `ao_core` and used by production config
+//! (`crates/ao-core/src/config.rs`). The helper
+//! `decide_existing_session_action` is test-only — the runtime lifecycle has
+//! its own strategy logic and does not call it. See
+//! `docs/ts-core-parity-report.md` → "Parity-only modules".
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]

--- a/crates/ao-core/src/parity_utils.rs
+++ b/crates/ao-core/src/parity_utils.rs
@@ -1,7 +1,13 @@
 //! TS core utilities (ported from `packages/core/src/utils.ts` and friends).
 //!
-//! This module exists for parity testing and gradual porting. It is not used by
-//! the main ao-rs runtime yet.
+//! Parity status: test-only.
+//!
+//! Not wired into the ao-rs runtime. Consumed only by
+//! `tests/parity_utils_parity_test.rs`. Duplicate `shell_escape`
+//! implementations live in the `runtime-tmux`, `agent-codex`, and
+//! `agent-aider` plugin crates; consolidation is deferred until a concrete
+//! runtime need makes it worth the churn. See
+//! `docs/ts-core-parity-report.md` → "Parity-only modules".
 
 use std::path::Path;
 

--- a/crates/ao-core/tests/parity_modules_meta.rs
+++ b/crates/ao-core/tests/parity_modules_meta.rs
@@ -1,0 +1,127 @@
+//! Staleness guard for `parity_*` modules in `crates/ao-core/src/`.
+//!
+//! Fails if the on-disk set of parity modules drifts from the documented
+//! classification, or if any module is missing the `Parity status:` header.
+//!
+//! See `docs/ts-core-parity-report.md` → "Parity-only modules" for the
+//! policy and per-module notes.
+
+use std::collections::BTreeSet;
+use std::fs;
+use std::path::{Path, PathBuf};
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ParityClass {
+    TestOnly,
+    Mixed,
+    #[allow(dead_code)] // reserved for future modules whose code runs in runtime paths
+    ProductionUsed,
+}
+
+impl ParityClass {
+    fn header_tag(self) -> &'static str {
+        match self {
+            ParityClass::TestOnly => "Parity status: test-only",
+            ParityClass::Mixed => "Parity status: mixed",
+            ParityClass::ProductionUsed => "Parity status: production-used",
+        }
+    }
+}
+
+/// Single source of truth for the classification of every `parity_*` module.
+///
+/// To add / remove / reclassify a parity module:
+/// 1. Update this list.
+/// 2. Update the table in `docs/ts-core-parity-report.md` →
+///    "Parity-only modules".
+/// 3. Ensure the module's `//!` header contains the matching
+///    `Parity status: <value>` line.
+const PARITY_MODULES: &[(&str, ParityClass)] = &[
+    ("parity_utils.rs", ParityClass::TestOnly),
+    ("parity_session_strategy.rs", ParityClass::Mixed),
+    ("parity_config_validation.rs", ParityClass::TestOnly),
+    ("parity_plugin_registry.rs", ParityClass::TestOnly),
+    ("parity_observability.rs", ParityClass::TestOnly),
+    ("parity_metadata.rs", ParityClass::TestOnly),
+    ("parity_feedback_tools.rs", ParityClass::TestOnly),
+];
+
+fn src_dir() -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join("src")
+}
+
+fn discovered_parity_files() -> BTreeSet<String> {
+    fs::read_dir(src_dir())
+        .expect("read src dir")
+        .filter_map(|e| e.ok())
+        .filter_map(|e| {
+            let name = e.file_name().to_string_lossy().to_string();
+            if name.starts_with("parity_") && name.ends_with(".rs") {
+                Some(name)
+            } else {
+                None
+            }
+        })
+        .collect()
+}
+
+#[test]
+fn parity_module_set_matches_expected() {
+    let on_disk = discovered_parity_files();
+    let expected: BTreeSet<String> = PARITY_MODULES
+        .iter()
+        .map(|(name, _)| (*name).to_string())
+        .collect();
+
+    let missing: Vec<_> = expected.difference(&on_disk).collect();
+    let unexpected: Vec<_> = on_disk.difference(&expected).collect();
+
+    assert!(
+        missing.is_empty() && unexpected.is_empty(),
+        "Parity module set drift.\n\
+         Missing (listed in `PARITY_MODULES` but not on disk): {missing:?}\n\
+         Unexpected (on disk but not listed): {unexpected:?}\n\
+         \n\
+         To fix: update `PARITY_MODULES` in this test AND the table in\n\
+         `docs/ts-core-parity-report.md` → \"Parity-only modules\"."
+    );
+}
+
+#[test]
+fn every_parity_module_has_status_header() {
+    let src = src_dir();
+    for (name, class) in PARITY_MODULES {
+        let path = src.join(name);
+        let content = fs::read_to_string(&path)
+            .unwrap_or_else(|e| panic!("read {}: {e}", path.display()));
+        assert!(
+            content.contains(class.header_tag()),
+            "{name} is missing required header line `{}`. \
+             Every `parity_*` module must carry a `//!` `Parity status:` tag \
+             matching its classification in `PARITY_MODULES`.",
+            class.header_tag(),
+        );
+    }
+}
+
+/// The `mixed` classification for `parity_session_strategy.rs` depends on
+/// its two enums being re-exported from `ao_core`. If the re-export goes
+/// away, the module is no longer "mixed" and must be reclassified (or the
+/// enums must be moved into a non-parity module).
+#[test]
+fn session_strategy_enums_still_reexported_from_lib() {
+    let lib = fs::read_to_string(src_dir().join("lib.rs")).expect("read lib.rs");
+    let has_reexport = lib.contains(
+        "pub use parity_session_strategy::{OpencodeIssueSessionStrategy, \
+         OrchestratorSessionStrategy}",
+    ) || (lib.contains("pub use parity_session_strategy::")
+        && lib.contains("OrchestratorSessionStrategy")
+        && lib.contains("OpencodeIssueSessionStrategy"));
+    assert!(
+        has_reexport,
+        "parity_session_strategy is classified as Mixed because its enums are \
+         re-exported from `ao_core::lib`. That re-export is gone. Either \
+         restore it, or reclassify the module in `PARITY_MODULES` and the \
+         docs table."
+    );
+}

--- a/docs/ts-core-parity-report.md
+++ b/docs/ts-core-parity-report.md
@@ -34,3 +34,32 @@ Goal: Port all modules + unit tests into Rust. This document tracks current pari
 - Then observability + feedback tools
 - Then session-manager/lifecycle/recovery parity
 
+## Parity-only modules
+
+Several modules under `crates/ao-core/src/` are named `parity_*`. They were
+ported from `packages/core/src/` for behavioral parity testing and are **not**
+uniformly wired into the ao-rs runtime. Each module carries a `Parity status:`
+tag in its `//!` header and is tracked in the guard test
+`crates/ao-core/tests/parity_modules_meta.rs`, which fails if:
+
+- A new `parity_*.rs` appears without being listed below, or
+- An existing one is removed/renamed without updating the list, or
+- A file is missing the `Parity status:` header line, or
+- The `mixed` module stops re-exporting its production-used items from
+  `lib.rs`.
+
+Policy: **prefer incremental graduation tied to real runtime needs.** Don't
+move parity code into production modules unless a concrete runtime caller
+needs it. When a runtime need arises, move the function, update the
+classification, and keep the parity test pointed at the production impl.
+
+| Module | Status | TS source | Notes |
+| --- | --- | --- | --- |
+| `parity_utils.rs` | test-only | `packages/core/src/utils.ts` | Standalone helpers (`shell_escape`, `validate_url`, `is_git_branch_name_safe`, retry-config, JSONL tailer). Duplicate `shell_escape` lives in `runtime-tmux`, `agent-codex`, `agent-aider` plugins; consolidation deferred. |
+| `parity_session_strategy.rs` | mixed | `packages/core/src/orchestrator-session-strategy.ts` | Enums `OrchestratorSessionStrategy` and `OpencodeIssueSessionStrategy` are re-exported from `ao_core` and used by `config.rs`. `decide_existing_session_action` is test-only (the runtime lifecycle code does not call it). |
+| `parity_config_validation.rs` | test-only | `packages/core/src/config.ts` (validation rules) | Rust config (`config.rs`) has its own stricter validator; parity module exists as a regression harness only. |
+| `parity_plugin_registry.rs` | test-only | `packages/core/src/plugin-registry.ts` | Rust plugin wiring lives in the workspace-level crate structure; this module mirrors the TS registry shape for comparison. |
+| `parity_observability.rs` | test-only | `packages/core/src/observability.ts` | No runtime consumer; depends on `parity_metadata::atomic_write_file`. |
+| `parity_metadata.rs` | test-only | `packages/core/src/metadata.ts`, `key-value.ts`, `atomic-write.ts` | Consumed only by other parity modules (`parity_observability`, `parity_feedback_tools`) and their tests. |
+| `parity_feedback_tools.rs` | test-only | `packages/core/src/feedback-tools.ts` | No runtime consumer. |
+


### PR DESCRIPTION
## Summary

- Adds a standardized `//!` header with a machine-readable `Parity status:` tag to every `parity_*` module in `crates/ao-core/src/` (six **test-only**, one **mixed**).
- Documents the classification in `docs/ts-core-parity-report.md` under a new **"Parity-only modules"** section, along with the policy (*prefer incremental graduation tied to real runtime needs*).
- Adds `crates/ao-core/tests/parity_modules_meta.rs` — a staleness guard that fails `cargo t` if the on-disk parity module set drifts from the documented list, if a file is missing the header, or if the `mixed` re-export disappears from `lib.rs`.

No runtime behavior changes.

## Classification

| Module | Status | Why |
|---|---|---|
| `parity_utils.rs` | test-only | Standalone helpers; not called from runtime. Duplicate `shell_escape` in plugin crates — consolidation deferred. |
| `parity_session_strategy.rs` | mixed | Enums re-exported via `ao_core::{OrchestratorSessionStrategy, OpencodeIssueSessionStrategy}` and used in `config.rs`. `decide_existing_session_action` is test-only. |
| `parity_config_validation.rs` | test-only | Runtime has its own stricter validator in `config.rs`. |
| `parity_plugin_registry.rs` | test-only | Real plugin wiring lives at the workspace level. |
| `parity_observability.rs` | test-only | No runtime consumer. |
| `parity_metadata.rs` | test-only | Consumed only by other parity modules and tests. |
| `parity_feedback_tools.rs` | test-only | No runtime consumer. |

Closes #105.

## Test plan
- [x] `cargo t -p ao-core --test parity_modules_meta` — 3/3 pass
- [x] `cargo t --workspace` — 711/711 pass
- [x] `cargo test --doc -p ao-core` — pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)