### PR TITLE
feat(paths): centralize cost-ledger and review-fingerprint dirs (#106)

### DIFF
--- a/crates/ao-cli/src/commands/review_check.rs
+++ b/crates/ao-cli/src/commands/review_check.rs
@@ -28,11 +28,10 @@ pub async fn review_check(
     use std::fmt::Write as _;
 
     let scm = AutoScm::new();
-    let fingerprint_dir = paths::data_dir().join("review-fingerprints");
 
     // Create fingerprint directory once, outside the loop.
     if !dry_run {
-        tokio::fs::create_dir_all(&fingerprint_dir).await?;
+        tokio::fs::create_dir_all(paths::review_fingerprint_dir()).await?;
     }
 
     let mut checked = 0u32;
@@ -80,7 +79,7 @@ pub async fn review_check(
         let fingerprint = ids.join(",");
 
         // Check if fingerprint changed since last run.
-        let fp_path = fingerprint_dir.join(format!("{}.txt", session.id.0));
+        let fp_path = paths::review_fingerprint_file(&session.id.0);
         let old_fp = tokio::fs::read_to_string(&fp_path)
             .await
             .unwrap_or_default();

--- a/crates/ao-core/src/cost_ledger.rs
+++ b/crates/ao-core/src/cost_ledger.rs
@@ -11,7 +11,7 @@
 //! determined by `created_at`, so a session that spans two months still
 //! writes to one file.
 
-use crate::{paths::data_dir, types::CostEstimate};
+use crate::{paths, types::CostEstimate};
 use serde::{Deserialize, Serialize};
 use std::path::PathBuf;
 
@@ -36,8 +36,9 @@ pub struct CostLedger {
 }
 
 /// Directory for cost ledger files: `~/.ao-rs/cost-ledger/`.
+/// Thin wrapper over [`paths::cost_ledger_dir`] — kept for readability at call sites.
 pub fn ledger_dir() -> PathBuf {
-    data_dir().join("cost-ledger")
+    paths::cost_ledger_dir()
 }
 
 /// Ledger file path for a given session's `created_at` timestamp.

--- a/crates/ao-core/src/paths.rs
+++ b/crates/ao-core/src/paths.rs
@@ -1,7 +1,8 @@
 //! Disk layout helpers for the `~/.ao-rs/` data dir.
 //!
 //! Equivalent of `packages/core/src/paths.ts` in the reference repo, scoped
-//! down to what Slice 1 needs.
+//! down to what ao-rs features actually use today. Keep this module minimal:
+//! add a helper when a feature needs a new on-disk location, not before.
 
 use std::path::PathBuf;
 
@@ -23,4 +24,85 @@ pub fn default_sessions_dir() -> PathBuf {
 /// in the reference repo.
 pub fn lifecycle_pid_file() -> PathBuf {
     data_dir().join("lifecycle.pid")
+}
+
+/// `~/.ao-rs/cost-ledger/` — monthly-rotated cost ledger files.
+/// See `cost_ledger.rs` for the `YYYY-MM.yaml` layout.
+pub fn cost_ledger_dir() -> PathBuf {
+    data_dir().join("cost-ledger")
+}
+
+/// `~/.ao-rs/review-fingerprints/` — per-session fingerprints used by
+/// `ao-rs review-check` to detect new PR comments since the last run.
+pub fn review_fingerprint_dir() -> PathBuf {
+    data_dir().join("review-fingerprints")
+}
+
+/// `~/.ao-rs/review-fingerprints/{session_id}.txt` — fingerprint file for
+/// a single session.
+pub fn review_fingerprint_file(session_id: &str) -> PathBuf {
+    review_fingerprint_dir().join(format!("{session_id}.txt"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn data_dir_ends_with_dot_ao_rs() {
+        let p = data_dir();
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some(".ao-rs"));
+    }
+
+    #[test]
+    fn default_sessions_dir_is_under_data_dir() {
+        let p = default_sessions_dir();
+        assert_eq!(p.parent(), Some(data_dir().as_path()));
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("sessions"));
+    }
+
+    #[test]
+    fn lifecycle_pid_file_is_under_data_dir() {
+        let p = lifecycle_pid_file();
+        assert_eq!(p.parent(), Some(data_dir().as_path()));
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("lifecycle.pid"));
+    }
+
+    #[test]
+    fn cost_ledger_dir_is_under_data_dir() {
+        let p = cost_ledger_dir();
+        assert_eq!(p.parent(), Some(data_dir().as_path()));
+        assert_eq!(p.file_name().and_then(|s| s.to_str()), Some("cost-ledger"));
+    }
+
+    #[test]
+    fn review_fingerprint_dir_is_under_data_dir() {
+        let p = review_fingerprint_dir();
+        assert_eq!(p.parent(), Some(data_dir().as_path()));
+        assert_eq!(
+            p.file_name().and_then(|s| s.to_str()),
+            Some("review-fingerprints")
+        );
+    }
+
+    #[test]
+    fn review_fingerprint_file_is_under_fingerprint_dir() {
+        let p = review_fingerprint_file("abcd-1234");
+        assert_eq!(p.parent(), Some(review_fingerprint_dir().as_path()));
+        assert_eq!(
+            p.file_name().and_then(|s| s.to_str()),
+            Some("abcd-1234.txt")
+        );
+    }
+
+    #[test]
+    fn review_fingerprint_file_respects_arbitrary_session_id() {
+        // Session ids are UUIDs in practice; the helper shouldn't mangle them.
+        let id = "9f2c5a0e-d8f4-4b2a-9e7c-123456789abc";
+        let p = review_fingerprint_file(id);
+        assert_eq!(
+            p.file_name().and_then(|s| s.to_str()),
+            Some("9f2c5a0e-d8f4-4b2a-9e7c-123456789abc.txt")
+        );
+    }
 }

--- a/docs/issues/0106-paths-subset.md
+++ b/docs/issues/0106-paths-subset.md
@@ -1,0 +1,78 @@
+# 7.1 paths subset — requirements & plan
+
+**Issue**: https://github.com/duonghb53/ao-rs/issues/106
+**Status**: in progress
+
+## Why
+
+`crates/ao-core/src/paths.rs` is the Slice 1 scope of `packages/core/src/paths.ts`.
+Since Slice 1, other features have landed (`cost_ledger`, `review_check`) that
+hardcode joins against `paths::data_dir()` instead of centralising the on-disk
+location. The acceptance criterion for #106 is: **newly required on-disk
+locations have a single source of truth in `paths.rs`**.
+
+## Inventory of hardcoded paths (2026-04)
+
+Found by grep for `data_dir().join(`:
+
+| Location (file:line)                                      | Path                                   | Already in `paths.rs`? |
+|-----------------------------------------------------------|----------------------------------------|------------------------|
+| `crates/ao-core/src/paths.rs:18`                          | `~/.ao-rs/sessions`                    | ✓ `default_sessions_dir()` |
+| `crates/ao-core/src/paths.rs:25`                          | `~/.ao-rs/lifecycle.pid`               | ✓ `lifecycle_pid_file()` |
+| `crates/ao-core/src/cost_ledger.rs:40` (`ledger_dir()`)   | `~/.ao-rs/cost-ledger/`                | ✗ — local helper only   |
+| `crates/ao-cli/src/commands/review_check.rs:31,83`        | `~/.ao-rs/review-fingerprints/{session_id}.txt` | ✗ — hardcoded   |
+
+**Out of scope** for this issue (no corresponding ao-rs feature exists yet, per the
+"only add what’s needed by real features" risk note):
+
+- `~/.agent-orchestrator/{hash}-observability/…` (TS `getObservabilityBaseDir`)
+- plugin-registry on-disk layout
+- hash-based project dirs (`generateConfigHash`, `getProjectBaseDir`, `.origin`)
+
+`activity_log::activity_log_path()` is workspace-relative (`{ws}/.ao/activity.jsonl`),
+not data-dir based; leaving its helper in `activity_log.rs` (parity with TS
+`activity-log.ts`) is fine.
+
+## Target state
+
+Add to `crates/ao-core/src/paths.rs`:
+
+1. `cost_ledger_dir() -> PathBuf` → `~/.ao-rs/cost-ledger/`
+2. `review_fingerprint_dir() -> PathBuf` → `~/.ao-rs/review-fingerprints/`
+3. `review_fingerprint_file(session_id: &str) -> PathBuf` → `~/.ao-rs/review-fingerprints/{session_id}.txt`
+
+All are pure, side-effect-free functions returning `PathBuf`.
+
+## Caller updates
+
+- `cost_ledger.rs`: `ledger_dir()` delegates to `paths::cost_ledger_dir()` (keep
+  the public re-export so existing callers don’t break).
+- `review_check.rs`: replace `paths::data_dir().join("review-fingerprints")` and
+  the per-session `.join(format!(…))` with `paths::review_fingerprint_dir()` and
+  `paths::review_fingerprint_file(&session.id.0)`.
+
+## Acceptance criteria
+
+- [x] Inventory complete (table above).
+- [ ] `paths.rs` exposes helpers for every hardcoded `~/.ao-rs/<something>`
+      path used by a shipped feature.
+- [ ] Existing callers use the helpers — no `data_dir().join("cost-ledger")` or
+      `data_dir().join("review-fingerprints")` outside `paths.rs`.
+- [ ] Unit tests in `paths.rs` verify stable formatting of each new helper.
+- [ ] `cargo t` + `cargo test --doc` + `cargo clippy --all-targets` pass.
+
+## Test plan
+
+- Unit tests inside `paths.rs` for each new helper:
+  - suffix matches (e.g. ends with `cost-ledger`),
+  - parent is `data_dir()`,
+  - `review_fingerprint_file("foo")` ends with `foo.txt` and lives under
+    `review_fingerprint_dir()`.
+- Existing `cost_ledger` and `review_check` test suites continue to pass.
+
+## Risks / notes
+
+- Keep `paths.rs` minimal — only helpers for paths that are actively used today.
+- Don’t introduce a `Paths` struct; free functions match the TS module style.
+- `cost_ledger::ledger_dir()` stays public (same signature) — it just delegates.
+  This avoids churn in any tests/docs referencing it by name.


### PR DESCRIPTION
## Summary

Closes #106. Expand `crates/ao-core/src/paths.rs` so every `~/.ao-rs/`
subpath used by a shipped feature has a single source of truth.

- Add `cost_ledger_dir`, `review_fingerprint_dir`, and
  `review_fingerprint_file` helpers (pure, side-effect-free).
- `cost_ledger::ledger_dir` delegates to `paths::cost_ledger_dir`
  (public signature preserved).
- `review_check` uses the new helpers instead of hand-joining
  `data_dir().join("review-fingerprints")` and
  `fingerprint_dir.join(format!("{}.txt", id))`.

Scope follows the risk note on #106: only helpers for paths an in-tree
feature actually uses today. Observability base dir, plugin-registry
on-disk layout, and hash-based project dirs stay deferred until their
features land in ao-rs. See `docs/issues/0106-paths-subset.md` for the
full inventory.

## Test plan

- [x] `cargo t` — 777 tests pass
- [x] `cargo test --doc -p ao-core` — passes
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] New unit tests in `paths.rs` cover parent / suffix invariants for
      each helper, including a UUID-shaped session id

🤖 Generated with [Claude Code](https://claude.com/claude-code)