### PR TITLE
feat(scm-github): host-agnostic parse_github_remote for GHE (#110)

### DIFF
--- a/crates/plugins/scm-github/src/lib.rs
+++ b/crates/plugins/scm-github/src/lib.rs
@@ -850,41 +850,71 @@ async fn run(bin: &str, args: &[&str], cwd: Option<&Path>) -> Result<String> {
 
 /// Discover `(owner, repo)` from the workspace's `origin` remote.
 ///
-/// Accepts GitHub's three canonical URL forms:
+/// Accepts GitHub-shaped URLs for any hostname — github.com **and**
+/// GitHub Enterprise (GHES) remotes:
 ///
 /// - `https://github.com/owner/repo.git`
-/// - `https://github.com/owner/repo`
-/// - `git@github.com:owner/repo.git`
+/// - `https://ghe.example.com/owner/repo.git`
+/// - `git@ghe.example.com:owner/repo.git`
+/// - `ssh://git@ghe.example.com/owner/repo.git`
 ///
-/// Returns an error for anything that isn't plausibly github.com-shaped.
-/// This is the single choke point for "is this session on GitHub?" — every
-/// `gh` call flows through `detect_pr`, which uses this.
+/// Routing to the right API host is handled by the `gh` CLI's own
+/// config (`gh auth login --hostname`, or the `GH_HOST` env var), so
+/// once the URL parses, `gh` talks to the right server.
+///
+/// Returns an error for anything that isn't plausibly GitHub-shaped
+/// (i.e. not a bare `owner/repo` path). This is the single choke point
+/// for "is this session on GitHub?" — every `gh` call flows through
+/// `detect_pr`, which uses this.
 async fn discover_origin(workspace: &Path) -> Result<(String, String)> {
     let url = git_in(workspace, &["remote", "get-url", "origin"]).await?;
     parse_github_remote(url.trim())
         .ok_or_else(|| AoError::Scm(format!("origin is not a github remote: {url:?}")))
 }
 
-/// Extract `(owner, repo)` from a GitHub remote URL. Pulled out as a pure
-/// function so the matrix of accepted URL shapes can be unit-tested.
+/// Extract `(owner, repo)` from a GitHub-shaped remote URL. Pulled out
+/// as a pure function so the matrix of accepted URL shapes can be
+/// unit-tested.
+///
+/// Host-agnostic: any hostname is accepted as long as the path shape is
+/// the strict `owner/repo[.git]` GitHub uses. That covers GitHub
+/// Enterprise out of the box without sacrificing the safety rule that
+/// forbids extra path segments (which would risk silently pointing at
+/// the wrong repo).
 pub(crate) fn parse_github_remote(url: &str) -> Option<(String, String)> {
     // Trim a trailing `.git` once; leave the rest untouched.
     let trimmed = url.strip_suffix(".git").unwrap_or(url);
 
-    // Case 1: https://github.com/owner/repo[/...]
+    // Case 1: https://<host>/owner/repo[/...]
     if let Some(rest) = trimmed
-        .strip_prefix("https://github.com/")
-        .or_else(|| trimmed.strip_prefix("http://github.com/"))
+        .strip_prefix("https://")
+        .or_else(|| trimmed.strip_prefix("http://"))
     {
-        return split_owner_repo(rest);
+        let (host, path) = rest.split_once('/')?;
+        if host.trim().is_empty() {
+            return None;
+        }
+        return split_owner_repo(path);
     }
-    // Case 2: git@github.com:owner/repo
-    if let Some(rest) = trimmed.strip_prefix("git@github.com:") {
-        return split_owner_repo(rest);
+    // Case 2: ssh://git@<host>/owner/repo
+    //
+    // Checked before the `git@` case because `ssh://git@host/...` also
+    // starts with `git@` once the `ssh://` prefix has been stripped —
+    // which it hasn't here, so the literal prefix match is safe.
+    if let Some(rest) = trimmed.strip_prefix("ssh://git@") {
+        let (host, path) = rest.split_once('/')?;
+        if host.trim().is_empty() {
+            return None;
+        }
+        return split_owner_repo(path);
     }
-    // Case 3: ssh://git@github.com/owner/repo
-    if let Some(rest) = trimmed.strip_prefix("ssh://git@github.com/") {
-        return split_owner_repo(rest);
+    // Case 3: git@<host>:owner/repo
+    if let Some(rest) = trimmed.strip_prefix("git@") {
+        let (host, path) = rest.split_once(':')?;
+        if host.trim().is_empty() {
+            return None;
+        }
+        return split_owner_repo(path);
     }
     None
 }
@@ -991,10 +1021,61 @@ mod tests {
     }
 
     #[test]
-    fn parse_github_remote_rejects_non_github() {
-        assert_eq!(parse_github_remote("https://gitlab.com/a/b.git"), None);
+    fn parse_github_remote_rejects_non_url_inputs() {
+        // The parser is host-agnostic (to support GHE), so anything that
+        // *looks* like `https://<host>/owner/repo` will match. These
+        // inputs don't, and must still be rejected.
         assert_eq!(parse_github_remote("not a url at all"), None);
         assert_eq!(parse_github_remote(""), None);
+        assert_eq!(parse_github_remote("https://"), None);
+        assert_eq!(parse_github_remote("https:///owner/repo"), None);
+        assert_eq!(parse_github_remote("git@:owner/repo.git"), None);
+        assert_eq!(parse_github_remote("ssh://git@/owner/repo.git"), None);
+    }
+
+    #[test]
+    fn parse_github_remote_accepts_github_enterprise_hosts() {
+        // Acceptance for issue #110: GHES remotes must parse the same
+        // way github.com ones do so the plugin works end-to-end on
+        // enterprise instances. `gh` handles host routing via its own
+        // auth config; this parser just needs to extract owner/repo.
+        assert_eq!(
+            parse_github_remote("https://ghe.example.com/acme/widgets.git"),
+            Some(("acme".into(), "widgets".into()))
+        );
+        assert_eq!(
+            parse_github_remote("https://ghe.example.com/acme/widgets"),
+            Some(("acme".into(), "widgets".into()))
+        );
+        assert_eq!(
+            parse_github_remote("git@ghe.example.com:acme/widgets.git"),
+            Some(("acme".into(), "widgets".into()))
+        );
+        assert_eq!(
+            parse_github_remote("ssh://git@ghe.example.com/acme/widgets.git"),
+            Some(("acme".into(), "widgets".into()))
+        );
+    }
+
+    #[test]
+    fn parse_github_remote_ghe_rejects_extra_path_segments() {
+        // Same safety rule as github.com: exotic GHE path prefixes
+        // (e.g. `/orgs/foo/owner/repo`) must fail closed rather than
+        // silently pointing the plugin at the wrong repo. Users with
+        // unusual path layouts should set `projects.<id>.repo`
+        // explicitly in `ao-rs.yaml`.
+        assert_eq!(
+            parse_github_remote("https://ghe.example.com/owner/repo/extra"),
+            None
+        );
+        assert_eq!(
+            parse_github_remote("git@ghe.example.com:owner/repo/extra"),
+            None
+        );
+        assert_eq!(
+            parse_github_remote("ssh://git@ghe.example.com/owner/repo/extra.git"),
+            None
+        );
     }
 
     #[test]

--- a/docs/plans/remaining-to-port/7-5-github-enterprise-remote-parsing.md
+++ b/docs/plans/remaining-to-port/7-5-github-enterprise-remote-parsing.md
@@ -1,46 +1,65 @@
 # 7.5 github enterprise remote parsing
 
-Status: planned
+Status: done (#110)
 
-## Why
+## Decision
 
-`parse_github_remote` is strict and only supports github.com-shaped remotes (`owner/repo`). This blocks GitHub Enterprise or nonstandard remote URL shapes.
+Make `parse_github_remote` **host-agnostic** — accept any hostname in
+the three GitHub-shaped URL forms rather than hard-coding `github.com`.
+Route-to-host is `gh`'s job (its own auth config / `GH_HOST`), so the
+parser only needs to extract `owner/repo`. This mirrors what the
+GitLab SCM plugin already does (`parse_gitlab_remote`) and matches
+ao-ts, which never parses remotes at all — it trusts the
+`ProjectConfig.repo` field.
 
-## Current state (ao-rs)
+The safety rule (reject extra path segments beyond `owner/repo`) is
+preserved: exotic GHE path prefixes like `https://ghe/orgs/.../owner/repo`
+still fail closed. Users with those layouts must set
+`projects.<id>.repo` explicitly in `ao-rs.yaml`, which `resolve_pr`
+already honors.
 
-- `crates/plugins/scm-github/src/lib.rs` (and parsing helpers) enforce strict `owner/repo`.
-- Extra path segments are rejected to avoid silently using the wrong repo.
+## What landed
 
-## Target behavior (parity/maturity)
+- `crates/plugins/scm-github/src/lib.rs`
+  - `parse_github_remote` now accepts any `<host>` for all three URL
+    shapes: `https://<host>/owner/repo[.git]`,
+    `git@<host>:owner/repo[.git]`, and
+    `ssh://git@<host>/owner/repo[.git]`. Empty hosts and missing paths
+    are rejected.
+  - Updated the `discover_origin` doc comment to list GHE URLs
+    alongside github.com.
+  - New unit tests covering GHE HTTPS/SSH acceptance and extra-segment
+    rejection on GHE hosts. The previous `rejects_non_github` test
+    (which asserted `gitlab.com` URLs fail) was replaced with
+    `rejects_non_url_inputs` — the parser is now host-agnostic, so a
+    plain `https://gitlab.com/...` URL *does* parse; AutoScm's
+    GitLab-first fallback handles the routing.
 
-- Support common GitHub Enterprise remote URL patterns without sacrificing safety.
+## Why no explicit-config-override plumbing
 
-## Proposed approach
+`ProjectConfig.repo` is already required and validated (`ao-core`
+config.rs `validate_projects`), and `resolve_pr` already reads it.
+The only place that auto-detects repo from the workspace remote is
+`detect_pr` discovery, which now handles the common GHE shapes
+directly. Threading `ProjectConfig.repo` into `detect_pr` would
+require either (a) adding repo to `Session` (breaks persistence) or
+(b) widening the `Scm::detect_pr` signature (breaks the plugin trait).
+Neither is justified by a rare exotic-path-prefix edge case — users
+in that position can set `projects.<id>.repo` and use
+`resolve_pr`-based flows.
 
-1. Extend remote parsing to accept:
-   - `https://ghe.example.com/owner/repo.git`
-   - `git@ghe.example.com:owner/repo.git`
-2. Keep safety rules:
-   - Still reject URLs with extra segments beyond `owner/repo`.
-   - Normalize `.git` suffix.
-3. Add an optional config override:
-   - Allow specifying `repo: owner/repo` explicitly in config to bypass remote parsing.
+## Parity status
 
-## Files to change
+- GitHub-shaped URL parsing is now on feature parity with the GitLab
+  plugin.
+- ao-ts parity: ao-ts relies on `projectRepo` string without parsing
+  remotes at all, so this change brings ao-rs closer by being more
+  permissive with host.
 
-- `crates/plugins/scm-github/src/lib.rs` (remote parsing helper)
-- `crates/ao-core/src/config.rs` (ensure explicit `repo` config is used first, if not already)
+## Follow-ups
 
-## Acceptance criteria
-
-- Projects hosted on GitHub Enterprise can use SCM GitHub plugin successfully.
-- Misformatted remotes still fail loudly with actionable error messages.
-
-## Test plan
-
-- Unit tests for remote parsing with multiple URL formats.
-
-## Risks / notes
-
-- Enterprise instances may have additional path prefixes; decide whether to support them or require explicit `repo` config.
-
+If a user reports an exotic GHE path layout (e.g. `/orgs/<org>/<repo>`)
+that a host-agnostic parse still can't handle, the right fix is to
+plumb `ProjectConfig.repo` into `detect_pr` — likely via a thin
+`ScmContext` wrapper — rather than making the parser progressively
+looser.

--- a/docs/remaining-to-port.md
+++ b/docs/remaining-to-port.md
@@ -227,9 +227,16 @@ Decision needed: integrate into runtime or keep as test infrastructure only.
 - See `docs/plans/remaining-to-port/7-4-default-merge-method.md` and the
   "Default merge method" subsection in `docs/reactions.md`.
 
-### 7.5 GitHub Enterprise
+### 7.5 GitHub Enterprise — **resolved (#110)**
 
-- `parse_github_remote` only handles github.com-shaped URLs (strict `owner/repo`)
+- `parse_github_remote` is now host-agnostic: `https://<host>/owner/repo`,
+  `git@<host>:owner/repo`, and `ssh://git@<host>/owner/repo` all work for
+  any hostname. The strict `owner/repo` path shape is preserved so
+  misformatted remotes still fail loudly.
+- Routing stays with `gh` (its own auth config / `GH_HOST`). Exotic GHE
+  path prefixes (`/orgs/<org>/<repo>`) still need an explicit
+  `projects.<id>.repo` in config.
+- See `docs/plans/remaining-to-port/7-5-github-enterprise-remote-parsing.md`.
 
 ---
 

--- a/docs/validation-ported-code.md
+++ b/docs/validation-ported-code.md
@@ -83,7 +83,7 @@ Status: **Complete audit** — comment-driven parity map based on what ao-rs cla
 - **Review thread resolution**: REST `pending_comments` cannot expose `is_resolved` (always `false`). TODO for GraphQL `reviewThreads` or consumer-side dedupe. Risk of spamming `changes-requested` reactions.
 - **Webhooks**: explicitly out of `scm-github` plugin scope
 - **Bot-comment severity**: reaction-engine concern, not SCM
-- **GitHub Enterprise**: `parse_github_remote` is github.com-shaped only (strict `owner/repo`)
+- **GitHub Enterprise**: `parse_github_remote` is host-agnostic (strict `owner/repo` path, any hostname — resolved in #110). Exotic GHE path prefixes still need explicit `projects.<id>.repo`.
 - **ETag 304 detection**: uses `output.contains("304")` — brittle vs structured headers
 - **GraphQL vs REST merge readiness**: two parallel implementations of similar rules (could drift)
 


### PR DESCRIPTION
## Summary

- `parse_github_remote` now accepts any hostname for the three GitHub-shaped URL forms (HTTPS, `git@host:`, `ssh://git@host/`), so GitHub Enterprise remotes are picked up by `detect_pr` without sacrificing the strict `owner/repo` path rule.
- Route-to-host stays with `gh` (its own auth config / `GH_HOST`); the parser only extracts owner/repo. Exotic GHE path prefixes still fail closed and users set `projects.<id>.repo` explicitly for those — `resolve_pr` already honors it.
- Updated design doc (`docs/plans/remaining-to-port/7-5-…md`) to Status: done and trimmed the companion notes in `docs/remaining-to-port.md` / `docs/validation-ported-code.md`.

Closes #110.

## Test plan

- [x] `cargo t -p ao-plugin-scm-github` — 88/88 pass, including 6 `parse_github_remote_*` tests covering GHE HTTPS/SSH acceptance, extra-segment rejection on GHE hosts, and non-URL inputs.
- [x] `cargo t` across the workspace — 788/788 pass.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)