### PR TITLE
feat(events): add SessionRestored variant (#108)

### DIFF
--- a/crates/ao-cli/src/cli/printing.rs
+++ b/crates/ao-cli/src/cli/printing.rs
@@ -47,6 +47,18 @@ pub(crate) fn print_event(event: &OrchestratorEvent) {
         OrchestratorEvent::Spawned { id, project_id } => {
             println!("{:<10} {:<20} project={project_id}", short(id), "spawned");
         }
+        OrchestratorEvent::SessionRestored {
+            id,
+            project_id,
+            status,
+        } => {
+            println!(
+                "{:<10} {:<20} project={project_id} status={}",
+                short(id),
+                "session_restored",
+                status.as_str()
+            );
+        }
         OrchestratorEvent::StatusChanged { id, from, to } => {
             println!(
                 "{:<10} {:<20} {} → {}",

--- a/crates/ao-core/src/events.rs
+++ b/crates/ao-core/src/events.rs
@@ -8,6 +8,10 @@
 //!
 //! We keep the event surface intentionally small for Phase C:
 //! - `Spawned` when a brand-new session is observed for the first time
+//! - `SessionRestored` when a session that already existed on disk is
+//!   observed on the loop's first tick — separate from `Spawned` so
+//!   `watch` and dashboard consumers don't mislabel pre-existing
+//!   sessions as new
 //! - `StatusChanged` when lifecycle transitions a session between
 //!   `SessionStatus` variants
 //! - `ActivityChanged` when the polled `ActivityState` changes
@@ -36,9 +40,27 @@ pub struct UiNotification {
 #[derive(Debug, Clone, Serialize)]
 #[serde(tag = "type", rename_all = "snake_case")]
 pub enum OrchestratorEvent {
-    /// A session was seen by the lifecycle loop for the first time.
-    /// (Emitted on the tick where the loop first observes it on disk.)
+    /// A session was created after the lifecycle loop was already running.
+    /// The loop decides "new" by comparing `session.created_at` against its
+    /// own startup timestamp — a session observed on the first tick whose
+    /// `created_at` predates startup is reported via `SessionRestored`
+    /// instead, so `watch` output distinguishes "brand new spawn" from
+    /// "restored from disk".
     Spawned { id: SessionId, project_id: String },
+
+    /// A session that already existed on disk was observed by the
+    /// lifecycle loop on its first tick after startup. Emitted at most
+    /// once per session and only during the first tick — subsequent
+    /// appearances use `Spawned`. Consumers use this to suppress the
+    /// "N sessions just spawned" flood on reconnect.
+    SessionRestored {
+        id: SessionId,
+        project_id: String,
+        /// On-disk status at the moment of observation. Useful for UI
+        /// filtering (e.g. skip terminal sessions) without an extra
+        /// snapshot round-trip.
+        status: SessionStatus,
+    },
 
     /// Lifecycle-driven status transition. `from == to` is never emitted.
     StatusChanged {
@@ -125,5 +147,144 @@ impl TerminationReason {
 impl std::fmt::Display for TerminationReason {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str(self.as_str())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    //! Serde tag checks — the wire form is public (SSE / logs), so a rename
+    //! is a breaking change. These tests pin every variant's `type` tag.
+
+    use super::*;
+    use serde_json::{json, Value};
+
+    fn tag_of(ev: &OrchestratorEvent) -> String {
+        let v: Value = serde_json::to_value(ev).unwrap();
+        v.get("type")
+            .and_then(Value::as_str)
+            .expect("event missing `type` tag")
+            .to_string()
+    }
+
+    fn sid(s: &str) -> SessionId {
+        SessionId(s.into())
+    }
+
+    #[test]
+    fn every_variant_has_expected_tag() {
+        let cases: &[(&str, OrchestratorEvent)] = &[
+            (
+                "spawned",
+                OrchestratorEvent::Spawned {
+                    id: sid("s1"),
+                    project_id: "demo".into(),
+                },
+            ),
+            (
+                "session_restored",
+                OrchestratorEvent::SessionRestored {
+                    id: sid("s1"),
+                    project_id: "demo".into(),
+                    status: SessionStatus::Spawning,
+                },
+            ),
+            (
+                "status_changed",
+                OrchestratorEvent::StatusChanged {
+                    id: sid("s1"),
+                    from: SessionStatus::Spawning,
+                    to: SessionStatus::Working,
+                },
+            ),
+            (
+                "activity_changed",
+                OrchestratorEvent::ActivityChanged {
+                    id: sid("s1"),
+                    prev: None,
+                    next: ActivityState::Ready,
+                },
+            ),
+            (
+                "terminated",
+                OrchestratorEvent::Terminated {
+                    id: sid("s1"),
+                    reason: TerminationReason::AgentExited,
+                },
+            ),
+            (
+                "tick_error",
+                OrchestratorEvent::TickError {
+                    id: sid("s1"),
+                    message: "boom".into(),
+                },
+            ),
+            (
+                "reaction_triggered",
+                OrchestratorEvent::ReactionTriggered {
+                    id: sid("s1"),
+                    reaction_key: "ci-failed".into(),
+                    action: ReactionAction::Notify,
+                },
+            ),
+            (
+                "reaction_escalated",
+                OrchestratorEvent::ReactionEscalated {
+                    id: sid("s1"),
+                    reaction_key: "ci-failed".into(),
+                    attempts: 3,
+                },
+            ),
+            (
+                "ui_notification",
+                OrchestratorEvent::UiNotification {
+                    notification: UiNotification {
+                        id: sid("s1"),
+                        reaction_key: "ci-failed".into(),
+                        action: ReactionAction::Notify,
+                        message: None,
+                        priority: None,
+                    },
+                },
+            ),
+        ];
+
+        for (expected, ev) in cases {
+            assert_eq!(&tag_of(ev), expected, "wrong tag for {ev:?}");
+        }
+    }
+
+    #[test]
+    fn session_restored_carries_status_field() {
+        let ev = OrchestratorEvent::SessionRestored {
+            id: sid("s1"),
+            project_id: "demo".into(),
+            status: SessionStatus::Working,
+        };
+        let v: Value = serde_json::to_value(&ev).unwrap();
+        assert_eq!(
+            v,
+            json!({
+                "type": "session_restored",
+                "id": "s1",
+                "project_id": "demo",
+                "status": "working",
+            })
+        );
+    }
+
+    #[test]
+    fn termination_reason_wire_form_is_snake_case() {
+        assert_eq!(
+            serde_json::to_value(TerminationReason::RuntimeGone).unwrap(),
+            json!("runtime_gone")
+        );
+        assert_eq!(
+            serde_json::to_value(TerminationReason::AgentExited).unwrap(),
+            json!("agent_exited")
+        );
+        assert_eq!(
+            serde_json::to_value(TerminationReason::NoHandle).unwrap(),
+            json!("no_handle")
+        );
     }
 }

--- a/crates/ao-core/src/lifecycle.rs
+++ b/crates/ao-core/src/lifecycle.rs
@@ -46,8 +46,11 @@ use crate::{
 };
 use std::{
     collections::{HashMap, HashSet},
-    sync::{Arc, Mutex},
-    time::{Duration, Instant},
+    sync::{
+        atomic::{AtomicU64, Ordering},
+        Arc, Mutex,
+    },
+    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
 };
 use tokio::sync::broadcast;
 use tokio_util::sync::CancellationToken;
@@ -128,6 +131,11 @@ pub struct LifecycleManager {
     /// `tick()` Pass 1 so `poll_scm` reuses the result instead of
     /// calling `detect_pr` a second time.
     detected_prs_cache: Mutex<HashMap<SessionId, Option<PullRequest>>>,
+    /// Unix-ms when `run_loop` started. `0` means "not yet started"
+    /// (e.g. tests driving `tick` directly). Used by `tick` to
+    /// classify first-seen sessions as `SessionRestored` (created
+    /// before startup) vs. `Spawned` (created after).
+    startup_ms: AtomicU64,
 }
 
 impl LifecycleManager {
@@ -194,6 +202,7 @@ impl LifecycleManager {
             pr_enrichment_cache: Mutex::new(HashMap::new()),
             last_review_backlog_check: Mutex::new(HashMap::new()),
             detected_prs_cache: Mutex::new(HashMap::new()),
+            startup_ms: AtomicU64::new(0),
         }
     }
 
@@ -268,6 +277,19 @@ impl LifecycleManager {
         // Per-loop memory of which session IDs we've already announced via
         // `Spawned`, so we emit it exactly once per session observed.
         let mut seen: HashSet<SessionId> = HashSet::new();
+
+        // Record startup time so `tick` can distinguish sessions that
+        // predate this loop (emitted as `SessionRestored`) from sessions
+        // created after startup (emitted as `Spawned`). Set *before* the
+        // sweep so any session whose `created_at` equals or exceeds this
+        // moment is classified as new.
+        let startup_ms = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .map(|d| d.as_millis() as u64)
+            .unwrap_or(0);
+        // `0` is the "not started" sentinel — guard against clock skew
+        // that would stamp it as such.
+        self.startup_ms.store(startup_ms.max(1), Ordering::Relaxed);
 
         // Crash-recovery sweep: if the process restarted after a session was
         // persisted as `Merged` but before its worktree was destroyed (e.g.
@@ -384,12 +406,25 @@ impl LifecycleManager {
         }
 
         // Pass 2: poll each session.
+        let startup_ms = self.startup_ms.load(Ordering::Relaxed);
         for session in sessions {
             if seen.insert(session.id.clone()) {
-                self.emit(OrchestratorEvent::Spawned {
-                    id: session.id.clone(),
-                    project_id: session.project_id.clone(),
-                });
+                // Sessions that predate loop startup are restored from disk,
+                // not newly spawned. When `startup_ms == 0` (tests driving
+                // `tick` directly, no `run_loop`), preserve the original
+                // behaviour and emit `Spawned` for everything.
+                if startup_ms != 0 && session.created_at < startup_ms {
+                    self.emit(OrchestratorEvent::SessionRestored {
+                        id: session.id.clone(),
+                        project_id: session.project_id.clone(),
+                        status: session.status,
+                    });
+                } else {
+                    self.emit(OrchestratorEvent::Spawned {
+                        id: session.id.clone(),
+                        project_id: session.project_id.clone(),
+                    });
+                }
             }
 
             if session.is_terminal() {
@@ -1820,6 +1855,111 @@ mod tests {
             }
         }
         assert_eq!(spawned_count, 1);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn session_restored_emitted_for_preexisting_sessions_on_first_tick() {
+        // A session whose `created_at` predates the lifecycle loop's startup
+        // must surface as `SessionRestored`, not `Spawned`. The `created_at: 1`
+        // stamp is deliberately far in the past to eliminate scheduler races.
+        let base = unique_temp_dir("restored");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let mut old = fake_session("old", "demo");
+        old.created_at = 1;
+        old.status = SessionStatus::Working;
+        sessions.save(&old).await.unwrap();
+
+        let lifecycle = Arc::new(
+            LifecycleManager::new(
+                sessions.clone(),
+                Arc::new(MockRuntime::new(true)) as Arc<dyn Runtime>,
+                Arc::new(MockAgent::new(ActivityState::Ready)) as Arc<dyn Agent>,
+            )
+            .with_poll_interval(Duration::from_millis(20)),
+        );
+
+        let mut rx = lifecycle.subscribe();
+        let handle = lifecycle.spawn();
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let mut saw_restored = None;
+        let mut saw_spawned = false;
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_millis(100), rx.recv()).await {
+                Ok(Ok(OrchestratorEvent::SessionRestored {
+                    id,
+                    project_id,
+                    status,
+                })) => {
+                    saw_restored = Some((id, project_id, status));
+                    break;
+                }
+                Ok(Ok(OrchestratorEvent::Spawned { .. })) => {
+                    saw_spawned = true;
+                }
+                _ => {}
+            }
+        }
+
+        handle.stop().await;
+        assert!(
+            !saw_spawned,
+            "pre-existing session must not surface as Spawned"
+        );
+        let (id, project_id, status) = saw_restored.expect("SessionRestored was never emitted");
+        assert_eq!(id.0, "old");
+        assert_eq!(project_id, "demo");
+        assert_eq!(status, SessionStatus::Working);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn spawned_emitted_for_sessions_created_after_loop_startup() {
+        // A session created *after* `run_loop` records its startup timestamp
+        // takes the normal `Spawned` path. The assertion pins that the
+        // `created_at` comparison is direction-correct.
+        let base = unique_temp_dir("post-startup-spawn");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+
+        let lifecycle = Arc::new(
+            LifecycleManager::new(
+                sessions.clone(),
+                Arc::new(MockRuntime::new(true)) as Arc<dyn Runtime>,
+                Arc::new(MockAgent::new(ActivityState::Ready)) as Arc<dyn Agent>,
+            )
+            .with_poll_interval(Duration::from_millis(20)),
+        );
+
+        let mut rx = lifecycle.subscribe();
+        let handle = lifecycle.spawn();
+
+        // Ensure the loop has recorded its startup_ms before we stamp the new
+        // session. A brief sleep is cheaper than exposing startup_ms publicly.
+        tokio::time::sleep(Duration::from_millis(5)).await;
+        sessions.save(&fake_session("fresh", "demo")).await.unwrap();
+
+        let deadline = tokio::time::Instant::now() + Duration::from_secs(2);
+        let mut saw_spawned = false;
+        let mut saw_restored = false;
+        while tokio::time::Instant::now() < deadline {
+            match tokio::time::timeout(Duration::from_millis(100), rx.recv()).await {
+                Ok(Ok(OrchestratorEvent::Spawned { id, .. })) if id.0 == "fresh" => {
+                    saw_spawned = true;
+                    break;
+                }
+                Ok(Ok(OrchestratorEvent::SessionRestored { id, .. })) if id.0 == "fresh" => {
+                    saw_restored = true;
+                }
+                _ => {}
+            }
+        }
+
+        handle.stop().await;
+        assert!(!saw_restored, "fresh session must not surface as restored");
+        assert!(saw_spawned, "fresh session never surfaced as Spawned");
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/docs/issues/0108-events-minimal-surface.md
+++ b/docs/issues/0108-events-minimal-surface.md
@@ -1,0 +1,86 @@
+# Issue #108 — 7.3 events minimal surface
+
+Tracking: https://github.com/duonghb53/ao-rs/issues/108
+
+## Decision
+
+The `events.rs` surface is intentionally minimal. The issue warns against
+speculative expansion: "Add event variants only as needed by new UI/CLI
+features."
+
+Research against ao-ts (`~/study/agent-orchestrator`) shows its richer
+`EventType` (28 variants) is largely **dead code** — most variants are
+defined but never emitted, and the web/CLI consumers do not match on raw
+event types (they re-render from periodic session snapshots).
+
+ao-rs already models the PR/CI/merge lifecycle via `SessionStatus`, which
+flows through `OrchestratorEvent::StatusChanged`. Adding dedicated
+`PrOpened`/`CiFailed`/`MergeReady`/… variants would duplicate that channel
+without a consumer that needs the distinction.
+
+**The one real consumer-visible gap** in the current surface: `Spawned`
+fires on *first observation* of any session — including sessions that
+already existed on disk when the lifecycle loop started. A user running
+`ao-rs watch` sees a flood of "spawned" rows for pre-existing sessions,
+which is misleading. Dashboard SSE subscribers have the same problem.
+
+## Scope
+
+Add one variant:
+
+- `SessionRestored { id, project_id, status }` — emitted on the first
+  observation of a session whose `created_at` predates the lifecycle
+  loop's startup timestamp. Replaces `Spawned` for that case.
+
+`Spawned` retains its meaning: a session that *appeared* while the loop
+was already running (i.e. was created after startup).
+
+## Implementation
+
+### `crates/ao-core/src/events.rs`
+- Add `SessionRestored` variant with stable serde tag `session_restored`
+  (snake_case rename matches the existing enum convention).
+
+### `crates/ao-core/src/lifecycle.rs`
+- Add `startup_ms: AtomicU64` to `LifecycleManager`. Initialised to `0`
+  (meaning "not yet started"). Set in `run_loop` before the first tick.
+- In `tick()`, when `seen.insert()` returns true:
+  - If `startup_ms != 0 && session.created_at < startup_ms` →
+    emit `SessionRestored`.
+  - Otherwise → emit `Spawned` (existing behaviour).
+- Tests that call `tick(&mut seen)` directly without `run_loop` continue
+  to see `Spawned` because `startup_ms` stays at `0` — backwards
+  compatible.
+
+### `crates/ao-cli/src/cli/printing.rs`
+- Add match arm for `SessionRestored`, mirroring `Spawned`'s row shape
+  but labelling the event `session_restored`.
+
+### Consumers that auto-benefit
+- Dashboard SSE (`crates/ao-dashboard/src/sse.rs`) — passes raw events
+  through, no code change.
+- Notifier registry / reaction engine — not interested in this variant;
+  no change.
+
+## Race condition note
+
+A session created *between* `run_loop` startup and the first tick is
+correctly classified by the `created_at < startup_ms` check — its
+`created_at` will be greater than `startup_ms`, so it emits `Spawned`,
+not `SessionRestored`.
+
+## Tests
+
+1. Serde round-trip for all `OrchestratorEvent` variants (including the
+   new one) — covers stable tags.
+2. Lifecycle producer test:
+   - Seed two sessions: one with `created_at < startup_ms` (restored),
+     one with `created_at > startup_ms` (new). Drive one tick. Assert
+     one `SessionRestored` + one `Spawned`.
+
+## Acceptance criteria
+
+- `ao-rs watch` renders `session_restored` rows for pre-existing
+  sessions instead of `spawned`.
+- Dashboard SSE stream carries the new variant unchanged.
+- `cargo t` green; `cargo clippy` clean; `cargo fmt` applied.


### PR DESCRIPTION
## Summary
- Adds `OrchestratorEvent::SessionRestored { id, project_id, status }` to disambiguate "pre-existing session observed on first tick" from "brand-new session spawned while the loop was running"
- Lifecycle loop records its startup Unix-ms before the sweep; `tick()` picks `SessionRestored` vs `Spawned` by comparing `session.created_at` against that timestamp
- `ao-rs watch` renders the new variant; dashboard SSE passes it through unchanged

## Why this scope
Issue #108 explicitly warns against speculative expansion. A quick audit of ao-ts showed most of its richer `EventType` values are dead code (defined but never emitted), and ao-rs already covers PR/CI/merge semantics via `StatusChanged` + `SessionStatus`. The one real consumer-visible gap was `Spawned` firing for pre-existing sessions on daemon startup — this PR fixes that gap and nothing else. Design notes live in `docs/issues/0108-events-minimal-surface.md`.

## Test plan
- [x] Serde tag stability test covering all `OrchestratorEvent` variants (`events::tests::every_variant_has_expected_tag`)
- [x] `session_restored` wire form pinned (`events::tests::session_restored_carries_status_field`)
- [x] Producer test: pre-existing session surfaces as `SessionRestored` (`lifecycle::tests::session_restored_emitted_for_preexisting_sessions_on_first_tick`)
- [x] Producer test: session created after loop startup surfaces as `Spawned` (`lifecycle::tests::spawned_emitted_for_sessions_created_after_loop_startup`)
- [x] `cargo t --workspace --no-fail-fast` — 775 tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] Existing `spawned_is_emitted_only_once_per_session` and other lifecycle tests unchanged — they call `tick` directly, leaving `startup_ms = 0`, which keeps the original `Spawned` behavior

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)