### PR TITLE
feat(workspace): add Workspace::exists() for clean restore checks

### DIFF
--- a/crates/ao-cli/src/commands/dashboard.rs
+++ b/crates/ao-cli/src/commands/dashboard.rs
@@ -21,6 +21,7 @@ fn build_dashboard_state() -> Result<ao_dashboard::state::AppState, Box<dyn std:
     let sessions = Arc::new(SessionManager::with_default());
     let agent: Arc<dyn Agent> = Arc::new(MultiAgent);
     let scm: Arc<dyn Scm> = Arc::new(AutoScm::new());
+    let workspace: Arc<dyn Workspace> = Arc::new(WorktreeWorkspace::new());
 
     // Dashboard handlers expect a broadcast sender even if no lifecycle loop is running.
     // In "HTTP-only" mode this sender will never publish any events.
@@ -46,6 +47,7 @@ fn build_dashboard_state() -> Result<ao_dashboard::state::AppState, Box<dyn std:
         runtime,
         scm,
         agent,
+        workspace,
     })
 }
 
@@ -157,7 +159,7 @@ pub async fn dashboard(
         lifecycle_builder
             .with_reaction_engine(engine)
             .with_scm(scm.clone())
-            .with_workspace(workspace),
+            .with_workspace(workspace.clone()),
     );
     let lifecycle_handle = lifecycle.spawn();
 
@@ -168,6 +170,7 @@ pub async fn dashboard(
         runtime,
         scm,
         agent,
+        workspace,
     };
 
     println!(

--- a/crates/ao-cli/src/session/restore.rs
+++ b/crates/ao-cli/src/session/restore.rs
@@ -1,6 +1,7 @@
 //! `ao-rs session restore`.
 
 use ao_core::{restore_session, SessionManager};
+use ao_plugin_workspace_worktree::WorktreeWorkspace;
 
 use crate::cli::agent_config::resolve_agent_config_for_restore;
 use crate::cli::plugins::select_agent;
@@ -18,6 +19,7 @@ pub async fn restore(session_id_or_prefix: String) -> Result<(), Box<dyn std::er
     }
     let runtime = select_runtime(&session.runtime);
     let agent_box = select_agent(&session.agent, session.agent_config.as_ref());
+    let workspace = WorktreeWorkspace::new();
 
     println!("→ restoring session: {session_id_or_prefix}");
     let outcome = restore_session(
@@ -25,6 +27,7 @@ pub async fn restore(session_id_or_prefix: String) -> Result<(), Box<dyn std::er
         &sessions,
         &*runtime,
         agent_box.as_ref(),
+        &workspace,
     )
     .await?;
 

--- a/crates/ao-core/src/restore.rs
+++ b/crates/ao-core/src/restore.rs
@@ -9,10 +9,13 @@
 //!    `terminated` in-memory so the `is_restorable` check passes. This
 //!    matches `enrichSessionWithRuntimeState(session, plugins, true)` in TS.
 //! 3. Refuse restore if the session is non-restorable (e.g. `merged`).
-//! 4. Verify the workspace path still exists on disk. Slice 1 does not
-//!    auto-recreate worktrees — if it's gone, the user has to `ao-rs spawn`
-//!    a fresh session. (TS has an optional `workspace.restore` plugin hook
-//!    for this; Phase D keeps the trait surface small.)
+//! 4. Verify the workspace is still usable via `Workspace::exists()`. The
+//!    plugin's own check catches corrupted/partially-removed workspaces
+//!    (e.g. directory present but `.git` gone) that a plain
+//!    `Path::exists()` would miss. Slice 1 does not auto-recreate
+//!    workspaces — if it's gone, the user has to `ao-rs spawn` a fresh
+//!    session. (TS has an optional `workspace.restore` plugin hook for
+//!    this; Phase D keeps the trait surface small.)
 //! 5. Best-effort `runtime.destroy` on the old handle in case it's still
 //!    lingering (tmux can survive the agent process exiting — see the
 //!    `// step 6` comment in the TS reference).
@@ -28,10 +31,9 @@
 use crate::{
     error::{AoError, Result},
     session_manager::SessionManager,
-    traits::{Agent, Runtime},
+    traits::{Agent, Runtime, Workspace},
     types::{Session, SessionStatus},
 };
-use std::path::Path;
 
 /// Outcome of a successful restore, returned so the caller can pretty-print.
 #[derive(Debug, Clone)]
@@ -58,6 +60,7 @@ pub async fn restore_session(
     sessions: &SessionManager,
     runtime: &dyn Runtime,
     agent: &dyn Agent,
+    workspace: &dyn Workspace,
 ) -> Result<RestoreOutcome> {
     // ---- 1. Locate the session on disk ----
     let mut session = sessions.find_by_prefix(id_or_prefix).await?;
@@ -86,12 +89,16 @@ pub async fn restore_session(
         )));
     }
 
-    // ---- 4. Workspace must still exist ----
+    // ---- 4. Workspace must still be usable ----
+    //
+    // Delegate the check to the plugin so it can apply backend-specific
+    // validation (e.g. git-backed workspaces verify the working tree is
+    // still recognised by git, not just present on disk).
     let workspace_path = session
         .workspace_path
         .clone()
         .ok_or_else(|| AoError::Workspace("session has no workspace_path".into()))?;
-    if !workspace_path.exists() {
+    if !workspace.exists(&workspace_path).await? {
         return Err(AoError::Workspace(format!(
             "workspace missing: {}",
             workspace_path.display()
@@ -145,21 +152,12 @@ pub async fn restore_session(
     })
 }
 
-/// Does anything exist at `p`? Thin wrapper so tests can stub this out.
-/// Currently unused — kept for when Slice 2 replaces `Path::exists` with
-/// a plugin-provided `Workspace::exists`.
-#[allow(dead_code)]
-fn path_exists(p: &Path) -> bool {
-    p.exists()
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
     use crate::types::{now_ms, ActivityState, SessionId, WorkspaceCreateConfig};
-    use crate::Workspace;
     use async_trait::async_trait;
-    use std::path::PathBuf;
+    use std::path::{Path, PathBuf};
     use std::sync::atomic::{AtomicBool, AtomicUsize, Ordering};
     use std::sync::Mutex;
     use std::time::{SystemTime, UNIX_EPOCH};
@@ -245,7 +243,9 @@ mod tests {
         }
     }
 
-    #[allow(dead_code)]
+    /// Thin workspace stub that relies on the trait's default `exists()`
+    /// (i.e. a plain `Path::exists` probe). Restore tests use it to drive
+    /// the "workspace is on disk → proceed" branch.
     struct StubWorkspace;
     #[async_trait]
     impl Workspace for StubWorkspace {
@@ -254,6 +254,26 @@ mod tests {
         }
         async fn destroy(&self, _workspace_path: &Path) -> Result<()> {
             Ok(())
+        }
+    }
+
+    /// Workspace stub whose `exists()` returns a configurable value without
+    /// touching the filesystem. Lets the "restore fails cleanly when the
+    /// workspace plugin reports corrupted" test run even if the directory
+    /// itself is present on disk.
+    struct ExistsWorkspace {
+        reports_exists: bool,
+    }
+    #[async_trait]
+    impl Workspace for ExistsWorkspace {
+        async fn create(&self, _cfg: &WorkspaceCreateConfig) -> Result<PathBuf> {
+            Ok(PathBuf::from("/tmp/ws"))
+        }
+        async fn destroy(&self, _workspace_path: &Path) -> Result<()> {
+            Ok(())
+        }
+        async fn exists(&self, _workspace_path: &Path) -> Result<bool> {
+            Ok(self.reports_exists)
         }
     }
 
@@ -302,7 +322,7 @@ mod tests {
         let rt = RecorderRuntime::new(false);
         let agent = StubAgent;
 
-        let out = restore_session("sess-ok", &manager, &rt, &agent)
+        let out = restore_session("sess-ok", &manager, &rt, &agent, &StubWorkspace)
             .await
             .unwrap();
 
@@ -353,7 +373,7 @@ mod tests {
         manager.save(&s).await.unwrap();
 
         let rt = RecorderRuntime::new(false);
-        let out = restore_session("sess-nohandle", &manager, &rt, &StubAgent)
+        let out = restore_session("sess-nohandle", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap();
 
@@ -390,7 +410,7 @@ mod tests {
         persist_session(&manager, "sess-crash", SessionStatus::Working, &ws).await;
 
         let rt = RecorderRuntime::new(false); // dead
-        let out = restore_session("sess-crash", &manager, &rt, &StubAgent)
+        let out = restore_session("sess-crash", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap();
 
@@ -410,7 +430,7 @@ mod tests {
         persist_session(&manager, "sess-merged", SessionStatus::Merged, &ws).await;
 
         let rt = RecorderRuntime::new(false);
-        let err = restore_session("sess-merged", &manager, &rt, &StubAgent)
+        let err = restore_session("sess-merged", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap_err();
         assert!(
@@ -438,7 +458,7 @@ mod tests {
         .await;
 
         let rt = RecorderRuntime::new(false);
-        let err = restore_session("sess-ghost", &manager, &rt, &StubAgent)
+        let err = restore_session("sess-ghost", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("workspace missing"), "got: {err}");
@@ -453,11 +473,40 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn corrupted_workspace_reports_missing_via_plugin_exists() {
+        // Directory is on disk but the plugin reports it as not usable
+        // (e.g. worktree's `git rev-parse` check failed). Restore must
+        // surface "workspace missing" and never touch the runtime.
+        let base = unique_temp_dir("corrupt");
+        let ws = base.join("ws");
+        std::fs::create_dir_all(&ws).unwrap();
+
+        let manager = SessionManager::new(base.clone());
+        persist_session(&manager, "sess-corrupt", SessionStatus::Terminated, &ws).await;
+
+        let rt = RecorderRuntime::new(false);
+        let workspace = ExistsWorkspace {
+            reports_exists: false,
+        };
+        let err = restore_session("sess-corrupt", &manager, &rt, &StubAgent, &workspace)
+            .await
+            .unwrap_err();
+        assert!(format!("{err}").contains("workspace missing"), "got: {err}");
+        assert!(
+            rt.calls().is_empty(),
+            "runtime was called: {:?}",
+            rt.calls()
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
     async fn unknown_session_id_errors() {
         let base = unique_temp_dir("missing");
         let manager = SessionManager::new(base.clone());
         let rt = RecorderRuntime::new(false);
-        let err = restore_session("nope", &manager, &rt, &StubAgent)
+        let err = restore_session("nope", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap_err();
         assert!(matches!(err, AoError::SessionNotFound(_)), "got {err:?}");
@@ -474,7 +523,7 @@ mod tests {
         persist_session(&manager, "abcd-2222", SessionStatus::Terminated, &ws).await;
 
         let rt = RecorderRuntime::new(false);
-        let err = restore_session("abcd", &manager, &rt, &StubAgent)
+        let err = restore_session("abcd", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap_err();
         assert!(format!("{err}").contains("ambiguous"), "got: {err}");
@@ -496,7 +545,7 @@ mod tests {
         .await;
 
         let rt = RecorderRuntime::new(false);
-        let out = restore_session("deadbeef", &manager, &rt, &StubAgent)
+        let out = restore_session("deadbeef", &manager, &rt, &StubAgent, &StubWorkspace)
             .await
             .unwrap();
         assert_eq!(out.session.id.0, "deadbeef-uuid-long");

--- a/crates/ao-core/src/traits.rs
+++ b/crates/ao-core/src/traits.rs
@@ -43,6 +43,20 @@ pub trait Workspace: Send + Sync {
     /// Create an isolated copy of the repo on a new branch, returning its path.
     async fn create(&self, cfg: &WorkspaceCreateConfig) -> Result<PathBuf>;
     async fn destroy(&self, workspace_path: &Path) -> Result<()>;
+
+    /// Report whether a previously-created workspace is still usable at
+    /// `workspace_path`. Session restore uses this to decide whether the
+    /// session can be brought back up or whether the user has to spawn a
+    /// fresh one.
+    ///
+    /// The default impl treats any directory that exists on disk as
+    /// usable — good enough for plugins that don't have backend-specific
+    /// validation. Plugins backed by git (worktree / clone) override this
+    /// to also verify the directory is still a working tree (catches the
+    /// case where someone `rm -rf`'d `.git` or the repo was corrupted).
+    async fn exists(&self, workspace_path: &Path) -> Result<bool> {
+        Ok(workspace_path.exists())
+    }
 }
 
 /// A specific AI coding tool (Claude Code, Codex, Aider, Cursor, ...).

--- a/crates/ao-dashboard/src/lib.rs
+++ b/crates/ao-dashboard/src/lib.rs
@@ -121,12 +121,29 @@ mod tests {
         let runtime: Arc<dyn ao_core::Runtime> = Arc::new(DummyRuntime);
         let scm: Arc<dyn Scm> = Arc::new(DummyScm);
         let agent: Arc<dyn ao_core::Agent> = Arc::new(DummyAgent);
+        let workspace: Arc<dyn ao_core::Workspace> = Arc::new(DummyWorkspace);
         AppState {
             sessions,
             events_tx,
             runtime,
             scm,
             agent,
+            workspace,
+        }
+    }
+
+    struct DummyWorkspace;
+
+    #[async_trait::async_trait]
+    impl ao_core::Workspace for DummyWorkspace {
+        async fn create(
+            &self,
+            _cfg: &ao_core::WorkspaceCreateConfig,
+        ) -> ao_core::Result<std::path::PathBuf> {
+            Ok(std::path::PathBuf::from("/tmp/dummy-ws"))
+        }
+        async fn destroy(&self, _workspace_path: &std::path::Path) -> ao_core::Result<()> {
+            Ok(())
         }
     }
 

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -449,6 +449,7 @@ pub async fn restore_session(
         state.sessions.as_ref(),
         state.runtime.as_ref(),
         state.agent.as_ref(),
+        state.workspace.as_ref(),
     )
     .await
     .map_err(session_error_response)?;

--- a/crates/ao-dashboard/src/state.rs
+++ b/crates/ao-dashboard/src/state.rs
@@ -1,6 +1,6 @@
 //! Shared application state for the dashboard API.
 
-use ao_core::{Agent, OrchestratorEvent, Runtime, Scm, SessionManager};
+use ao_core::{Agent, OrchestratorEvent, Runtime, Scm, SessionManager, Workspace};
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -12,4 +12,7 @@ pub struct AppState {
     pub runtime: Arc<dyn Runtime>,
     pub scm: Arc<dyn Scm>,
     pub agent: Arc<dyn Agent>,
+    /// Workspace plugin used by `restore` to probe `exists()` on the
+    /// persisted `workspace_path` before attempting to respawn.
+    pub workspace: Arc<dyn Workspace>,
 }

--- a/crates/plugins/workspace-clone/src/lib.rs
+++ b/crates/plugins/workspace-clone/src/lib.rs
@@ -122,6 +122,21 @@ impl Workspace for CloneWorkspace {
         Ok(clone_path)
     }
 
+    /// A clone is "usable" iff the directory exists *and* git still
+    /// recognizes it as a working tree. Mirrors the TS reference (`exists` at
+    /// `packages/plugins/workspace-clone/src/index.ts:169`).
+    ///
+    /// Returns `Ok(false)` — not an error — when the path is missing or the
+    /// `.git` directory is gone. Gives restore a clean boolean to branch on.
+    async fn exists(&self, workspace_path: &Path) -> Result<bool> {
+        if !workspace_path.exists() {
+            return Ok(false);
+        }
+        Ok(git(workspace_path, &["rev-parse", "--is-inside-work-tree"])
+            .await
+            .is_ok())
+    }
+
     /// Remove the cloned directory entirely. Unlike worktrees, there is no
     /// shared git bookkeeping to update — a plain directory removal is enough.
     async fn destroy(&self, workspace_path: &Path) -> Result<()> {

--- a/crates/plugins/workspace-clone/tests/integration.rs
+++ b/crates/plugins/workspace-clone/tests/integration.rs
@@ -239,6 +239,39 @@ async fn create_symlinks_and_post_create() {
 }
 
 #[tokio::test]
+async fn exists_reflects_workspace_usability() {
+    let repo = init_repo();
+    let base = unique_dir("clones-exists");
+    let workspace = CloneWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess-exists".to_string(),
+        branch: "feat-exists".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
+    };
+
+    // 1. Before create: path is missing → exists() = false.
+    let expected = base.join("demo").join("sess-exists");
+    assert!(!workspace.exists(&expected).await.unwrap());
+
+    // 2. After create: path is a valid git work tree → exists() = true.
+    let path = workspace.create(&cfg).await.expect("create failed");
+    assert!(workspace.exists(&path).await.unwrap());
+
+    // 3. Corrupt the clone by removing its `.git` directory.
+    //    git rev-parse --is-inside-work-tree now fails, so exists() = false.
+    std::fs::remove_dir_all(path.join(".git")).unwrap();
+    assert!(!workspace.exists(&path).await.unwrap());
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
 async fn rejects_missing_symlink_source() {
     let repo = init_repo();
 

--- a/crates/plugins/workspace-worktree/src/lib.rs
+++ b/crates/plugins/workspace-worktree/src/lib.rs
@@ -134,6 +134,23 @@ impl Workspace for WorktreeWorkspace {
         Ok(created_path)
     }
 
+    /// A worktree is "usable" iff the directory exists *and* git still
+    /// recognizes it as a working tree. Mirrors the TS reference (`exists` at
+    /// `packages/plugins/workspace-worktree/src/index.ts:241`), which runs
+    /// `git rev-parse --is-inside-work-tree` inside the path.
+    ///
+    /// Returns `Ok(false)` — not an error — when the path is missing or the
+    /// git bookkeeping is gone. That gives the restore flow a single clean
+    /// boolean to branch on.
+    async fn exists(&self, workspace_path: &Path) -> Result<bool> {
+        if !workspace_path.exists() {
+            return Ok(false);
+        }
+        Ok(git(workspace_path, &["rev-parse", "--is-inside-work-tree"])
+            .await
+            .is_ok())
+    }
+
     async fn destroy(&self, workspace_path: &Path) -> Result<()> {
         self.assert_under_base_dir(workspace_path)?;
         let worktree_str = path_to_str(workspace_path)?;

--- a/crates/plugins/workspace-worktree/tests/integration.rs
+++ b/crates/plugins/workspace-worktree/tests/integration.rs
@@ -181,6 +181,44 @@ async fn create_symlinks_and_post_create() {
 }
 
 #[tokio::test]
+async fn exists_reflects_workspace_usability() {
+    let repo = init_repo();
+    let base = unique_dir("worktrees-exists");
+    let workspace = WorktreeWorkspace::with_base_dir(base.clone());
+
+    let cfg = WorkspaceCreateConfig {
+        project_id: "demo".to_string(),
+        session_id: "sess-exists".to_string(),
+        branch: "feat-exists".to_string(),
+        repo_path: repo.clone(),
+        default_branch: "main".to_string(),
+        symlinks: vec![],
+        post_create: vec![],
+    };
+
+    // 1. Before create: path is missing → exists() = false.
+    let expected = base.join("demo").join("sess-exists");
+    assert!(!workspace.exists(&expected).await.unwrap());
+
+    // 2. After create: path is a valid work tree → exists() = true.
+    let path = workspace.create(&cfg).await.expect("create failed");
+    assert!(workspace.exists(&path).await.unwrap());
+
+    // 3. Corrupt the worktree by deleting the `.git` pointer file.
+    //    git rev-parse --is-inside-work-tree must now fail, so exists() = false.
+    let git_pointer = path.join(".git");
+    if git_pointer.is_file() {
+        std::fs::remove_file(&git_pointer).unwrap();
+    } else if git_pointer.is_dir() {
+        std::fs::remove_dir_all(&git_pointer).unwrap();
+    }
+    assert!(!workspace.exists(&path).await.unwrap());
+
+    let _ = std::fs::remove_dir_all(&repo);
+    let _ = std::fs::remove_dir_all(&base);
+}
+
+#[tokio::test]
 async fn rejects_missing_symlink_source() {
     let repo = init_repo();
 


### PR DESCRIPTION
Closes #102.

## Summary

- Added `Workspace::exists(path) -> Result<bool>` with a default `Path::exists` probe, and overrode it in `workspace-worktree` / `workspace-clone` to also verify `git rev-parse --is-inside-work-tree`.
- Threaded the plugin through `restore_session` so the workspace check is "clean" — the plugin decides whether its backing storage is still usable, not a raw `Path::exists` on the session's recorded path. Previously, a session whose `.git` was deleted or corrupted would pass the existence check and then blow up later in the runtime flow.
- Kept the trait surface minimal per the issue ("Avoid expanding the workspace trait too early") — no `list` / `restore` methods added.

Hook execution (`symlinks` + `postCreate`) was already wired in via `apply_workspace_hooks` during `create`, so the only outstanding gap in the issue was the restore-side existence check. The existing integration tests already cover the hook side; this PR adds a new `exists_reflects_workspace_usability` case to both plugins that corrupts `.git` and asserts the plugin-level check fires.

## Files touched

- `crates/ao-core/src/traits.rs` — new `Workspace::exists` with default impl.
- `crates/ao-core/src/restore.rs` — new `&dyn Workspace` parameter on `restore_session`; new unit test using `ExistsWorkspace` stub.
- `crates/plugins/workspace-worktree/src/lib.rs` + `tests/integration.rs` — `exists()` override + integration test.
- `crates/plugins/workspace-clone/src/lib.rs` + `tests/integration.rs` — same for the clone plugin.
- `crates/ao-dashboard/src/{state.rs,routes.rs,lib.rs}` — `AppState` grows a `workspace` field; restore route passes it; test harness supplies a `DummyWorkspace`.
- `crates/ao-cli/src/commands/dashboard.rs` + `src/session/restore.rs` — wire `WorktreeWorkspace` into both dashboard build sites and the CLI `restore` command.

## Test plan

- [x] `cargo t --workspace` — 711 passed, includes new `exists_reflects_workspace_usability` (worktree + clone) and `corrupted_workspace_reports_missing_via_plugin_exists` (restore)
- [x] `cargo test --doc`
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all -- --check`

🤖 Generated with [Claude Code](https://claude.com/claude-code)