### PR TITLE
docs(parity): document default merge_method divergence from ao-ts (#109)

### DIFF
--- a/ao-rs.yaml.example
+++ b/ao-rs.yaml.example
@@ -108,3 +108,10 @@ projects:
 #     action: send-to-agent
 #     retries: 2
 #     escalate_after: 2
+#   approved-and-green:
+#     auto: true
+#     action: auto-merge
+#     # Merge strategy when ao-rs auto-merges a PR. One of: merge | squash | rebase.
+#     # Default is `merge` (preserves history). Note: ao-ts defaults to `squash`
+#     # — set this explicitly if you want the ao-ts behavior. See issue #109.
+#     merge_method: merge

--- a/crates/ao-core/src/scm.rs
+++ b/crates/ao-core/src/scm.rs
@@ -59,6 +59,14 @@ pub enum PrState {
 }
 
 /// How to merge a PR. Mirrors GitHub's three merge methods exactly.
+///
+/// **Parity note (issue #109):** the default (`Merge`) diverges intentionally
+/// from the ao-ts reference, which defaults to `Squash`. Squash rewrites
+/// commit history, so ao-rs picks the safer default and asks users to opt
+/// into squash/rebase explicitly via the reaction config's `merge_method:`
+/// key (see `ReactionConfig::merge_method`) or the project-level override.
+/// The decision record lives at
+/// `docs/plans/remaining-to-port/7-4-default-merge-method.md`.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
 #[serde(rename_all = "snake_case")]
 pub enum MergeMethod {

--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -361,14 +361,7 @@ impl Scm for GitHubScm {
     }
 
     async fn merge(&self, pr: &PullRequest, method: Option<MergeMethod>) -> Result<()> {
-        // TS defaults to `squash`; we default to `merge` (see `MergeMethod`
-        // doc) because squash rewrites commit history and that's the kind
-        // of thing you want a human to opt into.
-        let flag = match method.unwrap_or_default() {
-            MergeMethod::Merge => "--merge",
-            MergeMethod::Squash => "--squash",
-            MergeMethod::Rebase => "--rebase",
-        };
+        let flag = merge_method_flag(method);
         let res = gh(&[
             "pr",
             "merge",
@@ -634,6 +627,25 @@ fn ci_status_label(s: CiStatus) -> &'static str {
         CiStatus::Passing => "passing",
         CiStatus::Failing => "failing",
         CiStatus::None => "none",
+    }
+}
+
+/// Map an optional [`MergeMethod`] to the corresponding `gh pr merge` flag.
+///
+/// Default (`None`) maps to `--merge` via [`MergeMethod::default`]. This is
+/// a **deliberate divergence from ao-ts**, which defaults to `squash`
+/// (`packages/plugins/scm-github/src/index.ts::mergePR`). Squash rewrites
+/// commit history and can surprise users migrating ao-ts configs, so ao-rs
+/// picks the safer merge-commit default and asks users to opt into squash
+/// explicitly via the reaction config's `merge_method:` key.
+///
+/// See `docs/plans/remaining-to-port/7-4-default-merge-method.md` for the
+/// parity decision record.
+pub(crate) fn merge_method_flag(method: Option<MergeMethod>) -> &'static str {
+    match method.unwrap_or_default() {
+        MergeMethod::Merge => "--merge",
+        MergeMethod::Squash => "--squash",
+        MergeMethod::Rebase => "--rebase",
     }
 }
 
@@ -1128,6 +1140,20 @@ mod tests {
     #[test]
     fn github_scm_name_is_github() {
         assert_eq!(GitHubScm::new().name(), "github");
+    }
+
+    #[test]
+    fn merge_method_flag_default_is_merge_commit() {
+        // Parity decision #109: ao-rs defaults to `--merge` even though the
+        // ao-ts reference defaults to `--squash`. Squash rewrites history;
+        // preserving it is the safer default and ao-ts users can opt in via
+        // `reactions.approved-and-green.merge_method`. Do NOT flip this
+        // without also updating `docs/plans/remaining-to-port/7-4-default-merge-method.md`
+        // and `ao-rs.yaml.example`.
+        assert_eq!(merge_method_flag(None), "--merge");
+        assert_eq!(merge_method_flag(Some(MergeMethod::Merge)), "--merge");
+        assert_eq!(merge_method_flag(Some(MergeMethod::Squash)), "--squash");
+        assert_eq!(merge_method_flag(Some(MergeMethod::Rebase)), "--rebase");
     }
 
     // Spot-check that the parse module and lib.rs agree on `CheckStatus`

--- a/docs/plans/remaining-to-port/7-4-default-merge-method.md
+++ b/docs/plans/remaining-to-port/7-4-default-merge-method.md
@@ -1,48 +1,45 @@
 # 7.4 default merge method
 
-Status: planned
+Status: done
 
-## Why
+## Decision
 
-Default merge method differs: ao-rs defaults to `merge`, ao-ts defaults to `squash`. This affects PR history and could surprise users migrating configs.
+Option 3 (from the original plan): **keep ao-rs's safer `merge` default and
+make the divergence explicit** in docs and the example config. Flipping to
+`squash` would silently rewrite commit history for anyone already running
+ao-rs; preserving the current default is less surprising, and ao-ts users
+who want squash opt in with one line.
 
-## Current state (ao-rs)
-
-- `crates/plugins/scm-github/src/lib.rs` documents the divergence.
-- `crates/ao-core/src/scm.rs` defines `MergeMethod` enum; defaults are Rust-defined.
-
-## Target behavior (parity decision)
-
-Decide one of:
-
-1. Keep ao-rs default as `merge` (current behavior) and document clearly.
-2. Switch default to `squash` to match ao-ts.
-3. Make default explicit in generated config examples to avoid ambiguity.
-
-## Proposed approach
-
-1. Choose policy (1/2/3).
-2. If switching default, update:
-   - default merge method in SCM plugin
-   - documentation and config example
-3. Add regression test verifying chosen default.
-
-## Files to change
+## What landed
 
 - `crates/plugins/scm-github/src/lib.rs`
-- (Optional) `crates/ao-core/src/scm.rs`
-- `docs/reactions.md` or config docs where merge behavior is discussed
+  - Extracted `merge_method_flag(Option<MergeMethod>) -> &'static str` as a
+    pure helper so the default can be unit-tested without shelling out to
+    `gh`. The `merge()` impl now just calls it.
+  - Added `merge_method_flag_default_is_merge_commit` test locking in that
+    `None → "--merge"`, plus the mapping for each explicit variant. The
+    test carries a "do not flip without updating this plan" comment.
+- `crates/ao-core/src/scm.rs`
+  - Enhanced the `MergeMethod` doc comment to call out the deliberate
+    divergence from ao-ts and point at this plan.
+- `ao-rs.yaml.example`
+  - Added a commented `approved-and-green` block with `merge_method: merge`
+    so new configs pick up the explicit value and ao-ts migrators see the
+    available override.
+- `docs/reactions.md`
+  - New "Default merge method (parity divergence, issue #109)" subsection
+    explaining the resolution order and the safer-default rationale.
 
-## Acceptance criteria
+## Parity status
 
-- Default merge method is consistent and documented.
-- Users can override via reaction config `merge_method` when using auto-merge.
+- Default now matches `MergeMethod::default()` in both the GitHub and
+  GitLab plugins (`scm-gitlab/src/lib.rs::merge` already called
+  `method.unwrap_or_default()`).
+- `docs/validation-ported-code.md` already lists the `Merge` vs `squash`
+  divergence; left as-is — it now has a documented rationale and a
+  regression test backing it.
 
-## Test plan
+## Follow-ups
 
-- Unit test asserting default merge method used when config omits it.
-
-## Risks / notes
-
-- Changing defaults is behavior-breaking; prefer explicit config for production setups.
-
+None. If a future port ever flips the default, update the test, the
+`MergeMethod` doc, `ao-rs.yaml.example`, and `docs/reactions.md` together.

--- a/docs/reactions.md
+++ b/docs/reactions.md
@@ -62,6 +62,33 @@ let lifecycle = LifecycleManager::new(sessions, runtime, agent)
   never called (older tests, Phase D compatibility), `dispatch_auto_merge`
   emits the intent event without touching a plugin.
 
+### Default merge method (parity divergence, issue #109)
+
+When `dispatch_auto_merge` calls `Scm::merge`, the method argument is
+resolved in this order:
+
+1. `reactions.approved-and-green.merge_method` (per-project override)
+2. `MergeMethod::default()` — **ao-rs returns `Merge`**
+
+The ao-ts reference defaults to `Squash` in its GitHub SCM plugin
+(`packages/plugins/scm-github/src/index.ts::mergePR`). ao-rs keeps the
+safer `Merge` default because squash rewrites commit history and we
+don't want that to happen by accident when an operator migrates a
+config. Users who want the ao-ts behavior set it explicitly:
+
+```yaml
+reactions:
+  approved-and-green:
+    auto: true
+    action: auto-merge
+    merge_method: squash   # or: merge (default) | rebase
+```
+
+See `docs/plans/remaining-to-port/7-4-default-merge-method.md` for the
+decision record; `merge_method_flag` in `scm-github/src/lib.rs` has a
+regression test locking in the default. The GitLab plugin follows the
+same default via `MergeMethod::default()`.
+
 ### Phase G wiring (merge-failure retry loop)
 
 Phase F left one known gap (the M1 backlog note that used to live in

--- a/docs/remaining-to-port.md
+++ b/docs/remaining-to-port.md
@@ -218,9 +218,14 @@ Decision needed: integrate into runtime or keep as test infrastructure only.
 
 - Event set is minimal (Phase C) — no TS file referenced; likely smaller than mature TS event bus
 
-### 7.4 Default merge method
+### 7.4 Default merge method — **resolved (#109)**
 
-- ao-rs defaults to `Merge`; ao-ts defaults to `squash`
+- ao-rs defaults to `Merge`; ao-ts defaults to `squash`.
+- Decision: keep `Merge` (safer — preserves history) and document the
+  divergence. Users opt into squash explicitly via
+  `reactions.approved-and-green.merge_method`.
+- See `docs/plans/remaining-to-port/7-4-default-merge-method.md` and the
+  "Default merge method" subsection in `docs/reactions.md`.
 
 ### 7.5 GitHub Enterprise
 


### PR DESCRIPTION
## Summary

Resolves parity item 7.4 (issue #109). The ao-ts reference defaults PR merges to `squash`; ao-rs defaults to `merge`.

**Decision: keep the safer `merge` default and document the divergence** rather than silently flip the behavior on existing users. Squash rewrites history and that's the kind of thing we want people to opt into.

- Extracted `merge_method_flag(Option<MergeMethod>) -> &'static str` as a pure helper in `scm-github` and added a regression test (`merge_method_flag_default_is_merge_commit`) that locks in `None → "--merge"` plus each explicit variant.
- Enhanced the `MergeMethod` enum doc in `ao-core/src/scm.rs` to call out the divergence and point at the decision record.
- Added a commented `approved-and-green` block with `merge_method: merge` to `ao-rs.yaml.example` so new configs pick up the explicit value and ao-ts migrators see the override.
- Added a "Default merge method (parity divergence, issue #109)" subsection to `docs/reactions.md` explaining the resolution order.
- Marked `docs/plans/remaining-to-port/7-4-default-merge-method.md` as `done` with the rationale; updated `docs/remaining-to-port.md` 7.4 entry.

No behavior changes — the flag mapping is byte-for-byte identical, just now reachable from tests.

## Test plan

- [x] `cargo t -p ao-plugin-scm-github -p ao-core` — 408/408 pass, including the new regression test.
- [x] `cargo clippy -p ao-plugin-scm-github -p ao-core --all-targets -- -D warnings` — clean.
- [x] `cargo fmt -p ao-plugin-scm-github -p ao-core --check` — clean on touched files.
- [x] `cargo test --doc -p ao-plugin-scm-github -p ao-core` — clean.

Closes #109

🤖 Generated with [Claude Code](https://claude.com/claude-code)