### PR TITLE
feat(scm-gitlab): port ao-ts parity surface (#103)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,6 +333,8 @@ dependencies = [
  "reqwest 0.12.28",
  "serde",
  "serde_json",
+ "serde_yaml",
+ "sha2",
  "tokio",
  "tracing",
  "urlencoding",

--- a/crates/plugins/scm-gitlab/Cargo.toml
+++ b/crates/plugins/scm-gitlab/Cargo.toml
@@ -14,6 +14,8 @@ serde_json = { workspace = true }
 tracing = { workspace = true }
 reqwest = { version = "0.12", default-features = false, features = ["rustls-tls", "json"] }
 urlencoding = "2"
+sha2 = "0.10"
 
 [dev-dependencies]
 wiremock = "0.6"
+serde_yaml = { workspace = true }

--- a/crates/plugins/scm-gitlab/src/lib.rs
+++ b/crates/plugins/scm-gitlab/src/lib.rs
@@ -1,11 +1,28 @@
 //! GitLab SCM plugin — GitLab Merge Requests via the GitLab REST API.
 //!
-//! Unlike `ao-plugin-scm-github` (which shells out to `gh`), this plugin uses
-//! HTTPS so we can test it with recorded fixtures (no real network).
+//! Behaviour parity target: `packages/plugins/scm-gitlab/src/index.ts` in
+//! ao-ts. Transport differs by design: ao-ts shells out to `glab`; we use
+//! HTTPS directly so we can hermetic-test the parser/plugin end-to-end with
+//! wiremock fixtures. See `docs/issues/0103-scm-gitlab-parity.md` for the
+//! parity matrix.
+//!
+//! ## Auth
+//!
+//! Reads `GITLAB_TOKEN` (or `GITLAB_PRIVATE_TOKEN` / `PRIVATE_TOKEN`) from
+//! the environment and sends it as `PRIVATE-TOKEN` — the same header `glab`
+//! uses, so both plugins accept the same tokens.
+//!
+//! ## Self-hosted GitLab
+//!
+//! The plugin derives `base_url` from the git remote (`https://gitlab.corp/…`
+//! or `git@gitlab.corp:…`) so GitLab Cloud and self-hosted instances work
+//! the same way. Tests pass an explicit base URL via
+//! `GitLabScm::with_base_url_and_token`.
 
 use ao_core::{
-    AoError, CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest, Result, Review,
-    ReviewComment, ReviewDecision, Scm, Session,
+    config::ProjectConfig, AoError, AutomatedComment, CheckRun, CiStatus, MergeMethod,
+    MergeReadiness, PrState, PrSummary, PullRequest, Result, Review, ReviewComment, ReviewDecision,
+    Scm, ScmWebhookEvent, ScmWebhookRequest, ScmWebhookVerificationResult, Session,
 };
 use async_trait::async_trait;
 use reqwest::header::{HeaderMap, HeaderValue};
@@ -14,6 +31,7 @@ use std::time::Duration;
 use tokio::process::Command;
 
 pub(crate) mod parse;
+pub(crate) mod webhook;
 
 const HTTP_TIMEOUT: Duration = Duration::from_secs(30);
 
@@ -108,21 +126,82 @@ impl Scm for GitLabScm {
         Ok(parse::map_pr_state(mr.state.as_deref().unwrap_or("")))
     }
 
-    async fn ci_checks(&self, pr: &PullRequest) -> Result<Vec<CheckRun>> {
+    async fn pr_summary(&self, pr: &PullRequest) -> Result<PrSummary> {
+        // Parity with ao-ts: additions/deletions come back as 0 because the
+        // GitLab MR view doesn't expose per-line counts; callers that want
+        // real diff stats should call out separately. This keeps the signature
+        // identical so dashboards get a usable title + state.
         let api = self.api_from_pr(pr)?;
         let mr = api.get_merge_request(&project_path(pr), pr.number).await?;
-        Ok(parse::extract_ci_checks(&mr))
+        Ok(PrSummary {
+            state: parse::map_pr_state(mr.state.as_deref().unwrap_or("")),
+            title: mr.title.unwrap_or_default(),
+            additions: 0,
+            deletions: 0,
+        })
+    }
+
+    async fn ci_checks(&self, pr: &PullRequest) -> Result<Vec<CheckRun>> {
+        let api = self.api_from_pr(pr)?;
+        match api.list_mr_pipelines(&project_path(pr), pr.number).await {
+            Ok(pipelines) => {
+                let Some(latest) = pipelines.first() else {
+                    return Ok(Vec::new());
+                };
+                let jobs = api
+                    .list_pipeline_jobs(&project_path(pr), latest.id)
+                    .await?;
+                Ok(parse::jobs_into_check_runs(jobs))
+            }
+            Err(e) => Err(AoError::Scm(format!("Failed to fetch CI checks: {e}"))),
+        }
     }
 
     async fn ci_status(&self, pr: &PullRequest) -> Result<CiStatus> {
-        let checks = self.ci_checks(pr).await?;
-        Ok(parse::summarize_ci(&checks))
+        // Parity with ao-ts `getCISummary`: on CI fetch failure, fall back to
+        // "none" when the PR is already merged/closed (common once CI history
+        // has been pruned). Any other failure bubbles "failing" so the
+        // reaction engine treats it conservatively.
+        match self.ci_checks(pr).await {
+            Ok(checks) => Ok(parse::summarize_ci(&checks)),
+            Err(ci_err) => match self.pr_state(pr).await {
+                Ok(PrState::Merged) | Ok(PrState::Closed) => {
+                    tracing::debug!(
+                        "ci_status: CI fetch failed for MR !{}, PR state fallback says closed/merged: {ci_err}",
+                        pr.number
+                    );
+                    Ok(CiStatus::None)
+                }
+                _ => {
+                    tracing::debug!("ci_status: CI fetch failed for MR !{}: {ci_err}", pr.number);
+                    Ok(CiStatus::Failing)
+                }
+            },
+        }
     }
 
     async fn reviews(&self, pr: &PullRequest) -> Result<Vec<Review>> {
         let api = self.api_from_pr(pr)?;
         let approvals = api.get_approvals(&project_path(pr), pr.number).await?;
-        Ok(parse::approvals_into_reviews(approvals))
+        let mut reviews = parse::approvals_into_reviews(&approvals);
+        let approvers = parse::approver_usernames(&approvals);
+        // Discussions can fail independently (rate limits, auth on older
+        // GitLab versions); match ao-ts by logging and returning approvals
+        // alone rather than erroring the reactions-engine tick.
+        match api
+            .list_all_discussions(&project_path(pr), pr.number)
+            .await
+        {
+            Ok(discussions) => reviews.extend(parse::synthesise_changes_requested_reviews(
+                &discussions,
+                &approvers,
+            )),
+            Err(e) => tracing::warn!(
+                "reviews: discussions fetch failed for MR !{}: {e}",
+                pr.number
+            ),
+        }
+        Ok(reviews)
     }
 
     async fn review_decision(&self, pr: &PullRequest) -> Result<ReviewDecision> {
@@ -139,10 +218,19 @@ impl Scm for GitLabScm {
         Ok(parse::extract_pending_comments(&discussions, &pr.url))
     }
 
+    async fn automated_comments(&self, pr: &PullRequest) -> Result<Vec<AutomatedComment>> {
+        let api = self.api_from_pr(pr)?;
+        let discussions = api
+            .list_all_discussions(&project_path(pr), pr.number)
+            .await?;
+        Ok(parse::extract_automated_comments(&discussions, &pr.url))
+    }
+
     async fn mergeability(&self, pr: &PullRequest) -> Result<MergeReadiness> {
         let api = self.api_from_pr(pr)?;
-
-        if matches!(self.pr_state(pr).await?, PrState::Merged) {
+        let mr = api.get_merge_request(&project_path(pr), pr.number).await?;
+        let state = parse::map_pr_state(mr.state.as_deref().unwrap_or(""));
+        if matches!(state, PrState::Merged) {
             return Ok(MergeReadiness {
                 mergeable: true,
                 ci_passing: true,
@@ -151,8 +239,16 @@ impl Scm for GitLabScm {
                 blockers: Vec::new(),
             });
         }
+        if matches!(state, PrState::Closed) {
+            return Ok(MergeReadiness {
+                mergeable: false,
+                ci_passing: false,
+                approved: false,
+                no_conflicts: true,
+                blockers: vec!["MR is closed".into()],
+            });
+        }
 
-        let mr = api.get_merge_request(&project_path(pr), pr.number).await?;
         let approvals = api.get_approvals(&project_path(pr), pr.number).await?;
         let ci_status = self.ci_status(pr).await?;
         Ok(compose_merge_readiness(&mr, &approvals, ci_status))
@@ -160,10 +256,29 @@ impl Scm for GitLabScm {
 
     async fn merge(&self, pr: &PullRequest, method: Option<MergeMethod>) -> Result<()> {
         let api = self.api_from_pr(pr)?;
-        let squash = matches!(method.unwrap_or_default(), MergeMethod::Squash);
-        api.merge_merge_request(&project_path(pr), pr.number, squash)
-            .await?;
-        Ok(())
+        api.merge_merge_request(&project_path(pr), pr.number, method.unwrap_or_default())
+            .await
+    }
+
+    async fn close_pr(&self, pr: &PullRequest) -> Result<()> {
+        let api = self.api_from_pr(pr)?;
+        api.close_merge_request(&project_path(pr), pr.number).await
+    }
+
+    async fn verify_webhook(
+        &self,
+        request: &ScmWebhookRequest,
+        project: &ProjectConfig,
+    ) -> Result<ScmWebhookVerificationResult> {
+        webhook::verify(request, project).await
+    }
+
+    async fn parse_webhook(
+        &self,
+        request: &ScmWebhookRequest,
+        project: &ProjectConfig,
+    ) -> Result<Option<ScmWebhookEvent>> {
+        webhook::parse(request, project)
     }
 }
 
@@ -184,38 +299,45 @@ pub(crate) fn compose_merge_readiness(
         blockers.push(format!("CI is {}", ci_status_label(ci_status)));
     }
 
-    // Reviews / approvals
+    // Reviews / approvals (parity with ao-ts: only "pending" adds a blocker).
     let decision = parse::review_decision_from_approvals(approvals);
-    let approved = matches!(decision, ReviewDecision::Approved | ReviewDecision::None);
-    match decision {
-        ReviewDecision::ChangesRequested => blockers.push("Changes requested in review".into()),
-        ReviewDecision::Pending => blockers.push("Review required".into()),
+    let approved = matches!(decision, ReviewDecision::Approved);
+    if matches!(decision, ReviewDecision::Pending) {
+        blockers.push("Approval required".into());
+    }
+
+    // Conflicts — check before merge_status so the more specific message wins.
+    let has_conflicts = mr.has_conflicts.unwrap_or(false);
+    let no_conflicts = !has_conflicts;
+    if has_conflicts {
+        blockers.push("Merge conflicts".into());
+    }
+
+    // GitLab's merge_status narrows why the branch can't merge when the
+    // conflict check doesn't already explain it.
+    let merge_status = mr.merge_status.as_deref().unwrap_or("").to_ascii_lowercase();
+    match merge_status.as_str() {
+        "cannot_be_merged" if no_conflicts => {
+            blockers.push("Merge status: cannot be merged".into());
+        }
+        "checking" => blockers.push("Merge status unknown (GitLab is computing)".into()),
         _ => {}
     }
 
-    // Draft
+    // Unresolved blocking discussions (parity with ao-ts).
+    if mr
+        .blocking_discussions_resolved
+        .map(|b| !b)
+        .unwrap_or(false)
+    {
+        blockers.push("Unresolved discussions blocking merge".into());
+    }
+
+    // Draft MRs never merge cleanly.
     if mr.is_draft() {
         blockers.push("MR is still a draft".into());
     }
 
-    // Conflicts / merge status
-    let no_conflicts = !mr.has_conflicts.unwrap_or(false);
-    if mr.has_conflicts.unwrap_or(false) {
-        blockers.push("Merge conflicts".into());
-    }
-    match mr
-        .merge_status
-        .as_deref()
-        .unwrap_or("")
-        .to_ascii_lowercase()
-        .as_str()
-    {
-        "cannot_be_merged" => blockers.push("Merge is blocked".into()),
-        "checking" | "" => blockers.push("Merge status unknown (GitLab is computing)".into()),
-        _ => {}
-    }
-
-    // Mergeable is the conjunction of our blockers.
     MergeReadiness {
         mergeable: blockers.is_empty(),
         ci_passing,
@@ -268,6 +390,29 @@ impl<'a> GitLabApi<'a> {
         Ok(h)
     }
 
+    async fn get_text(&self, url: String, ctx: &str) -> Result<String> {
+        let resp = self
+            .client
+            .get(url)
+            .headers(self.headers()?)
+            .send()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab {ctx} failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab {ctx} read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Scm(format!(
+                "gitlab {ctx} failed: http {}: {}",
+                status.as_u16(),
+                body.trim()
+            )));
+        }
+        Ok(body)
+    }
+
     async fn list_open_merge_requests_by_source_branch(
         &self,
         project_path: &str,
@@ -280,25 +425,7 @@ impl<'a> GitLabApi<'a> {
             encoded,
             urlencoding::encode(branch)
         );
-        let resp = self
-            .client
-            .get(url)
-            .headers(self.headers()?)
-            .send()
-            .await
-            .map_err(|e| AoError::Scm(format!("gitlab mr list failed: {e}")))?;
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| AoError::Scm(format!("gitlab mr list read failed: {e}")))?;
-        if !status.is_success() {
-            return Err(AoError::Scm(format!(
-                "gitlab mr list failed: http {}: {}",
-                status.as_u16(),
-                body.trim()
-            )));
-        }
+        let body = self.get_text(url, "mr list").await?;
         parse::parse_mr_list(&body)
     }
 
@@ -310,26 +437,40 @@ impl<'a> GitLabApi<'a> {
             encoded,
             iid
         );
-        let resp = self
-            .client
-            .get(url)
-            .headers(self.headers()?)
-            .send()
-            .await
-            .map_err(|e| AoError::Scm(format!("gitlab mr view failed: {e}")))?;
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| AoError::Scm(format!("gitlab mr view read failed: {e}")))?;
-        if !status.is_success() {
-            return Err(AoError::Scm(format!(
-                "gitlab mr view failed: http {}: {}",
-                status.as_u16(),
-                body.trim()
-            )));
-        }
+        let body = self.get_text(url, "mr view").await?;
         parse::parse_mr_view(&body)
+    }
+
+    async fn list_mr_pipelines(
+        &self,
+        project_path: &str,
+        iid: u32,
+    ) -> Result<Vec<parse::Pipeline>> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}/pipelines",
+            self.api_base(),
+            encoded,
+            iid
+        );
+        let body = self.get_text(url, "pipelines").await?;
+        parse::parse_pipelines(&body)
+    }
+
+    async fn list_pipeline_jobs(
+        &self,
+        project_path: &str,
+        pipeline_id: u64,
+    ) -> Result<Vec<parse::Job>> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/pipelines/{}/jobs",
+            self.api_base(),
+            encoded,
+            pipeline_id
+        );
+        let body = self.get_text(url, "pipeline jobs").await?;
+        parse::parse_jobs(&body)
     }
 
     async fn get_approvals(&self, project_path: &str, iid: u32) -> Result<parse::Approvals> {
@@ -340,25 +481,7 @@ impl<'a> GitLabApi<'a> {
             encoded,
             iid
         );
-        let resp = self
-            .client
-            .get(url)
-            .headers(self.headers()?)
-            .send()
-            .await
-            .map_err(|e| AoError::Scm(format!("gitlab approvals failed: {e}")))?;
-        let status = resp.status();
-        let body = resp
-            .text()
-            .await
-            .map_err(|e| AoError::Scm(format!("gitlab approvals read failed: {e}")))?;
-        if !status.is_success() {
-            return Err(AoError::Scm(format!(
-                "gitlab approvals failed: http {}: {}",
-                status.as_u16(),
-                body.trim()
-            )));
-        }
+        let body = self.get_text(url, "approvals").await?;
         parse::parse_approvals(&body)
     }
 
@@ -379,25 +502,7 @@ impl<'a> GitLabApi<'a> {
                 encoded,
                 iid
             );
-            let resp = self
-                .client
-                .get(url)
-                .headers(self.headers()?)
-                .send()
-                .await
-                .map_err(|e| AoError::Scm(format!("gitlab discussions failed: {e}")))?;
-            let status = resp.status();
-            let body = resp
-                .text()
-                .await
-                .map_err(|e| AoError::Scm(format!("gitlab discussions read failed: {e}")))?;
-            if !status.is_success() {
-                return Err(AoError::Scm(format!(
-                    "gitlab discussions failed: http {}: {}",
-                    status.as_u16(),
-                    body.trim()
-                )));
-            }
+            let body = self.get_text(url, "discussions").await?;
             let page_items = parse::parse_discussions(&body)?;
             let got = page_items.len();
             all.extend(page_items);
@@ -408,7 +513,12 @@ impl<'a> GitLabApi<'a> {
         Ok(all)
     }
 
-    async fn merge_merge_request(&self, project_path: &str, iid: u32, squash: bool) -> Result<()> {
+    async fn merge_merge_request(
+        &self,
+        project_path: &str,
+        iid: u32,
+        method: MergeMethod,
+    ) -> Result<()> {
         let encoded = urlencoding::encode(project_path);
         let url = format!(
             "{}/projects/{}/merge_requests/{}/merge",
@@ -416,6 +526,36 @@ impl<'a> GitLabApi<'a> {
             encoded,
             iid
         );
+        // GitLab MR merge accepts `squash` + `should_remove_source_branch`;
+        // rebase is a separate endpoint (`/merge_requests/:id/rebase`). The TS
+        // reference runs `glab mr merge --rebase` which rebases then merges in
+        // one shot — we approximate by calling `/rebase` first when asked.
+        if matches!(method, MergeMethod::Rebase) {
+            let rebase_url = format!(
+                "{}/projects/{}/merge_requests/{}/rebase",
+                self.api_base(),
+                encoded,
+                iid
+            );
+            let resp = self
+                .client
+                .put(rebase_url)
+                .headers(self.headers()?)
+                .send()
+                .await
+                .map_err(|e| AoError::Scm(format!("gitlab rebase failed: {e}")))?;
+            let status = resp.status();
+            if !status.is_success() {
+                let body = resp.text().await.unwrap_or_default();
+                return Err(AoError::Scm(format!(
+                    "gitlab rebase failed: http {}: {}",
+                    status.as_u16(),
+                    body.trim()
+                )));
+            }
+        }
+
+        let squash = matches!(method, MergeMethod::Squash);
         let resp = self
             .client
             .put(url)
@@ -435,6 +575,37 @@ impl<'a> GitLabApi<'a> {
         if !status.is_success() {
             return Err(AoError::Scm(format!(
                 "gitlab merge failed: http {}: {}",
+                status.as_u16(),
+                body.trim()
+            )));
+        }
+        Ok(())
+    }
+
+    async fn close_merge_request(&self, project_path: &str, iid: u32) -> Result<()> {
+        let encoded = urlencoding::encode(project_path);
+        let url = format!(
+            "{}/projects/{}/merge_requests/{}",
+            self.api_base(),
+            encoded,
+            iid
+        );
+        let resp = self
+            .client
+            .put(url)
+            .headers(self.headers()?)
+            .json(&serde_json::json!({ "state_event": "close" }))
+            .send()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab close failed: {e}")))?;
+        let status = resp.status();
+        let body = resp
+            .text()
+            .await
+            .map_err(|e| AoError::Scm(format!("gitlab close read failed: {e}")))?;
+        if !status.is_success() {
+            return Err(AoError::Scm(format!(
+                "gitlab close failed: http {}: {}",
                 status.as_u16(),
                 body.trim()
             )));
@@ -609,6 +780,19 @@ mod tests {
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
 
+    fn make_pr() -> PullRequest {
+        PullRequest {
+            number: 42,
+            url: "https://gitlab.example.com/acme/widgets/-/merge_requests/42".into(),
+            title: "feat: add feature".into(),
+            owner: "acme".into(),
+            repo: "widgets".into(),
+            branch: "feat/x".into(),
+            base_branch: "main".into(),
+            is_draft: false,
+        }
+    }
+
     #[test]
     fn parse_gitlab_remote_accepts_https_and_ssh_and_nested_groups() {
         let o = parse_gitlab_remote("https://gitlab.com/acme/sub/widgets.git").unwrap();
@@ -657,6 +841,312 @@ mod tests {
         assert_eq!(got[0].iid, Some(7));
     }
 
+    #[tokio::test]
+    async fn ci_checks_fans_out_pipelines_then_jobs() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/pipelines",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"[{"id":100},{"id":99}]"#),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/pipelines/100/jobs",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {"name":"build","status":"success","web_url":"https://ci/1"},
+                    {"name":"lint","status":"failed","web_url":""},
+                    {"name":"deploy","status":"running"}
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let checks = scm.ci_checks(&make_pr()).await.unwrap();
+        assert_eq!(checks.len(), 3);
+        assert_eq!(checks[0].name, "build");
+        assert_eq!(checks[0].url.as_deref(), Some("https://ci/1"));
+        assert_eq!(checks[1].name, "lint");
+        assert!(checks[1].url.is_none());
+        assert_eq!(checks[2].name, "deploy");
+    }
+
+    #[tokio::test]
+    async fn ci_checks_empty_when_no_pipelines() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/pipelines",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("[]"))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let checks = scm.ci_checks(&make_pr()).await.unwrap();
+        assert!(checks.is_empty());
+    }
+
+    #[tokio::test]
+    async fn ci_status_falls_back_to_none_when_merged_and_fetch_fails() {
+        let server = MockServer::start().await;
+        // Pipelines endpoint 500s → ci_checks errors.
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/pipelines",
+            ))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        // MR view returns "merged" → fallback sets status to None.
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"state":"merged"}"#))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        assert_eq!(scm.ci_status(&make_pr()).await.unwrap(), CiStatus::None);
+    }
+
+    #[tokio::test]
+    async fn ci_status_is_failing_when_both_fetches_fail() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/pipelines",
+            ))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(ResponseTemplate::new(500))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        assert_eq!(scm.ci_status(&make_pr()).await.unwrap(), CiStatus::Failing);
+    }
+
+    #[tokio::test]
+    async fn mergeability_returns_merged_clean() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"state":"merged"}"#))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let r = scm.mergeability(&make_pr()).await.unwrap();
+        assert!(r.mergeable);
+        assert!(r.blockers.is_empty());
+    }
+
+    #[tokio::test]
+    async fn mergeability_closed_returns_blocker() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(r#"{"state":"closed"}"#))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let r = scm.mergeability(&make_pr()).await.unwrap();
+        assert!(!r.mergeable);
+        assert!(r.blockers.iter().any(|b| b == "MR is closed"));
+    }
+
+    #[tokio::test]
+    async fn mergeability_reports_draft_and_conflicts_and_unresolved_discussions() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{
+                    "state":"opened",
+                    "draft":true,
+                    "has_conflicts":true,
+                    "merge_status":"cannot_be_merged",
+                    "blocking_discussions_resolved":false
+                }"#,
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/approvals",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"approved":false,"approvals_required":1,"approvals_left":1}"#),
+            )
+            .mount(&server)
+            .await;
+        // ci_status → need pipelines + jobs; return empty pipelines so CI = None.
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/pipelines",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("[]"))
+            .mount(&server)
+            .await;
+
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let r = scm.mergeability(&make_pr()).await.unwrap();
+        assert!(!r.mergeable);
+        // Conflicts + draft + unresolved discussions + approval required.
+        assert!(r.blockers.iter().any(|b| b == "Merge conflicts"));
+        assert!(r.blockers.iter().any(|b| b == "MR is still a draft"));
+        assert!(r
+            .blockers
+            .iter()
+            .any(|b| b == "Unresolved discussions blocking merge"));
+        assert!(r.blockers.iter().any(|b| b == "Approval required"));
+    }
+
+    #[tokio::test]
+    async fn close_pr_sends_state_event_close() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        scm.close_pr(&make_pr()).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn merge_honours_squash_method() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/merge",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        scm.merge(&make_pr(), Some(MergeMethod::Squash)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn merge_rebase_hits_rebase_then_merge_endpoints() {
+        let server = MockServer::start().await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/rebase",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+        Mock::given(method("PUT"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/merge",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string("{}"))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        scm.merge(&make_pr(), Some(MergeMethod::Rebase)).await.unwrap();
+    }
+
+    #[tokio::test]
+    async fn pr_summary_returns_state_title_zero_diff() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_string(r#"{"state":"opened","title":"feat: add feature"}"#),
+            )
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let summary = scm.pr_summary(&make_pr()).await.unwrap();
+        assert_eq!(summary.state, PrState::Open);
+        assert_eq!(summary.title, "feat: add feature");
+        assert_eq!(summary.additions, 0);
+        assert_eq!(summary.deletions, 0);
+    }
+
+    #[tokio::test]
+    async fn reviews_merges_approvals_and_unresolved_discussions() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/approvals",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"{"approved":false,"approvals_required":1,"approvals_left":1,"approved_by":[{"user":{"username":"alice"}}]}"#,
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/discussions",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {"notes":[{"id":1,"author":{"username":"bob"},"body":"needs work","resolvable":true,"resolved":false}]},
+                    {"notes":[{"id":2,"author":{"username":"alice"},"body":"drift","resolvable":true,"resolved":false}]}
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let reviews = scm.reviews(&make_pr()).await.unwrap();
+        assert_eq!(reviews.len(), 2);
+        assert_eq!(reviews[0].author, "alice");
+        assert_eq!(reviews[0].state, ao_core::ReviewState::Approved);
+        assert_eq!(reviews[1].author, "bob");
+        assert_eq!(reviews[1].state, ao_core::ReviewState::ChangesRequested);
+    }
+
+    #[tokio::test]
+    async fn automated_comments_returns_bot_notes_only() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v4/projects/acme%2Fwidgets/merge_requests/42/discussions",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_string(
+                r#"[
+                    {"notes":[{"id":1,"author":{"username":"gitlab-bot"},"body":"found a critical error","resolvable":true,"resolved":false}]},
+                    {"notes":[{"id":2,"author":{"username":"alice"},"body":"lgtm","resolvable":true,"resolved":false}]}
+                ]"#,
+            ))
+            .mount(&server)
+            .await;
+        let scm = GitLabScm::with_base_url_and_token(server.uri(), "t");
+        let comments = scm.automated_comments(&make_pr()).await.unwrap();
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].bot_name, "gitlab-bot");
+        assert_eq!(
+            comments[0].severity,
+            ao_core::AutomatedCommentSeverity::Error
+        );
+    }
+
     #[test]
     fn compose_merge_readiness_blocks_on_ci_and_conflicts_and_review_required() {
         let mr = parse::MergeRequest {
@@ -670,17 +1160,68 @@ mod tests {
             work_in_progress: Some(false),
             merge_status: Some("cannot_be_merged".into()),
             has_conflicts: Some(true),
-            head_pipeline: None,
+            blocking_discussions_resolved: Some(true),
         };
         let approvals = parse::Approvals {
-            approvals_required: Some(1),
+            approved: Some(false),
             approvals_left: Some(1),
             approved_by: vec![],
         };
         let r = compose_merge_readiness(&mr, &approvals, CiStatus::Failing);
         assert!(!r.is_ready());
         assert!(r.blockers.iter().any(|b| b.contains("CI is failing")));
-        assert!(r.blockers.iter().any(|b| b.contains("Review required")));
+        assert!(r.blockers.iter().any(|b| b.contains("Approval required")));
         assert!(r.blockers.iter().any(|b| b.contains("Merge conflicts")));
+    }
+
+    #[test]
+    fn compose_merge_readiness_clean_when_gates_pass() {
+        let mr = parse::MergeRequest {
+            iid: Some(1),
+            web_url: None,
+            title: Some("feat".into()),
+            source_branch: Some("feat/x".into()),
+            target_branch: Some("main".into()),
+            state: Some("opened".into()),
+            draft: Some(false),
+            work_in_progress: Some(false),
+            merge_status: Some("can_be_merged".into()),
+            has_conflicts: Some(false),
+            blocking_discussions_resolved: Some(true),
+        };
+        let approvals = parse::Approvals {
+            approved: Some(true),
+            approvals_left: Some(0),
+            approved_by: vec![],
+        };
+        let r = compose_merge_readiness(&mr, &approvals, CiStatus::Passing);
+        assert!(r.is_ready());
+    }
+
+    #[test]
+    fn compose_merge_readiness_checking_status_is_blocker() {
+        let mr = parse::MergeRequest {
+            iid: Some(1),
+            web_url: None,
+            title: Some("feat".into()),
+            source_branch: Some("feat/x".into()),
+            target_branch: Some("main".into()),
+            state: Some("opened".into()),
+            draft: Some(false),
+            work_in_progress: Some(false),
+            merge_status: Some("checking".into()),
+            has_conflicts: Some(false),
+            blocking_discussions_resolved: Some(true),
+        };
+        let approvals = parse::Approvals {
+            approved: Some(true),
+            approvals_left: Some(0),
+            approved_by: vec![],
+        };
+        let r = compose_merge_readiness(&mr, &approvals, CiStatus::Passing);
+        assert!(r
+            .blockers
+            .iter()
+            .any(|b| b.contains("GitLab is computing")));
     }
 }

--- a/crates/plugins/scm-gitlab/src/parse.rs
+++ b/crates/plugins/scm-gitlab/src/parse.rs
@@ -1,10 +1,40 @@
 //! Pure JSON → domain-type parsers for the GitLab SCM plugin.
 
 use ao_core::{
-    AoError, CheckRun, CheckStatus, CiStatus, PrState, PullRequest, Result, Review, ReviewComment,
-    ReviewDecision, ReviewState,
+    AoError, AutomatedComment, AutomatedCommentSeverity, CheckRun, CheckStatus, CiStatus, PrState,
+    PullRequest, Result, Review, ReviewComment, ReviewDecision, ReviewState,
 };
 use serde::Deserialize;
+
+/// GitLab-specific bot usernames whose comments should be surfaced as
+/// `AutomatedComment`s rather than human review feedback. Mirrors the
+/// `BOT_AUTHORS` set in `packages/plugins/scm-gitlab/src/index.ts`.
+const BOT_AUTHORS: &[&str] = &[
+    "gitlab-bot",
+    "ghost",
+    "dependabot[bot]",
+    "renovate[bot]",
+    "sast-bot",
+    "codeclimate[bot]",
+    "sonarcloud[bot]",
+    "snyk-bot",
+];
+
+pub(crate) fn is_bot(username: &str) -> bool {
+    if BOT_AUTHORS.contains(&username) {
+        return true;
+    }
+    if username.ends_with("[bot]") {
+        return true;
+    }
+    // GitLab project bot convention: `project_<N>_bot`.
+    if let Some(rest) = username.strip_prefix("project_") {
+        if let Some(tail) = rest.strip_suffix("_bot") {
+            return !tail.is_empty() && tail.chars().all(|c| c.is_ascii_digit());
+        }
+    }
+    false
+}
 
 fn bad(msg: impl Into<String>, err: impl std::fmt::Display) -> AoError {
     AoError::Scm(format!("{}: {}", msg.into(), err))
@@ -38,15 +68,7 @@ pub(crate) struct MergeRequest {
     #[serde(default)]
     pub has_conflicts: Option<bool>,
     #[serde(default)]
-    pub head_pipeline: Option<HeadPipeline>,
-}
-
-#[derive(Debug, Clone, Deserialize)]
-pub(crate) struct HeadPipeline {
-    #[serde(default)]
-    pub status: Option<String>,
-    #[serde(default)]
-    pub web_url: Option<String>,
+    pub blocking_discussions_resolved: Option<bool>,
 }
 
 impl MergeRequest {
@@ -97,42 +119,66 @@ pub(crate) fn map_pr_state(raw: &str) -> PrState {
 }
 
 // ---------------------------------------------------------------------------
-// CI (head pipeline)
+// CI: pipelines + jobs (ao-ts parity shape)
 // ---------------------------------------------------------------------------
 
-pub(crate) fn extract_ci_checks(mr: &MergeRequest) -> Vec<CheckRun> {
-    let Some(p) = mr.head_pipeline.as_ref() else {
-        return Vec::new();
-    };
-    let status_raw = p.status.as_deref().unwrap_or("").to_string();
-    let status = map_pipeline_status(&status_raw);
-    let url = p.web_url.clone().filter(|s| !s.is_empty());
-    let conclusion = if status_raw.trim().is_empty() {
-        None
-    } else {
-        Some(status_raw)
-    };
-    vec![CheckRun {
-        name: "pipeline".into(),
-        status,
-        url,
-        conclusion,
-    }]
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Pipeline {
+    #[serde(default)]
+    pub id: u64,
 }
 
-fn map_pipeline_status(raw: &str) -> CheckStatus {
+#[derive(Debug, Clone, Deserialize)]
+pub(crate) struct Job {
+    #[serde(default)]
+    pub name: String,
+    #[serde(default)]
+    pub status: String,
+    #[serde(default)]
+    pub web_url: Option<String>,
+}
+
+pub(crate) fn parse_pipelines(json: &str) -> Result<Vec<Pipeline>> {
+    serde_json::from_str(json).map_err(|e| bad("parse pipelines", e))
+}
+
+pub(crate) fn parse_jobs(json: &str) -> Result<Vec<Job>> {
+    serde_json::from_str(json).map_err(|e| bad("parse jobs", e))
+}
+
+pub(crate) fn jobs_into_check_runs(jobs: Vec<Job>) -> Vec<CheckRun> {
+    jobs.into_iter()
+        .map(|j| {
+            let status = map_job_status(&j.status);
+            let url = j.web_url.filter(|s| !s.is_empty());
+            let conclusion = if j.status.trim().is_empty() {
+                None
+            } else {
+                Some(j.status)
+            };
+            CheckRun {
+                name: j.name,
+                status,
+                url,
+                conclusion,
+            }
+        })
+        .collect()
+}
+
+/// Map a GitLab job status to the normalised `CheckStatus`. Mirrors
+/// `mapJobStatus` in the TS plugin — unknown statuses fall through to
+/// `Failed` (fail-closed) so we never hide a broken pipeline.
+pub(crate) fn map_job_status(raw: &str) -> CheckStatus {
     match raw.trim().to_ascii_lowercase().as_str() {
+        "pending" | "waiting_for_resource" | "preparing" | "created" | "scheduled" | "manual" => {
+            CheckStatus::Pending
+        }
         "running" => CheckStatus::Running,
-        "pending" => CheckStatus::Pending,
-        "created" => CheckStatus::Pending,
-        "waiting_for_resource" => CheckStatus::Pending,
-        "preparing" => CheckStatus::Pending,
-        "manual" => CheckStatus::Pending,
-        "scheduled" => CheckStatus::Pending,
         "success" => CheckStatus::Passed,
         "failed" | "canceled" | "cancelled" => CheckStatus::Failed,
         "skipped" => CheckStatus::Skipped,
-        _ => CheckStatus::Skipped,
+        _ => CheckStatus::Failed,
     }
 }
 
@@ -162,7 +208,7 @@ pub(crate) fn summarize_ci(checks: &[CheckRun]) -> CiStatus {
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct Approvals {
     #[serde(default)]
-    pub approvals_required: Option<u32>,
+    pub approved: Option<bool>,
     #[serde(default)]
     pub approvals_left: Option<u32>,
     #[serde(default)]
@@ -187,13 +233,28 @@ pub(crate) fn parse_approvals(json: &str) -> Result<Approvals> {
     serde_json::from_str(json).map_err(|e| bad("parse approvals", e))
 }
 
-pub(crate) fn approvals_into_reviews(a: Approvals) -> Vec<Review> {
+/// Collect approver usernames (bots *included* so we don't double-count bot
+/// approvals as changes-requested below).
+pub(crate) fn approver_usernames(a: &Approvals) -> Vec<String> {
     a.approved_by
-        .into_iter()
+        .iter()
+        .filter_map(|ab| {
+            ab.user
+                .as_ref()
+                .and_then(|u| u.username.clone().or_else(|| u.name.clone()))
+        })
+        .filter(|s| !s.is_empty())
+        .collect()
+}
+
+pub(crate) fn approvals_into_reviews(a: &Approvals) -> Vec<Review> {
+    a.approved_by
+        .iter()
         .map(|ab| {
             let author = ab
                 .user
-                .and_then(|u| u.username.or(u.name))
+                .as_ref()
+                .and_then(|u| u.username.clone().or_else(|| u.name.clone()))
                 .filter(|s| !s.is_empty())
                 .unwrap_or_else(|| "unknown".to_string());
             Review {
@@ -206,20 +267,19 @@ pub(crate) fn approvals_into_reviews(a: Approvals) -> Vec<Review> {
 }
 
 pub(crate) fn review_decision_from_approvals(a: &Approvals) -> ReviewDecision {
-    let required = a.approvals_required.unwrap_or(0);
-    if required == 0 {
-        return ReviewDecision::None;
+    if a.approved.unwrap_or(false) {
+        return ReviewDecision::Approved;
     }
-    let left = a.approvals_left.unwrap_or(required);
-    if left == 0 {
-        ReviewDecision::Approved
-    } else {
-        ReviewDecision::Pending
+    let left = a.approvals_left.unwrap_or(0);
+    if left > 0 {
+        return ReviewDecision::Pending;
     }
+    // `approved` is false but no approvals are required — treat as "no gate".
+    ReviewDecision::None
 }
 
 // ---------------------------------------------------------------------------
-// Discussions → pending comments
+// Discussions → pending comments + synthesised "changes_requested" reviews
 // ---------------------------------------------------------------------------
 
 #[derive(Debug, Clone, Deserialize)]
@@ -262,6 +322,15 @@ pub(crate) fn parse_discussions(json: &str) -> Result<Vec<Discussion>> {
     serde_json::from_str(json).map_err(|e| bad("parse discussions", e))
 }
 
+fn note_author(n: &Note) -> String {
+    n.author
+        .as_ref()
+        .and_then(|u| u.username.clone().or_else(|| u.name.clone()))
+        .filter(|s| !s.is_empty())
+        .unwrap_or_else(|| "unknown".to_string())
+}
+
+/// Unresolved, resolvable, non-bot first-notes become pending review comments.
 pub(crate) fn extract_pending_comments(
     discussions: &[Discussion],
     default_url: &str,
@@ -272,12 +341,10 @@ pub(crate) fn extract_pending_comments(
             if !n.resolvable || n.resolved {
                 continue;
             }
-            let author = n
-                .author
-                .as_ref()
-                .and_then(|u| u.username.clone().or_else(|| u.name.clone()))
-                .filter(|s| !s.is_empty())
-                .unwrap_or_else(|| "unknown".to_string());
+            let author = note_author(n);
+            if is_bot(&author) {
+                continue;
+            }
             let (path, line) = n
                 .position
                 .as_ref()
@@ -301,6 +368,92 @@ pub(crate) fn extract_pending_comments(
     out
 }
 
+/// Each unresolved discussion from a non-bot author turns into a
+/// `changes_requested` review (deduped by author, skipping anyone already
+/// counted as an approver). Mirrors the TS reference.
+pub(crate) fn synthesise_changes_requested_reviews(
+    discussions: &[Discussion],
+    approver_usernames: &[String],
+) -> Vec<Review> {
+    let approved: std::collections::HashSet<&str> =
+        approver_usernames.iter().map(String::as_str).collect();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+    let mut out = Vec::new();
+    for d in discussions {
+        let Some(note) = d.notes.first() else {
+            continue;
+        };
+        if !note.resolvable || note.resolved {
+            continue;
+        }
+        let author = note_author(note);
+        if is_bot(&author) || approved.contains(author.as_str()) {
+            continue;
+        }
+        if !seen.insert(author.clone()) {
+            continue;
+        }
+        out.push(Review {
+            author,
+            state: ReviewState::ChangesRequested,
+            body: None,
+        });
+    }
+    out
+}
+
+/// Infer a severity from the comment body. Mirrors TS `inferSeverity`.
+pub(crate) fn infer_severity(body: &str) -> AutomatedCommentSeverity {
+    let lower = body.to_ascii_lowercase();
+    if lower.contains("error")
+        || lower.contains("bug")
+        || lower.contains("critical")
+        || lower.contains("potential issue")
+    {
+        return AutomatedCommentSeverity::Error;
+    }
+    if lower.contains("warning") || lower.contains("suggest") || lower.contains("consider") {
+        return AutomatedCommentSeverity::Warning;
+    }
+    AutomatedCommentSeverity::Info
+}
+
+/// Bot discussions become `AutomatedComment`s with a severity heuristic.
+pub(crate) fn extract_automated_comments(
+    discussions: &[Discussion],
+    default_url: &str,
+) -> Vec<AutomatedComment> {
+    let mut out = Vec::new();
+    for d in discussions {
+        let Some(n) = d.notes.first() else {
+            continue;
+        };
+        let author = note_author(n);
+        if !is_bot(&author) {
+            continue;
+        }
+        let (path, line) = n
+            .position
+            .as_ref()
+            .map(|p| {
+                let path = p.new_path.clone().or_else(|| p.old_path.clone());
+                let line = p.new_line.or(p.old_line);
+                (path.filter(|s| !s.is_empty()), line)
+            })
+            .unwrap_or((None, None));
+        out.push(AutomatedComment {
+            id: n.id.to_string(),
+            bot_name: author,
+            body: n.body.clone(),
+            path,
+            line,
+            severity: infer_severity(&n.body),
+            url: n.web_url.clone().unwrap_or_else(|| default_url.to_string()),
+        });
+    }
+    out
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -318,7 +471,7 @@ mod tests {
             work_in_progress: None,
             merge_status: None,
             has_conflicts: None,
-            head_pipeline: None,
+            blocking_discussions_resolved: None,
         };
         assert!(mr.is_draft());
     }
@@ -331,10 +484,179 @@ mod tests {
     #[test]
     fn review_decision_required_zero_is_none() {
         let a = Approvals {
-            approvals_required: Some(0),
+            approved: Some(false),
             approvals_left: Some(0),
             approved_by: vec![],
         };
         assert_eq!(review_decision_from_approvals(&a), ReviewDecision::None);
+    }
+
+    #[test]
+    fn review_decision_maps_approved_flag() {
+        let a = Approvals {
+            approved: Some(true),
+            approvals_left: Some(0),
+            approved_by: vec![],
+        };
+        assert_eq!(review_decision_from_approvals(&a), ReviewDecision::Approved);
+    }
+
+    #[test]
+    fn review_decision_pending_when_approvals_left() {
+        let a = Approvals {
+            approved: Some(false),
+            approvals_left: Some(2),
+            approved_by: vec![],
+        };
+        assert_eq!(review_decision_from_approvals(&a), ReviewDecision::Pending);
+    }
+
+    #[test]
+    fn is_bot_matches_suffix_and_project_bots() {
+        assert!(is_bot("gitlab-bot"));
+        assert!(is_bot("renovate[bot]"));
+        assert!(is_bot("project_42_bot"));
+        assert!(!is_bot("project__bot"));
+        assert!(!is_bot("project_abc_bot"));
+        assert!(!is_bot("alice"));
+    }
+
+    #[test]
+    fn map_job_status_covers_all_gitlab_statuses() {
+        assert_eq!(map_job_status("success"), CheckStatus::Passed);
+        assert_eq!(map_job_status("failed"), CheckStatus::Failed);
+        assert_eq!(map_job_status("canceled"), CheckStatus::Failed);
+        assert_eq!(map_job_status("running"), CheckStatus::Running);
+        assert_eq!(map_job_status("pending"), CheckStatus::Pending);
+        assert_eq!(map_job_status("manual"), CheckStatus::Pending);
+        assert_eq!(map_job_status("created"), CheckStatus::Pending);
+        assert_eq!(map_job_status("waiting_for_resource"), CheckStatus::Pending);
+        assert_eq!(map_job_status("preparing"), CheckStatus::Pending);
+        assert_eq!(map_job_status("scheduled"), CheckStatus::Pending);
+        assert_eq!(map_job_status("skipped"), CheckStatus::Skipped);
+        // Fail-closed on unknown status.
+        assert_eq!(map_job_status("new_status"), CheckStatus::Failed);
+    }
+
+    #[test]
+    fn jobs_into_check_runs_preserves_name_and_url() {
+        let jobs = vec![
+            Job {
+                name: "build".into(),
+                status: "success".into(),
+                web_url: Some("https://ci/1".into()),
+            },
+            Job {
+                name: "lint".into(),
+                status: "failed".into(),
+                web_url: Some("".into()),
+            },
+        ];
+        let checks = jobs_into_check_runs(jobs);
+        assert_eq!(checks[0].name, "build");
+        assert_eq!(checks[0].status, CheckStatus::Passed);
+        assert_eq!(checks[0].url.as_deref(), Some("https://ci/1"));
+        assert_eq!(checks[1].name, "lint");
+        assert_eq!(checks[1].status, CheckStatus::Failed);
+        assert!(checks[1].url.is_none());
+    }
+
+    #[test]
+    fn approvals_into_reviews_returns_unknown_for_null_user() {
+        let a = Approvals {
+            approved: Some(false),
+            approvals_left: Some(1),
+            approved_by: vec![ApprovedBy { user: None }],
+        };
+        let reviews = approvals_into_reviews(&a);
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].author, "unknown");
+    }
+
+    #[test]
+    fn synthesise_changes_requested_dedupes_and_respects_approvers() {
+        let discussions: Vec<Discussion> = serde_json::from_str(
+            r#"[
+                {"notes":[{"id":1,"author":{"username":"alice"},"body":"x","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":2,"author":{"username":"alice"},"body":"y","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":3,"author":{"username":"gitlab-bot"},"body":"z","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":4,"author":{"username":"carol"},"body":"w","resolvable":true,"resolved":false}]}
+            ]"#,
+        )
+        .unwrap();
+        let approvers = vec!["bob".to_string()];
+        let reviews = synthesise_changes_requested_reviews(&discussions, &approvers);
+        assert_eq!(reviews.len(), 2);
+        assert_eq!(reviews[0].author, "alice");
+        assert_eq!(reviews[0].state, ReviewState::ChangesRequested);
+        assert_eq!(reviews[1].author, "carol");
+
+        // Alice as approver suppresses the synthesised review.
+        let approvers = vec!["alice".to_string()];
+        let reviews = synthesise_changes_requested_reviews(&discussions, &approvers);
+        assert_eq!(reviews.len(), 1);
+        assert_eq!(reviews[0].author, "carol");
+    }
+
+    #[test]
+    fn extract_pending_comments_skips_bots_and_resolved() {
+        let discussions: Vec<Discussion> = serde_json::from_str(
+            r#"[
+                {"notes":[{"id":1,"author":{"username":"alice"},"body":"Fix this","resolvable":true,"resolved":false,"position":{"new_path":"src/foo.ts","new_line":10}}]},
+                {"notes":[{"id":2,"author":{"username":"bob"},"body":"resolved","resolvable":true,"resolved":true}]},
+                {"notes":[{"id":3,"author":{"username":"project_99_bot"},"body":"bot comment","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":4,"author":{"username":"carol"},"body":"system","resolvable":false,"resolved":false}]}
+            ]"#,
+        )
+        .unwrap();
+        let comments = extract_pending_comments(&discussions, "https://gitlab/mr");
+        assert_eq!(comments.len(), 1);
+        assert_eq!(comments[0].author, "alice");
+        assert_eq!(comments[0].path.as_deref(), Some("src/foo.ts"));
+        assert_eq!(comments[0].line, Some(10));
+    }
+
+    #[test]
+    fn extract_automated_comments_severity_buckets() {
+        let discussions: Vec<Discussion> = serde_json::from_str(
+            r#"[
+                {"notes":[{"id":1,"author":{"username":"sast-bot"},"body":"Error: build failed","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":2,"author":{"username":"sast-bot"},"body":"Warning: deprecated API","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":3,"author":{"username":"sast-bot"},"body":"Deployed to staging","resolvable":true,"resolved":false}]},
+                {"notes":[{"id":4,"author":{"username":"alice"},"body":"nit","resolvable":true,"resolved":false}]}
+            ]"#,
+        )
+        .unwrap();
+        let comments = extract_automated_comments(&discussions, "https://gitlab/mr");
+        assert_eq!(comments.len(), 3);
+        assert_eq!(comments[0].severity, AutomatedCommentSeverity::Error);
+        assert_eq!(comments[1].severity, AutomatedCommentSeverity::Warning);
+        assert_eq!(comments[2].severity, AutomatedCommentSeverity::Info);
+        assert!(comments.iter().all(|c| c.bot_name == "sast-bot"));
+    }
+
+    #[test]
+    fn approver_usernames_skips_null_users() {
+        let a = Approvals {
+            approved: Some(true),
+            approvals_left: Some(0),
+            approved_by: vec![
+                ApprovedBy {
+                    user: Some(User {
+                        username: Some("alice".into()),
+                        name: None,
+                    }),
+                },
+                ApprovedBy { user: None },
+                ApprovedBy {
+                    user: Some(User {
+                        username: None,
+                        name: Some("Bob".into()),
+                    }),
+                },
+            ],
+        };
+        let names = approver_usernames(&a);
+        assert_eq!(names, vec!["alice", "Bob"]);
     }
 }

--- a/crates/plugins/scm-gitlab/src/webhook.rs
+++ b/crates/plugins/scm-gitlab/src/webhook.rs
@@ -1,0 +1,736 @@
+//! GitLab webhook verification + parsing.
+//!
+//! Ports TS `verifyWebhook` / `parseWebhook` from
+//! `packages/plugins/scm-gitlab/src/index.ts`. GitLab's webhook auth is a
+//! plaintext token in `x-gitlab-token` rather than a MAC over the body — we
+//! follow the TS reference and compare SHA-256 digests of secret and provided
+//! token in constant time to avoid byte-wise timing leaks.
+
+use ao_core::{
+    config::{ProjectConfig, ScmWebhookConfig},
+    AoError, Result, ScmWebhookEvent, ScmWebhookEventKind, ScmWebhookRepository, ScmWebhookRequest,
+    ScmWebhookVerificationResult,
+};
+use sha2::{Digest, Sha256};
+
+/// Effective webhook config with GitLab-flavoured defaults applied. Mirrors
+/// the TS `getGitLabWebhookConfig` helper.
+pub(crate) struct EffectiveWebhookConfig {
+    pub enabled: bool,
+    pub secret_env_var: Option<String>,
+    pub signature_header: String,
+    pub event_header: String,
+    pub delivery_header: String,
+    pub max_body_bytes: Option<u64>,
+}
+
+pub(crate) fn effective_config(project: &ProjectConfig) -> EffectiveWebhookConfig {
+    let cfg: ScmWebhookConfig = project
+        .scm
+        .as_ref()
+        .and_then(|s| s.webhook.as_ref())
+        .cloned()
+        .unwrap_or_default();
+    EffectiveWebhookConfig {
+        enabled: cfg.enabled,
+        secret_env_var: cfg.secret_env_var,
+        signature_header: cfg
+            .signature_header
+            .unwrap_or_else(|| "x-gitlab-token".into()),
+        event_header: cfg.event_header.unwrap_or_else(|| "x-gitlab-event".into()),
+        delivery_header: cfg
+            .delivery_header
+            .unwrap_or_else(|| "x-gitlab-event-uuid".into()),
+        max_body_bytes: cfg.max_body_bytes,
+    }
+}
+
+/// Case-insensitive header lookup. Returns the first value when the header
+/// appears more than once (matches TS behaviour and RFC 7230).
+pub(crate) fn get_header<'a>(req: &'a ScmWebhookRequest, name: &str) -> Option<&'a str> {
+    let target = name.to_ascii_lowercase();
+    for (key, values) in &req.headers {
+        if key.to_ascii_lowercase() == target {
+            return values.first().map(|s| s.as_str());
+        }
+    }
+    None
+}
+
+/// Constant-time comparison of SHA-256(secret) and SHA-256(provided).
+///
+/// Uses digests of equal length so the compare stays constant-time regardless
+/// of the token's size. Mirrors TS `verifyGitLabToken`.
+pub(crate) fn verify_token(secret: &str, provided: &str) -> bool {
+    let a = Sha256::digest(secret.as_bytes());
+    let b = Sha256::digest(provided.as_bytes());
+    let mut diff: u8 = 0;
+    for (x, y) in a.iter().zip(b.iter()) {
+        diff |= x ^ y;
+    }
+    diff == 0
+}
+
+pub(crate) async fn verify(
+    request: &ScmWebhookRequest,
+    project: &ProjectConfig,
+) -> Result<ScmWebhookVerificationResult> {
+    let cfg = effective_config(project);
+    if !cfg.enabled {
+        return Ok(rejected("Webhook is disabled for this project"));
+    }
+    if !request.method.eq_ignore_ascii_case("POST") {
+        return Ok(rejected("Webhook requests must use POST"));
+    }
+    if let Some(max) = cfg.max_body_bytes {
+        let len = request
+            .raw_body
+            .as_ref()
+            .map(|b| b.len() as u64)
+            .unwrap_or_else(|| request.body.len() as u64);
+        if len > max {
+            return Ok(rejected("Webhook payload exceeds configured maxBodyBytes"));
+        }
+    }
+
+    let event_type = match get_header(request, &cfg.event_header) {
+        Some(e) => e.to_string(),
+        None => return Ok(rejected(&format!("Missing {} header", cfg.event_header))),
+    };
+    let delivery_id = get_header(request, &cfg.delivery_header).map(str::to_string);
+
+    let Some(secret_env) = cfg.secret_env_var.as_deref() else {
+        // No secret configured → skip the token check (local/dev path).
+        return Ok(ScmWebhookVerificationResult {
+            ok: true,
+            reason: None,
+            delivery_id,
+            event_type: Some(event_type),
+        });
+    };
+
+    let Ok(secret) = std::env::var(secret_env) else {
+        return Ok(rejected(&format!(
+            "Webhook secret env var {secret_env} is not configured"
+        )));
+    };
+
+    let Some(provided) = get_header(request, &cfg.signature_header) else {
+        return Ok(rejected(&format!(
+            "Missing {} header",
+            cfg.signature_header
+        )));
+    };
+
+    if !verify_token(&secret, provided) {
+        return Ok(ScmWebhookVerificationResult {
+            ok: false,
+            reason: Some("Webhook token verification failed".into()),
+            delivery_id,
+            event_type: Some(event_type),
+        });
+    }
+
+    Ok(ScmWebhookVerificationResult {
+        ok: true,
+        reason: None,
+        delivery_id,
+        event_type: Some(event_type),
+    })
+}
+
+fn rejected(reason: &str) -> ScmWebhookVerificationResult {
+    ScmWebhookVerificationResult {
+        ok: false,
+        reason: Some(reason.into()),
+        delivery_id: None,
+        event_type: None,
+    }
+}
+
+pub(crate) fn parse(
+    request: &ScmWebhookRequest,
+    project: &ProjectConfig,
+) -> Result<Option<ScmWebhookEvent>> {
+    let cfg = effective_config(project);
+    let Some(raw_event_type) = get_header(request, &cfg.event_header) else {
+        return Ok(None);
+    };
+    let raw_event_type = raw_event_type.to_string();
+    let normalized = raw_event_type.to_ascii_lowercase();
+    let delivery_id = get_header(request, &cfg.delivery_header).map(str::to_string);
+
+    let payload: serde_json::Value = serde_json::from_str(&request.body)
+        .map_err(|e| AoError::Scm(format!("webhook payload is not valid JSON: {e}")))?;
+    if !payload.is_object() {
+        return Err(AoError::Scm("webhook payload must be a JSON object".into()));
+    }
+
+    let object_kind = payload
+        .get("object_kind")
+        .and_then(|v| v.as_str())
+        .map(str::to_string);
+    let object_attributes = payload.get("object_attributes").and_then(|v| v.as_object());
+    let repository = parse_repository(&payload);
+
+    let action = object_attributes
+        .and_then(|o| o.get("action"))
+        .and_then(|v| v.as_str())
+        .map(str::to_string)
+        .or_else(|| {
+            payload
+                .get("action")
+                .and_then(|v| v.as_str())
+                .map(str::to_string)
+        })
+        .unwrap_or_else(|| raw_event_type.clone());
+
+    // Merge request
+    if normalized == "merge request hook" || object_kind.as_deref() == Some("merge_request") {
+        let Some(mr) = payload.get("object_attributes").and_then(|v| v.as_object()) else {
+            return Ok(None);
+        };
+        let pr_number = mr
+            .get("iid")
+            .and_then(|v| v.as_u64())
+            .or_else(|| mr.get("id").and_then(|v| v.as_u64()))
+            .map(|n| n as u32);
+        let branch = mr
+            .get("source_branch")
+            .and_then(|v| v.as_str())
+            .and_then(parse_branch_ref)
+            .map(str::to_string);
+        let sha = mr
+            .get("last_commit")
+            .and_then(|v| v.as_object())
+            .and_then(|o| o.get("id"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        return Ok(Some(ScmWebhookEvent {
+            provider: "gitlab".into(),
+            kind: ScmWebhookEventKind::PullRequest,
+            action,
+            raw_event_type,
+            delivery_id,
+            repository,
+            pr_number,
+            branch,
+            sha,
+            data: payload,
+        }));
+    }
+
+    // Note (comment) — only MR-bound notes
+    if normalized == "note hook" || object_kind.as_deref() == Some("note") {
+        let Some(mr) = payload.get("merge_request").and_then(|v| v.as_object()) else {
+            return Ok(None);
+        };
+        let noteable = object_attributes
+            .and_then(|o| o.get("noteable_type"))
+            .and_then(|v| v.as_str());
+        if noteable != Some("MergeRequest") {
+            return Ok(None);
+        }
+        let pr_number = mr
+            .get("iid")
+            .and_then(|v| v.as_u64())
+            .map(|n| n as u32);
+        let branch = mr
+            .get("source_branch")
+            .and_then(|v| v.as_str())
+            .and_then(parse_branch_ref)
+            .map(str::to_string);
+        let sha = mr
+            .get("last_commit")
+            .and_then(|v| v.as_object())
+            .and_then(|o| o.get("id"))
+            .and_then(|v| v.as_str())
+            .map(str::to_string);
+        return Ok(Some(ScmWebhookEvent {
+            provider: "gitlab".into(),
+            kind: ScmWebhookEventKind::Comment,
+            action,
+            raw_event_type,
+            delivery_id,
+            repository,
+            pr_number,
+            branch,
+            sha,
+            data: payload,
+        }));
+    }
+
+    // Pipeline / Job
+    if normalized == "pipeline hook"
+        || normalized == "job hook"
+        || object_kind.as_deref() == Some("pipeline")
+        || object_kind.as_deref() == Some("build")
+    {
+        let pr_number = payload
+            .get("merge_request")
+            .and_then(|v| v.as_object())
+            .and_then(|mr| {
+                mr.get("iid")
+                    .and_then(|v| v.as_u64())
+                    .or_else(|| mr.get("id").and_then(|v| v.as_u64()))
+            })
+            .map(|n| n as u32);
+        let branch = parse_ci_branch(&payload);
+        let sha = payload
+            .get("checkout_sha")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("sha").and_then(|v| v.as_str()))
+            .or_else(|| {
+                object_attributes
+                    .and_then(|o| o.get("sha"))
+                    .and_then(|v| v.as_str())
+            })
+            .map(str::to_string);
+        return Ok(Some(ScmWebhookEvent {
+            provider: "gitlab".into(),
+            kind: ScmWebhookEventKind::Ci,
+            action,
+            raw_event_type,
+            delivery_id,
+            repository,
+            pr_number,
+            branch,
+            sha,
+            data: payload,
+        }));
+    }
+
+    // Push / tag push
+    if normalized == "push hook"
+        || normalized == "tag push hook"
+        || object_kind.as_deref() == Some("push")
+        || object_kind.as_deref() == Some("tag_push")
+    {
+        let branch = if is_tag_ref(&payload) {
+            None
+        } else {
+            payload
+                .get("ref")
+                .and_then(|v| v.as_str())
+                .and_then(parse_branch_ref)
+                .map(str::to_string)
+        };
+        let sha = payload
+            .get("after")
+            .and_then(|v| v.as_str())
+            .or_else(|| payload.get("checkout_sha").and_then(|v| v.as_str()))
+            .map(str::to_string);
+        return Ok(Some(ScmWebhookEvent {
+            provider: "gitlab".into(),
+            kind: ScmWebhookEventKind::Push,
+            action,
+            raw_event_type,
+            delivery_id,
+            repository,
+            pr_number: None,
+            branch,
+            sha,
+            data: payload,
+        }));
+    }
+
+    Ok(Some(ScmWebhookEvent {
+        provider: "gitlab".into(),
+        kind: ScmWebhookEventKind::Unknown,
+        action,
+        raw_event_type,
+        delivery_id,
+        repository,
+        pr_number: None,
+        branch: None,
+        sha: None,
+        data: payload,
+    }))
+}
+
+fn parse_repository(payload: &serde_json::Value) -> Option<ScmWebhookRepository> {
+    let project = payload.get("project")?.as_object()?;
+    if let Some(p) = project
+        .get("path_with_namespace")
+        .and_then(|v| v.as_str())
+        .filter(|s| !s.is_empty())
+    {
+        let parts: Vec<&str> = p.split('/').collect();
+        if parts.len() >= 2 {
+            let name = parts[parts.len() - 1].to_string();
+            let owner = parts[..parts.len() - 1].join("/");
+            if !owner.is_empty() && !name.is_empty() {
+                return Some(ScmWebhookRepository { owner, name });
+            }
+        }
+    }
+    let namespace = project.get("namespace").and_then(|v| v.as_str())?;
+    let name = project.get("path").and_then(|v| v.as_str())?;
+    if namespace.is_empty() || name.is_empty() {
+        return None;
+    }
+    Some(ScmWebhookRepository {
+        owner: namespace.to_string(),
+        name: name.to_string(),
+    })
+}
+
+fn is_tag_ref(payload: &serde_json::Value) -> bool {
+    let oa = payload.get("object_attributes").and_then(|v| v.as_object());
+    if oa
+        .and_then(|o| o.get("tag"))
+        .and_then(|v| v.as_bool())
+        .unwrap_or(false)
+    {
+        return true;
+    }
+    if payload.get("ref_type").and_then(|v| v.as_str()) == Some("tag") {
+        return true;
+    }
+    payload.get("object_kind").and_then(|v| v.as_str()) == Some("tag_push")
+}
+
+fn parse_ci_branch(payload: &serde_json::Value) -> Option<String> {
+    if is_tag_ref(payload) {
+        return None;
+    }
+    let oa = payload.get("object_attributes").and_then(|v| v.as_object());
+    let r = payload
+        .get("ref")
+        .and_then(|v| v.as_str())
+        .or_else(|| oa.and_then(|o| o.get("ref")).and_then(|v| v.as_str()))?;
+    parse_branch_ref(r).map(str::to_string)
+}
+
+/// Extract a branch name from a `refs/heads/<branch>` ref. Returns `None`
+/// for `refs/tags/...`; passes plain branch names through.
+pub(crate) fn parse_branch_ref(ref_str: &str) -> Option<&str> {
+    if let Some(rest) = ref_str.strip_prefix("refs/heads/") {
+        if rest.is_empty() {
+            return None;
+        }
+        return Some(rest);
+    }
+    if ref_str.starts_with("refs/") {
+        return None;
+    }
+    if ref_str.is_empty() {
+        None
+    } else {
+        Some(ref_str)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ao_core::config::PluginConfig;
+    use std::collections::HashMap;
+
+    fn make_project(webhook: Option<ScmWebhookConfig>) -> ProjectConfig {
+        let yaml = r#"
+repo: acme/repo
+path: /tmp
+default_branch: main
+"#;
+        let mut project: ProjectConfig = serde_yaml::from_str(yaml).unwrap();
+        if let Some(w) = webhook {
+            project.scm = Some(PluginConfig {
+                plugin: None,
+                package: None,
+                path: None,
+                webhook: Some(w),
+                extra: HashMap::new(),
+            });
+        }
+        project
+    }
+
+    fn make_request(method: &str, body: &str, headers: &[(&str, &str)]) -> ScmWebhookRequest {
+        let mut h: HashMap<String, Vec<String>> = HashMap::new();
+        for (k, v) in headers {
+            h.entry(k.to_string()).or_default().push(v.to_string());
+        }
+        ScmWebhookRequest {
+            method: method.into(),
+            headers: h,
+            body: body.into(),
+            raw_body: Some(body.as_bytes().to_vec()),
+            path: None,
+        }
+    }
+
+    const SECRET: &str = "topsecret";
+
+    #[test]
+    fn get_header_case_insensitive() {
+        let req = make_request("POST", "{}", &[("X-Gitlab-Event", "Merge Request Hook")]);
+        assert_eq!(
+            get_header(&req, "x-gitlab-event"),
+            Some("Merge Request Hook")
+        );
+        assert_eq!(
+            get_header(&req, "X-GITLAB-EVENT"),
+            Some("Merge Request Hook")
+        );
+    }
+
+    #[test]
+    fn verify_token_accepts_matching_tokens() {
+        assert!(verify_token(SECRET, SECRET));
+        assert!(!verify_token(SECRET, "wrong"));
+        assert!(!verify_token(SECRET, ""));
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_non_post() {
+        let project = make_project(Some(ScmWebhookConfig::default()));
+        let req = make_request("GET", "{}", &[("X-Gitlab-Event", "Push Hook")]);
+        let res = verify(&req, &project).await.unwrap();
+        assert!(!res.ok);
+        assert!(res.reason.unwrap().contains("POST"));
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_disabled_webhook() {
+        let project = make_project(Some(ScmWebhookConfig {
+            enabled: false,
+            ..Default::default()
+        }));
+        let req = make_request("POST", "{}", &[("X-Gitlab-Event", "Push Hook")]);
+        let res = verify(&req, &project).await.unwrap();
+        assert!(!res.ok);
+        assert!(res.reason.unwrap().contains("disabled"));
+    }
+
+    #[tokio::test]
+    async fn verify_rejects_body_exceeding_max() {
+        let project = make_project(Some(ScmWebhookConfig {
+            max_body_bytes: Some(2),
+            ..Default::default()
+        }));
+        let req = make_request("POST", "abcd", &[("X-Gitlab-Event", "Push Hook")]);
+        let res = verify(&req, &project).await.unwrap();
+        assert!(!res.ok);
+        assert!(res.reason.unwrap().contains("maxBodyBytes"));
+    }
+
+    #[tokio::test]
+    async fn verify_requires_event_header() {
+        let project = make_project(Some(ScmWebhookConfig::default()));
+        let req = make_request("POST", "{}", &[]);
+        let res = verify(&req, &project).await.unwrap();
+        assert!(!res.ok);
+        assert!(res.reason.unwrap().to_lowercase().contains("missing"));
+    }
+
+    #[tokio::test]
+    async fn verify_passes_without_configured_secret() {
+        let project = make_project(Some(ScmWebhookConfig::default()));
+        let req = make_request(
+            "POST",
+            "{}",
+            &[
+                ("X-Gitlab-Event", "Push Hook"),
+                ("X-Gitlab-Event-UUID", "delivery-1"),
+            ],
+        );
+        let res = verify(&req, &project).await.unwrap();
+        assert!(res.ok);
+        assert_eq!(res.event_type.as_deref(), Some("Push Hook"));
+        assert_eq!(res.delivery_id.as_deref(), Some("delivery-1"));
+    }
+
+    #[tokio::test]
+    async fn verify_with_secret_accepts_valid_token() {
+        let env_var = "AO_TEST_GITLAB_WEBHOOK_SECRET_VALID";
+        // SAFETY: test-only env mutation; no concurrent writers to this name.
+        unsafe {
+            std::env::set_var(env_var, SECRET);
+        }
+        let project = make_project(Some(ScmWebhookConfig {
+            secret_env_var: Some(env_var.into()),
+            ..Default::default()
+        }));
+        let req = make_request(
+            "POST",
+            "{}",
+            &[
+                ("X-Gitlab-Event", "Merge Request Hook"),
+                ("X-Gitlab-Token", SECRET),
+            ],
+        );
+        let res = verify(&req, &project).await.unwrap();
+        assert!(res.ok, "reason: {:?}", res.reason);
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    #[tokio::test]
+    async fn verify_with_secret_rejects_bad_token() {
+        let env_var = "AO_TEST_GITLAB_WEBHOOK_SECRET_BAD";
+        unsafe {
+            std::env::set_var(env_var, SECRET);
+        }
+        let project = make_project(Some(ScmWebhookConfig {
+            secret_env_var: Some(env_var.into()),
+            ..Default::default()
+        }));
+        let req = make_request(
+            "POST",
+            "{}",
+            &[
+                ("X-Gitlab-Event", "Merge Request Hook"),
+                ("X-Gitlab-Token", "wrong"),
+            ],
+        );
+        let res = verify(&req, &project).await.unwrap();
+        assert!(!res.ok);
+        assert!(res.reason.unwrap().contains("verification failed"));
+        unsafe {
+            std::env::remove_var(env_var);
+        }
+    }
+
+    #[test]
+    fn parse_branch_ref_handles_refs_and_plain() {
+        assert_eq!(parse_branch_ref("refs/heads/main"), Some("main"));
+        assert_eq!(parse_branch_ref("refs/heads/feat/x"), Some("feat/x"));
+        assert_eq!(parse_branch_ref("refs/tags/v1"), None);
+        assert_eq!(parse_branch_ref("refs/heads/"), None);
+        assert_eq!(parse_branch_ref(""), None);
+        assert_eq!(parse_branch_ref("main"), Some("main"));
+    }
+
+    #[test]
+    fn parse_merge_request_event_extracts_fields() {
+        let project = make_project(None);
+        let body = r#"{
+            "object_kind":"merge_request",
+            "object_attributes":{
+                "action":"open",
+                "iid":42,
+                "source_branch":"feat/x",
+                "updated_at":"2026-03-11T00:00:00Z",
+                "last_commit":{"id":"abc123"}
+            },
+            "project":{"path_with_namespace":"acme/repo"}
+        }"#;
+        let req = make_request(
+            "POST",
+            body,
+            &[
+                ("X-Gitlab-Event", "Merge Request Hook"),
+                ("X-Gitlab-Event-UUID", "delivery-1"),
+            ],
+        );
+        let event = parse(&req, &project).unwrap().unwrap();
+        assert_eq!(event.provider, "gitlab");
+        assert_eq!(event.kind, ScmWebhookEventKind::PullRequest);
+        assert_eq!(event.action, "open");
+        assert_eq!(event.pr_number, Some(42));
+        assert_eq!(event.branch.as_deref(), Some("feat/x"));
+        assert_eq!(event.sha.as_deref(), Some("abc123"));
+        assert_eq!(event.delivery_id.as_deref(), Some("delivery-1"));
+        let repo = event.repository.as_ref().unwrap();
+        assert_eq!(repo.owner, "acme");
+        assert_eq!(repo.name, "repo");
+    }
+
+    #[test]
+    fn parse_push_event_strips_refs_heads() {
+        let project = make_project(None);
+        let body = r#"{
+            "object_kind":"push",
+            "ref":"refs/heads/feat/x",
+            "after":"def456",
+            "project":{"path_with_namespace":"acme/repo"}
+        }"#;
+        let req = make_request("POST", body, &[("X-Gitlab-Event", "Push Hook")]);
+        let event = parse(&req, &project).unwrap().unwrap();
+        assert_eq!(event.kind, ScmWebhookEventKind::Push);
+        assert_eq!(event.branch.as_deref(), Some("feat/x"));
+        assert_eq!(event.sha.as_deref(), Some("def456"));
+    }
+
+    #[test]
+    fn parse_tag_push_has_no_branch() {
+        let project = make_project(None);
+        let body = r#"{
+            "object_kind":"tag_push",
+            "ref":"refs/tags/v1.0.0",
+            "after":"def456",
+            "project":{"path_with_namespace":"acme/repo"}
+        }"#;
+        let req = make_request("POST", body, &[("X-Gitlab-Event", "Tag Push Hook")]);
+        let event = parse(&req, &project).unwrap().unwrap();
+        assert_eq!(event.kind, ScmWebhookEventKind::Push);
+        assert!(event.branch.is_none());
+        assert_eq!(event.sha.as_deref(), Some("def456"));
+    }
+
+    #[test]
+    fn parse_plain_tag_ref_has_no_branch() {
+        let project = make_project(None);
+        let body = r#"{
+            "object_kind":"tag_push",
+            "ref":"v1.0.0",
+            "ref_type":"tag",
+            "after":"def456",
+            "project":{"path_with_namespace":"acme/repo"}
+        }"#;
+        let req = make_request("POST", body, &[("X-Gitlab-Event", "Tag Push Hook")]);
+        let event = parse(&req, &project).unwrap().unwrap();
+        assert!(event.branch.is_none());
+    }
+
+    #[test]
+    fn parse_pipeline_tag_has_no_branch() {
+        let project = make_project(None);
+        let body = r#"{
+            "object_kind":"pipeline",
+            "ref":"v1.0.0",
+            "ref_type":"tag",
+            "checkout_sha":"def456",
+            "project":{"path_with_namespace":"acme/repo"},
+            "object_attributes":{"ref":"v1.0.0","tag":true}
+        }"#;
+        let req = make_request("POST", body, &[("X-Gitlab-Event", "Pipeline Hook")]);
+        let event = parse(&req, &project).unwrap().unwrap();
+        assert_eq!(event.kind, ScmWebhookEventKind::Ci);
+        assert!(event.branch.is_none());
+        assert_eq!(event.sha.as_deref(), Some("def456"));
+    }
+
+    #[test]
+    fn parse_note_on_plain_issue_is_dropped() {
+        let project = make_project(None);
+        let body = r#"{
+            "object_kind":"note",
+            "object_attributes":{"noteable_type":"Issue"},
+            "project":{"path_with_namespace":"acme/repo"}
+        }"#;
+        let req = make_request("POST", body, &[("X-Gitlab-Event", "Note Hook")]);
+        let event = parse(&req, &project).unwrap();
+        assert!(event.is_none());
+    }
+
+    #[test]
+    fn parse_unknown_event_keeps_raw_type() {
+        let project = make_project(None);
+        let body = r#"{"project":{"path_with_namespace":"acme/repo"}}"#;
+        let req = make_request("POST", body, &[("X-Gitlab-Event", "Feature Flag Hook")]);
+        let event = parse(&req, &project).unwrap().unwrap();
+        assert_eq!(event.kind, ScmWebhookEventKind::Unknown);
+        assert_eq!(event.raw_event_type, "Feature Flag Hook");
+    }
+
+    #[test]
+    fn parse_rejects_non_object_payload() {
+        let project = make_project(None);
+        let req = make_request("POST", "42", &[("X-Gitlab-Event", "Push Hook")]);
+        let err = parse(&req, &project).unwrap_err().to_string();
+        assert!(err.to_lowercase().contains("json object"));
+    }
+}

--- a/docs/issues/0103-scm-gitlab-parity.md
+++ b/docs/issues/0103-scm-gitlab-parity.md
@@ -1,0 +1,73 @@
+# 5.6 scm-gitlab — parity with ao-ts
+
+**Status**: Decision made — **parity-targeted**.
+
+## Decision
+
+The ao-ts repo has a first-class `packages/plugins/scm-gitlab` plugin that
+implements the same `SCM` interface as `scm-github`. ao-rs targets parity with
+that plugin (behavior, not transport — ao-ts shells out to `glab`, ao-rs uses
+REST).
+
+## Parity matrix (ao-ts → ao-rs)
+
+Checked against `packages/plugins/scm-gitlab/src/index.ts` at HEAD.
+
+| ao-ts method           | ao-rs method         | Port status | Note |
+|------------------------|----------------------|-------------|------|
+| `name`                 | `name`               | ✓           | returns `"gitlab"` |
+| `verifyWebhook`        | `verify_webhook`     | **added**   | SHA-256 constant-time token compare on `x-gitlab-token` |
+| `parseWebhook`         | `parse_webhook`      | **added**   | MR / push / tag_push / pipeline / note |
+| `detectPR`             | `detect_pr`          | ✓           | REST MR list by source branch |
+| `getPRState`           | `pr_state`           | ✓           | opened/merged/closed |
+| `getPRSummary`         | `pr_summary`         | **added**   | state + title, additions/deletions always 0 (ao-ts parity) |
+| `mergePR`              | `merge`              | **updated** | squash / rebase / merge |
+| `closePR`              | `close_pr`           | **added**   | PUT merge_request with `state_event=close` |
+| `getCIChecks`          | `ci_checks`          | **updated** | pipelines → jobs (per-job granularity, matches ao-ts) |
+| `getCISummary`         | `ci_status`          | **updated** | "none" for merged/closed MRs when CI fetch fails |
+| `getReviews`           | `reviews`            | **updated** | approvals + unresolved-discussion `changes_requested`, bot-filtered, deduped |
+| `getReviewDecision`    | `review_decision`    | ✓           | approved / pending / none |
+| `getPendingComments`   | `pending_comments`   | **updated** | bot authors filtered |
+| `getAutomatedComments` | `automated_comments` | **added**   | bot-only notes with severity heuristic |
+| `getMergeability`      | `mergeability`       | **updated** | early return for merged/closed; adds `blocking_discussions_resolved` + draft |
+
+## GitHub vs GitLab API differences (worth recording)
+
+- **Review decision**: GitHub exposes one `reviewDecision` enum; GitLab derives
+  it from `approvals_required`/`approvals_left` + per-reviewer `approved_by`.
+- **CI**: GitHub has `check_run`s (per-check granularity natively). GitLab
+  pipelines roll up jobs — we list pipelines, pick the latest, then list its
+  jobs to match GitHub's per-check shape.
+- **Conflicts**: GitHub's `mergeable` bool bundles conflicts + branch
+  protection + required reviews. GitLab splits these: `has_conflicts`,
+  `blocking_discussions_resolved`, `merge_status` (`can_be_merged` /
+  `cannot_be_merged` / `checking`).
+- **Reviews**: GitLab doesn't have an explicit `changes_requested` review
+  state. ao-ts synthesises one from unresolved resolvable discussions; we
+  follow the same convention.
+- **Webhook auth**: GitHub signs with HMAC-SHA256 over the raw body. GitLab
+  sends a plain token in `x-gitlab-token` — we compare in constant time.
+
+## Implementation notes
+
+- Auth: ao-rs reads `GITLAB_TOKEN` (or `GITLAB_PRIVATE_TOKEN` / `PRIVATE_TOKEN`)
+  from env. ao-ts delegates to `glab`'s config; the behaviors converge at the
+  HTTP layer (both send `PRIVATE-TOKEN: <pat>`).
+- Transport: REST `api/v4` via `reqwest`. Kept because (a) no native Rust
+  analogue of `glab`; (b) wiremock fixtures give us hermetic unit tests.
+- Bot list: mirrors ao-ts' GitLab-specific bot authors (`gitlab-bot`, `ghost`,
+  `project_<N>_bot`, `*[bot]`).
+
+## Test plan
+
+Unit tests cover, via fixture JSON + wiremock:
+- CI job mapping (all GitLab statuses including `canceled`, `manual`,
+  `waiting_for_resource`, `preparing`, `scheduled`, `created`).
+- Merge readiness composer (draft, CI, approvals, conflicts,
+  `cannot_be_merged`, `checking`, unresolved discussions).
+- Reviews (approvals + unresolved discussions, bot filtering, approved/
+  changes-requested dedup).
+- Pending/automated comments (resolvable+unresolved + bot split).
+- Webhook verify (secret-env var, bad token, missing header, non-POST).
+- Webhook parse (merge_request, push, tag_push branch=None, pipeline tag).
+- Merge method mapping (squash/rebase/merge).

--- a/docs/remaining-to-port.md
+++ b/docs/remaining-to-port.md
@@ -170,8 +170,13 @@ Status: **Complete inventory** of what ao-ts has that ao-rs does not.
 
 ### 5.6 scm-gitlab
 
-- Not framed as ao-ts port — independent REST implementation
-- No parity claim
+- **Decision**: parity-targeted (see `docs/issues/0103-scm-gitlab-parity.md`).
+- Transport differs by design: ao-ts shells out to `glab`, ao-rs uses the GitLab
+  REST API via `reqwest` so wiremock fixtures can drive hermetic tests.
+- Behavior parity covers: `detect_pr`, `pr_state`, `pr_summary`, `ci_checks`,
+  `ci_status`, `reviews`, `review_decision`, `pending_comments`,
+  `automated_comments`, `mergeability`, `merge` (squash/rebase/merge),
+  `close_pr`, `verify_webhook`, `parse_webhook`.
 
 ### 5.7 notifier-ntfy
 


### PR DESCRIPTION
## Summary

- Marks `scm-gitlab` as **parity-targeted** and documents the decision in `docs/issues/0103-scm-gitlab-parity.md` (transport differs — ao-ts shells out to `glab`; ao-rs uses REST via `reqwest` so wiremock drives hermetic tests).
- Ports the ao-ts behavioural surface:
  - `detect_pr`, `pr_state`, `pr_summary`, `close_pr`
  - CI: list pipelines → latest pipeline's jobs → `CheckRun[]` (`mapJobStatus` incl. fail-closed default); `ci_status` falls back to `None` when fetch fails AND MR is merged/closed.
  - Reviews: approvals + synthesised `changes_requested` from unresolved non-bot discussions (deduped by author, approvers skipped).
  - Comments: `pending_comments` filters bots; `automated_comments` keeps only bot first-notes with severity heuristic (error/warning/info).
  - `mergeability`: early-return `Clean` for merged; `MR is closed` for closed; emits labelled blockers for draft / conflicts / `cannot_be_merged` / `checking` / unresolved discussions / review required.
  - `merge`: Squash (PUT `/merge` with `squash: true`), Rebase (PUT `/rebase` then PUT `/merge`), Merge (PUT `/merge` with `squash: false`).
  - Webhooks: `verify_webhook` (plaintext `X-Gitlab-Token` SHA-256 constant-time compare, GitLab-flavoured defaults, enabled/POST/body-size checks) and `parse_webhook` (Merge Request / Note-on-MR / Pipeline / Push / Tag Push / Unknown).

## Test plan

- [x] `cargo t -p ao-plugin-scm-gitlab` — 49 tests pass (wiremock-backed HTTP + pure-fn parsers + webhook verify/parse).
- [x] `cargo test --doc -p ao-plugin-scm-gitlab` — no doctests, clean.
- [x] `cargo clippy --all-targets -p ao-plugin-scm-gitlab -- -D warnings` — clean.
- [x] `cargo clippy --all-targets --workspace -- -D warnings` — clean.
- [x] `cargo t -p ao-core -p ao-plugin-scm-gitlab -p ao-plugin-scm-github` — 452 tests pass (no regression in adjacent crates).

Closes #103.

🤖 Generated with [Claude Code](https://claude.com/claude-code)