### PR TITLE
feat(ui): show active session count in topbar (#141)

### DIFF
--- a/crates/ao-desktop/ui/src/ui/App.test.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.test.tsx
@@ -33,6 +33,16 @@ vi.mock("../api/client", () => {
   };
 });
 
+describe("topbar active counter", () => {
+  it("shows the count of non-terminal sessions next to the connection pill", async () => {
+    render(<App />);
+
+    // Both mocked sessions (pr_open, working) are non-terminal.
+    const counter = await screen.findByLabelText("2 active sessions");
+    expect(counter).toHaveTextContent("2 active");
+  });
+});
+
 describe("App session tabs", () => {
   it("shows the session detail for the active session tab", async () => {
     const user = userEvent.setup();

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -14,7 +14,7 @@ import { ProjectSidebar } from "../components/ProjectSidebar";
 import { SessionDetail } from "../components/SessionDetail";
 import { getSessionTabLabel } from "../lib/format";
 import type { DashboardSession } from "../lib/types";
-import { getAttentionLevel } from "../lib/types";
+import { getAttentionLevel, isTerminalSession } from "../lib/types";
 
 const TerminalLazy = lazy(() => import("../components/TerminalView"));
 
@@ -366,6 +366,11 @@ export function App() {
     return dashboardSessions.filter((s) => s.projectId === selectedProjectId);
   }, [dashboardSessions, selectedProjectId]);
 
+  const activeCount = useMemo(
+    () => dashboardSessions.filter((s) => !isTerminalSession(s)).length,
+    [dashboardSessions],
+  );
+
   const selectedSession = useMemo(() => {
     if (!selectedSessionId) return null;
     return dashboardSessions.find((s) => s.id === selectedSessionId) ?? null;
@@ -488,6 +493,9 @@ export function App() {
             {connLabel}
           </span>
         </button>
+        <span className="hint" aria-label={`${activeCount} active sessions`} title="Non-terminal sessions">
+          {activeCount} active
+        </span>
         <div className="controls">
           <span className="hint">Dashboard URL</span>
           <input


### PR DESCRIPTION
## Summary
- Adds a small "N active" counter in the topbar next to the connection pill, showing the number of non-terminal sessions (working + pending + review + merge).
- Keeps the existing connection pill and controls untouched; counter uses the existing `.hint` styling.

Closes #141.

## Test plan
- [x] `./node_modules/.bin/vitest run` — 23/23 pass, including a new test asserting the counter reflects the two non-terminal mock sessions.
- [ ] Manual: run `npm run dev` in `crates/ao-desktop/ui/`, connect to `ao-dashboard`, verify the counter updates as sessions spawn/are killed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)