### PR TITLE
refactor(ui): extract ActiveDetail helper to deduplicate SessionDetail (#140)

### DIFF
--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -1,4 +1,4 @@
-import { lazy, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type Dispatch, lazy, type SetStateAction, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 import {
   type ApiEvent,
   type ApiSession,
@@ -35,6 +35,38 @@ function TerminalPanel({
     >
       <TerminalLazy baseUrl={baseUrl} sessionId={sessionId} />
     </Suspense>
+  );
+}
+
+function ActiveDetail({
+  session,
+  baseUrl,
+  setSessions,
+  onRefresh,
+}: {
+  session: DashboardSession | null;
+  baseUrl: string;
+  setSessions: Dispatch<SetStateAction<ApiSession[]>>;
+  onRefresh: () => Promise<void>;
+}) {
+  if (!session) return <div className="hint">select a session</div>;
+  return (
+    <SessionDetail
+      session={session}
+      onSendMessage={async (msg) => {
+        await sendMessage(baseUrl, session.id, msg);
+        await onRefresh();
+      }}
+      onKill={async () => {
+        await killSession(baseUrl, session.id);
+        await onRefresh();
+      }}
+      onRestore={async () => {
+        const updated = await restoreSession(baseUrl, session.id);
+        setSessions((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
+        await onRefresh();
+      }}
+    />
   );
 }
 
@@ -648,26 +680,12 @@ export function App() {
                 <section className="panel">
                   <div className="panel__title">Session Detail</div>
                   <div style={{ padding: 10 }}>
-                    {activeSession ? (
-                      <SessionDetail
-                        session={activeSession}
-                        onSendMessage={async (msg) => {
-                          await sendMessage(baseUrl, activeSession.id, msg);
-                          await refreshSessionsWithPr();
-                        }}
-                        onKill={async () => {
-                          await killSession(baseUrl, activeSession.id);
-                          await refreshSessionsWithPr();
-                        }}
-                        onRestore={async () => {
-                          const updated = await restoreSession(baseUrl, activeSession.id);
-                          setSessions((prev) => prev.map((s) => (s.id === updated.id ? updated : s)));
-                          await refreshSessionsWithPr();
-                        }}
-                      />
-                    ) : (
-                      <div className="hint">select a session</div>
-                    )}
+                    <ActiveDetail
+                      session={activeSession}
+                      baseUrl={baseUrl}
+                      setSessions={setSessions}
+                      onRefresh={refreshSessionsWithPr}
+                    />
                   </div>
                 </section>
 
@@ -690,28 +708,12 @@ export function App() {
             <section className="panel">
               <div className="panel__title">Session Detail</div>
               <div style={{ padding: 10 }}>
-                {selectedSession ? (
-                  <SessionDetail
-                    session={selectedSession}
-                    onSendMessage={async (msg) => {
-                      await sendMessage(baseUrl, selectedSession.id, msg);
-                      await refreshSessionsWithPr();
-                    }}
-                    onKill={async () => {
-                      await killSession(baseUrl, selectedSession.id);
-                      await refreshSessionsWithPr();
-                    }}
-                    onRestore={async () => {
-                      const updated = await restoreSession(baseUrl, selectedSession.id);
-                      setSessions((prev) =>
-                        prev.map((s) => (s.id === updated.id ? updated : s)),
-                      );
-                      await refreshSessionsWithPr();
-                    }}
-                  />
-                ) : (
-                  <div className="hint">select a session</div>
-                )}
+                <ActiveDetail
+                  session={selectedSession}
+                  baseUrl={baseUrl}
+                  setSessions={setSessions}
+                  onRefresh={refreshSessionsWithPr}
+                />
               </div>
             </section>
 


### PR DESCRIPTION
## Summary
- `App.tsx` rendered `<SessionDetail>` in two nearly-identical blocks (regular tab view + `detailOnly` Tauri embedded view), each with the same `onSendMessage` / `onKill` / `onRestore` handlers. Any future change had to be made in two places.
- Extract a small top-level `ActiveDetail` component that owns the three handlers and the "select a session" fallback. Both render paths now call `<ActiveDetail />` with the appropriate session.
- Behavior is unchanged — the handlers read exactly the same APIs (`sendMessage`, `killSession`, `restoreSession`) and still trigger `refreshSessionsWithPr` after each action, with the same optimistic `setSessions` update on restore.

## Test plan
- [x] `npm run typecheck` passes.
- [x] `npm test` — all 22 existing tests pass (including `App session tabs` which exercises the regular-view `SessionDetail`).
- [x] `npm run build` produces a clean bundle.

Closes #140

🤖 Generated with [Claude Code](https://claude.com/claude-code)