### PR TITLE
feat(notifier-ntfy): add bearer/basic auth + wiremock tests (#104)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -261,6 +261,7 @@ dependencies = [
  "reqwest 0.12.28",
  "tokio",
  "tracing",
+ "wiremock",
 ]
 
 [[package]]

--- a/crates/ao-cli/src/cli/lifecycle_wiring.rs
+++ b/crates/ao-cli/src/cli/lifecycle_wiring.rs
@@ -5,7 +5,7 @@ use std::sync::Arc;
 use ao_core::{AoConfig, NotificationRouting, NotifierRegistry};
 use ao_plugin_notifier_desktop::DesktopNotifier;
 use ao_plugin_notifier_discord::DiscordNotifier;
-use ao_plugin_notifier_ntfy::NtfyNotifier;
+use ao_plugin_notifier_ntfy::{NtfyAuth, NtfyNotifier};
 use ao_plugin_notifier_slack::SlackNotifier;
 use ao_plugin_notifier_stdout::StdoutNotifier;
 
@@ -17,6 +17,36 @@ fn yaml_string(v: &serde_yaml::Value) -> Option<String> {
 
 fn notifier_extra_string(cfg: &ao_core::config::PluginConfig, key: &str) -> Option<String> {
     cfg.extra.get(key).and_then(yaml_string)
+}
+
+fn env_non_empty(key: &str) -> Option<String> {
+    std::env::var(key)
+        .ok()
+        .map(|s| s.trim().to_string())
+        .filter(|s| !s.is_empty())
+}
+
+/// Resolve ntfy auth from resolved config/env strings. Bearer token wins
+/// over Basic when both are set (private-server setups usually prefer
+/// access tokens).
+fn resolve_ntfy_auth(
+    token: Option<String>,
+    username: Option<String>,
+    password: Option<String>,
+) -> Option<NtfyAuth> {
+    if let Some(t) = token.filter(|s| !s.is_empty()) {
+        return Some(NtfyAuth::Bearer(t));
+    }
+    match (
+        username.filter(|s| !s.is_empty()),
+        password.filter(|s| !s.is_empty()),
+    ) {
+        (Some(u), Some(p)) => Some(NtfyAuth::Basic {
+            username: u,
+            password: p,
+        }),
+        _ => None,
+    }
 }
 
 /// Build the notifier registry from `ao-rs.yaml` routing + env-discovered plugins.
@@ -45,40 +75,62 @@ pub(crate) fn notifier_registry_from_config(config: &AoConfig) -> NotifierRegist
     //   notifiers:
     //     openclaw:
     //       url: https://ntfy.sh
-    //       token: my-topic
+    //       token: my-topic                 # ntfy topic (not the auth token)
+    //       token_auth: tk_...              # optional bearer for private servers
+    //       username: alice                 # or basic auth
+    //       password: hunter2
     //
-    // For backwards compatibility we also accept `notifiers.ntfy.{url,topic}`.
+    // For backwards compatibility we also accept `notifiers.ntfy.{url,topic,
+    // token_auth,username,password}`.
     let mut ntfy_topic: Option<String> = None;
     let mut ntfy_base: Option<String> = None;
+    let mut ntfy_token_auth: Option<String> = None;
+    let mut ntfy_user: Option<String> = None;
+    let mut ntfy_pass: Option<String> = None;
 
     if let Some(openclaw) = config.notifiers.get("openclaw") {
         ntfy_topic = notifier_extra_string(openclaw, "token");
         ntfy_base = notifier_extra_string(openclaw, "url");
+        ntfy_token_auth = notifier_extra_string(openclaw, "token_auth");
+        ntfy_user = notifier_extra_string(openclaw, "username");
+        ntfy_pass = notifier_extra_string(openclaw, "password");
     }
     if ntfy_topic.is_none() {
         if let Some(ntfy) = config.notifiers.get("ntfy") {
             ntfy_topic = notifier_extra_string(ntfy, "topic")
                 .or_else(|| notifier_extra_string(ntfy, "token"));
-            ntfy_base = notifier_extra_string(ntfy, "url");
+            ntfy_base = ntfy_base.or_else(|| notifier_extra_string(ntfy, "url"));
+            ntfy_token_auth = ntfy_token_auth.or_else(|| notifier_extra_string(ntfy, "token_auth"));
+            ntfy_user = ntfy_user.or_else(|| notifier_extra_string(ntfy, "username"));
+            ntfy_pass = ntfy_pass.or_else(|| notifier_extra_string(ntfy, "password"));
         }
     }
 
     if ntfy_topic.is_none() {
-        ntfy_topic = std::env::var("AO_NTFY_TOPIC")
-            .ok()
-            .map(|s| s.trim().to_string());
+        ntfy_topic = env_non_empty("AO_NTFY_TOPIC");
     }
     if ntfy_base.is_none() {
-        ntfy_base = std::env::var("AO_NTFY_URL")
-            .ok()
-            .map(|s| s.trim().to_string());
+        ntfy_base = env_non_empty("AO_NTFY_URL");
+    }
+    if ntfy_token_auth.is_none() {
+        ntfy_token_auth = env_non_empty("AO_NTFY_TOKEN");
+    }
+    if ntfy_user.is_none() {
+        ntfy_user = env_non_empty("AO_NTFY_USERNAME");
+    }
+    if ntfy_pass.is_none() {
+        ntfy_pass = env_non_empty("AO_NTFY_PASSWORD");
     }
 
     if let Some(topic) = ntfy_topic.filter(|s| !s.is_empty()) {
         let base = ntfy_base
             .filter(|s| !s.is_empty())
             .unwrap_or_else(|| "https://ntfy.sh".to_string());
-        notifier_registry.register("ntfy", Arc::new(NtfyNotifier::with_base_url(topic, base)));
+        let auth = resolve_ntfy_auth(ntfy_token_auth, ntfy_user, ntfy_pass);
+        notifier_registry.register(
+            "ntfy",
+            Arc::new(NtfyNotifier::with_base_url_and_auth(topic, base, auth)),
+        );
     }
 
     notifier_registry.register("desktop", Arc::new(DesktopNotifier::new()));
@@ -92,4 +144,49 @@ pub(crate) fn notifier_registry_from_config(config: &AoConfig) -> NotifierRegist
     }
 
     notifier_registry
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn resolve_ntfy_auth_none_when_all_empty() {
+        assert!(resolve_ntfy_auth(None, None, None).is_none());
+        assert!(resolve_ntfy_auth(Some(String::new()), None, None).is_none());
+    }
+
+    #[test]
+    fn resolve_ntfy_auth_prefers_bearer_over_basic() {
+        let out = resolve_ntfy_auth(
+            Some("tk_abc".into()),
+            Some("alice".into()),
+            Some("pw".into()),
+        )
+        .expect("should resolve auth");
+        match out {
+            NtfyAuth::Bearer(t) => assert_eq!(t, "tk_abc"),
+            other => panic!("expected Bearer, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_ntfy_auth_builds_basic_when_both_user_and_pass_present() {
+        let out = resolve_ntfy_auth(None, Some("alice".into()), Some("pw".into()))
+            .expect("should resolve auth");
+        match out {
+            NtfyAuth::Basic { username, password } => {
+                assert_eq!(username, "alice");
+                assert_eq!(password, "pw");
+            }
+            other => panic!("expected Basic, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn resolve_ntfy_auth_requires_both_user_and_pass_for_basic() {
+        assert!(resolve_ntfy_auth(None, Some("alice".into()), None).is_none());
+        assert!(resolve_ntfy_auth(None, None, Some("pw".into())).is_none());
+        assert!(resolve_ntfy_auth(None, Some("alice".into()), Some(String::new())).is_none());
+    }
 }

--- a/crates/ao-cli/src/cli/plugins.rs
+++ b/crates/ao-cli/src/cli/plugins.rs
@@ -319,7 +319,13 @@ pub fn compiled_plugins() -> PluginRegistry {
                 "notification_routing.<priority>[]",
                 "notifiers.<name>.plugin",
             ],
-            env_vars: &["AO_NTFY_TOPIC", "AO_NTFY_URL"],
+            env_vars: &[
+                "AO_NTFY_TOPIC",
+                "AO_NTFY_URL",
+                "AO_NTFY_TOKEN",
+                "AO_NTFY_USERNAME",
+                "AO_NTFY_PASSWORD",
+            ],
         },
         PluginDescriptor {
             slot: PluginSlot::Notifier,

--- a/crates/plugins/notifier-ntfy/Cargo.toml
+++ b/crates/plugins/notifier-ntfy/Cargo.toml
@@ -13,3 +13,4 @@ reqwest = { version = "0.12", default-features = false, features = ["rustls-tls"
 
 [dev-dependencies]
 tokio = { workspace = true }
+wiremock = "0.6"

--- a/crates/plugins/notifier-ntfy/src/lib.rs
+++ b/crates/plugins/notifier-ntfy/src/lib.rs
@@ -1,15 +1,16 @@
 //! ntfy.sh notifier plugin — Slice 3 Phase D.
 //!
 //! Delivers notifications via HTTP POST to an [ntfy](https://ntfy.sh)
-//! server. The simplest HTTP-based notifier — one POST, no auth
-//! required for public topics, no JSON body (just plain text).
+//! server. One POST, no JSON body (just plain text). Public topics
+//! need no auth; private / self-hosted servers can require bearer
+//! tokens or HTTP Basic.
 //!
 //! ## Configuration
 //!
 //! Construction takes a topic (required) and an optional base URL
-//! (defaults to `https://ntfy.sh`). Both are set once at startup via
-//! `ao-cli` and immutable thereafter. Future phases may add auth
-//! token support for private ntfy servers.
+//! (defaults to `https://ntfy.sh`). An optional [`NtfyAuth`] adds
+//! the `Authorization` header for private servers. All fields are
+//! set once at startup via `ao-cli` and immutable thereafter.
 //!
 //! ## Priority mapping
 //!
@@ -41,23 +42,60 @@ use async_trait::async_trait;
 const DEFAULT_BASE_URL: &str = "https://ntfy.sh";
 const DEFAULT_TIMEOUT_SECS: u64 = 5;
 
+/// Authentication for private / self-hosted ntfy servers.
+///
+/// `Debug` is manually implemented to redact the secret so credentials
+/// never leak through `tracing::debug!` or `{:?}` formatting.
+#[derive(Clone)]
+pub enum NtfyAuth {
+    /// Bearer token — sends `Authorization: Bearer <token>`. Matches
+    /// ntfy's access-token header format.
+    Bearer(String),
+    /// HTTP Basic auth — sends `Authorization: Basic base64(user:pass)`.
+    Basic { username: String, password: String },
+}
+
+impl std::fmt::Debug for NtfyAuth {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Bearer(_) => f.debug_tuple("Bearer").field(&"<redacted>").finish(),
+            Self::Basic { username, .. } => f
+                .debug_struct("Basic")
+                .field("username", username)
+                .field("password", &"<redacted>")
+                .finish(),
+        }
+    }
+}
+
 /// Notifier that POSTs to an ntfy topic.
 pub struct NtfyNotifier {
     topic: String,
     base_url: String,
+    auth: Option<NtfyAuth>,
     client: reqwest::Client,
 }
 
 impl NtfyNotifier {
     /// Create a notifier for the given topic on the public ntfy.sh
-    /// server. Timeout defaults to 5 seconds.
+    /// server. Timeout defaults to 5 seconds. No auth.
     pub fn new(topic: impl Into<String>) -> Self {
         Self::with_base_url(topic, DEFAULT_BASE_URL)
     }
 
     /// Create a notifier pointed at a custom ntfy server (e.g. a
-    /// self-hosted instance at `http://ntfy.internal:8080`).
+    /// self-hosted instance at `http://ntfy.internal:8080`). No auth.
     pub fn with_base_url(topic: impl Into<String>, base_url: impl Into<String>) -> Self {
+        Self::with_base_url_and_auth(topic, base_url, None)
+    }
+
+    /// Create a notifier with a custom base URL and optional auth
+    /// header for private / self-hosted ntfy servers.
+    pub fn with_base_url_and_auth(
+        topic: impl Into<String>,
+        base_url: impl Into<String>,
+        auth: Option<NtfyAuth>,
+    ) -> Self {
         let client = reqwest::Client::builder()
             .timeout(std::time::Duration::from_secs(DEFAULT_TIMEOUT_SECS))
             .build()
@@ -65,8 +103,14 @@ impl NtfyNotifier {
         Self {
             topic: topic.into(),
             base_url: base_url.into(),
+            auth,
             client,
         }
+    }
+
+    /// `true` if this notifier is configured with auth credentials.
+    pub fn has_auth(&self) -> bool {
+        self.auth.is_some()
     }
 }
 
@@ -95,26 +139,32 @@ impl Notifier for NtfyNotifier {
             "ao-rs"
         };
 
-        let response = self
+        let mut request = self
             .client
             .post(&url)
             .header("X-Title", &payload.title)
             .header("X-Priority", ntfy_priority(payload.priority))
             .header("X-Tags", tag)
-            .body(payload.body.clone())
-            .send()
-            .await
-            .map_err(|e| {
-                if e.is_timeout() {
-                    NotifierError::Timeout {
-                        elapsed_ms: DEFAULT_TIMEOUT_SECS * 1000,
-                    }
-                } else if e.is_connect() {
-                    NotifierError::Unavailable(format!("ntfy connection failed: {e}"))
-                } else {
-                    NotifierError::Io(format!("ntfy request failed: {e}"))
+            .body(payload.body.clone());
+
+        if let Some(auth) = &self.auth {
+            request = match auth {
+                NtfyAuth::Bearer(token) => request.bearer_auth(token),
+                NtfyAuth::Basic { username, password } => request.basic_auth(username, Some(password)),
+            };
+        }
+
+        let response = request.send().await.map_err(|e| {
+            if e.is_timeout() {
+                NotifierError::Timeout {
+                    elapsed_ms: DEFAULT_TIMEOUT_SECS * 1000,
                 }
-            })?;
+            } else if e.is_connect() {
+                NotifierError::Unavailable(format!("ntfy connection failed: {e}"))
+            } else {
+                NotifierError::Io(format!("ntfy request failed: {e}"))
+            }
+        })?;
 
         let status = response.status().as_u16();
         if !response.status().is_success() {
@@ -128,7 +178,7 @@ impl Notifier for NtfyNotifier {
             });
         }
 
-        tracing::debug!(topic = %self.topic, "ntfy notification sent");
+        tracing::debug!(topic = %self.topic, authed = self.auth.is_some(), "ntfy notification sent");
         Ok(())
     }
 }
@@ -136,6 +186,21 @@ impl Notifier for NtfyNotifier {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use ao_core::{notifier::NotificationPayload, reactions::ReactionAction, types::SessionId};
+    use wiremock::matchers::{header, method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn fake_payload(escalated: bool, priority: EventPriority) -> NotificationPayload {
+        NotificationPayload {
+            session_id: SessionId("sess-test".into()),
+            reaction_key: "ci-failed".into(),
+            action: ReactionAction::Notify,
+            priority,
+            title: "CI failed".into(),
+            body: "Tests failed on main".into(),
+            escalated,
+        }
+    }
 
     #[test]
     fn name_is_ntfy() {
@@ -163,9 +228,190 @@ mod tests {
         assert_eq!(ntfy_priority(EventPriority::Info), "2");
     }
 
-    // NOTE: We do not test the actual HTTP POST here — that would
-    // require either mocking reqwest or standing up a real ntfy server.
-    // The plugin's `send` method is covered by the Phase B integration
-    // test pattern (FailNotifier / TestNotifier) at the engine level.
-    // End-to-end smoke testing against ntfy.sh is manual.
+    #[test]
+    fn has_auth_reports_configured_state() {
+        let none = NtfyNotifier::new("t");
+        assert!(!none.has_auth());
+
+        let bearer = NtfyNotifier::with_base_url_and_auth(
+            "t",
+            "http://x",
+            Some(NtfyAuth::Bearer("tk_secret".into())),
+        );
+        assert!(bearer.has_auth());
+    }
+
+    #[test]
+    fn debug_redacts_bearer_token() {
+        let a = NtfyAuth::Bearer("tk_supersecret_12345".into());
+        let rendered = format!("{a:?}");
+        assert!(!rendered.contains("supersecret"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    #[test]
+    fn debug_redacts_basic_password_but_keeps_username() {
+        let a = NtfyAuth::Basic {
+            username: "alice".into(),
+            password: "hunter2".into(),
+        };
+        let rendered = format!("{a:?}");
+        assert!(rendered.contains("alice"));
+        assert!(!rendered.contains("hunter2"));
+        assert!(rendered.contains("<redacted>"));
+    }
+
+    // --- wiremock-backed integration tests ---
+
+    #[tokio::test]
+    async fn send_posts_to_topic_with_expected_headers_and_body() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/my-topic"))
+            .and(header("X-Title", "CI failed"))
+            .and(header("X-Priority", "4"))
+            .and(header("X-Tags", "ao-rs"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let n = NtfyNotifier::with_base_url("my-topic", server.uri());
+        let payload = fake_payload(false, EventPriority::Action);
+
+        let result = n.send(&payload).await;
+        assert!(result.is_ok(), "send failed: {result:?}");
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let body = String::from_utf8_lossy(&received[0].body);
+        assert_eq!(body, "Tests failed on main");
+        assert!(
+            received[0].headers.get("authorization").is_none(),
+            "no auth header should be sent when auth is None"
+        );
+    }
+
+    #[tokio::test]
+    async fn send_tags_escalated_when_payload_is_escalated() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/t"))
+            .and(header("X-Priority", "5"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let n = NtfyNotifier::with_base_url("t", server.uri());
+        n.send(&fake_payload(true, EventPriority::Urgent))
+            .await
+            .unwrap();
+
+        let received = server.received_requests().await.unwrap();
+        assert_eq!(received.len(), 1);
+        let tags = received[0]
+            .headers
+            .get("x-tags")
+            .expect("X-Tags header should be present")
+            .to_str()
+            .unwrap();
+        assert_eq!(tags, "ao-rs,escalated");
+    }
+
+    #[tokio::test]
+    async fn send_includes_bearer_auth_header() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/t"))
+            .and(header("authorization", "Bearer tk_abc123"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let n = NtfyNotifier::with_base_url_and_auth(
+            "t",
+            server.uri(),
+            Some(NtfyAuth::Bearer("tk_abc123".into())),
+        );
+        n.send(&fake_payload(false, EventPriority::Info))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_includes_basic_auth_header() {
+        let server = MockServer::start().await;
+
+        // base64("alice:hunter2") = "YWxpY2U6aHVudGVyMg=="
+        Mock::given(method("POST"))
+            .and(path("/t"))
+            .and(header("authorization", "Basic YWxpY2U6aHVudGVyMg=="))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let n = NtfyNotifier::with_base_url_and_auth(
+            "t",
+            server.uri(),
+            Some(NtfyAuth::Basic {
+                username: "alice".into(),
+                password: "hunter2".into(),
+            }),
+        );
+        n.send(&fake_payload(false, EventPriority::Info))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_trims_trailing_slash_on_base_url() {
+        let server = MockServer::start().await;
+
+        // If base_url keeps its trailing slash, reqwest hits "//t" and the
+        // mock below (which matches the canonical "/t") will fail.
+        Mock::given(method("POST"))
+            .and(path("/t"))
+            .respond_with(ResponseTemplate::new(200))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let base_with_slash = format!("{}/", server.uri());
+        let n = NtfyNotifier::with_base_url("t", base_with_slash);
+        n.send(&fake_payload(false, EventPriority::Warning))
+            .await
+            .unwrap();
+    }
+
+    #[tokio::test]
+    async fn send_maps_non_2xx_to_service_error() {
+        let server = MockServer::start().await;
+
+        Mock::given(method("POST"))
+            .and(path("/t"))
+            .respond_with(ResponseTemplate::new(401).set_body_string("unauthorized"))
+            .mount(&server)
+            .await;
+
+        let n = NtfyNotifier::with_base_url("t", server.uri());
+        let err = n
+            .send(&fake_payload(false, EventPriority::Info))
+            .await
+            .unwrap_err();
+
+        match err {
+            NotifierError::Service { status, message } => {
+                assert_eq!(status, 401);
+                assert!(message.contains("unauthorized"), "body was {message:?}");
+            }
+            other => panic!("expected Service error, got {other:?}"),
+        }
+    }
+
 }

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -336,6 +336,9 @@ ao-rs issue show <PATH|NNNN> [--repo PATH]
 | `RUST_LOG` | Log level. Default: `warn,ao_core=info`. Set `ao_core=debug` to trace the lifecycle loop. |
 | `AO_NTFY_TOPIC` | [ntfy.sh](https://ntfy.sh) topic for push notifications. Required to activate the ntfy notifier. |
 | `AO_NTFY_URL` | Custom ntfy server URL. Default: `https://ntfy.sh`. |
+| `AO_NTFY_TOKEN` | Optional bearer access token for private ntfy servers. Sent as `Authorization: Bearer …`. |
+| `AO_NTFY_USERNAME` | Optional HTTP Basic username for private ntfy servers (requires `AO_NTFY_PASSWORD`). Ignored if `AO_NTFY_TOKEN` is set. |
+| `AO_NTFY_PASSWORD` | Optional HTTP Basic password paired with `AO_NTFY_USERNAME`. |
 | `AO_DISCORD_WEBHOOK_URL` | Discord webhook URL for the discord notifier. |
 | `AO_SLACK_WEBHOOK_URL` | Slack incoming webhook URL for the slack notifier. |
 

--- a/docs/plans/remaining-to-port/5-7-notifier-ntfy-gaps.md
+++ b/docs/plans/remaining-to-port/5-7-notifier-ntfy-gaps.md
@@ -1,6 +1,6 @@
 # 5.7 notifier-ntfy gaps
 
-Status: planned
+Status: done (#104)
 
 ## Why
 


### PR DESCRIPTION
Closes #104.

## Summary

- `NtfyAuth::Bearer` / `NtfyAuth::Basic` with a hand-written `Debug` impl that redacts the secret so tokens never leak through `tracing::debug!` or `{:?}` formatting.
- New `NtfyNotifier::with_base_url_and_auth` constructor; the existing `new` / `with_base_url` constructors stay compatible (no auth header sent).
- CLI wiring resolves auth from `notifiers.openclaw.{token_auth,username,password}` and the `notifiers.ntfy.*` fallback, plus the env vars `AO_NTFY_TOKEN`, `AO_NTFY_USERNAME`, `AO_NTFY_PASSWORD`. Bearer wins over Basic when both are set.
- Docs: `docs/cli-reference.md` lists the new env vars; plan doc marked done.

## Test plan

- [x] `cargo t -p ao-plugin-notifier-ntfy` — 13 tests pass (priority mapping, redaction, URL/header/body, Bearer, Basic, trailing-slash trim, non-2xx → `NotifierError::Service`).
- [x] `cargo t -p ao-cli cli::lifecycle_wiring` — 4 tests pass (bearer-over-basic precedence, empty-input handling).
- [x] `cargo t --workspace` — 721/721 pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

## Risks / notes

- Auth is opt-in; public ntfy.sh topics keep working with zero config changes.
- Secrets redacted in `Debug`; the only tracing line logs `topic` and a boolean `authed`, never the credential.

🤖 Generated with [Claude Code](https://claude.com/claude-code)