### PR TITLE
feat(ui): flexible TerminalView height (min 360px, 50vh) (#148)

### DIFF
--- a/crates/ao-desktop/ui/src/components/TerminalView.test.tsx
+++ b/crates/ao-desktop/ui/src/components/TerminalView.test.tsx
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+
+vi.mock("@xterm/xterm", () => {
+  class FakeTerminal {
+    cols = 80;
+    rows = 24;
+    loadAddon() {}
+    open() {}
+    focus() {}
+    reset() {}
+    writeln() {}
+    write() {}
+    onData() {
+      return { dispose: () => {} };
+    }
+    dispose() {}
+  }
+  return { Terminal: FakeTerminal };
+});
+
+vi.mock("@xterm/addon-fit", () => {
+  class FakeFitAddon {
+    fit() {}
+  }
+  return { FitAddon: FakeFitAddon };
+});
+
+vi.mock("@xterm/xterm/css/xterm.css", () => ({}));
+
+import { TerminalView } from "./TerminalView";
+
+describe("TerminalView host sizing", () => {
+  afterEach(() => {
+    cleanup();
+  });
+
+  it("uses flexible height (50vh) with a 360px minimum", () => {
+    const { container } = render(<TerminalView baseUrl="http://localhost" sessionId={null} />);
+    const host = container.firstElementChild as HTMLElement | null;
+    expect(host).not.toBeNull();
+    expect(host!.style.minHeight).toBe("360px");
+    expect(host!.style.height).toBe("50vh");
+    expect(host!.style.width).toBe("100%");
+  });
+});

--- a/crates/ao-desktop/ui/src/components/TerminalView.tsx
+++ b/crates/ao-desktop/ui/src/components/TerminalView.tsx
@@ -234,7 +234,7 @@ export function TerminalView({
     <div
       ref={hostRef}
       tabIndex={0}
-      style={{ height: 360, width: "100%", outline: "none" }}
+      style={{ minHeight: 360, height: "50vh", width: "100%", outline: "none" }}
       onMouseDown={() => forceFocus()}
       onFocus={() => forceFocus()}
     />


### PR DESCRIPTION
## Summary
- Change `TerminalView` host div from fixed `height: 360` to `minHeight: 360, height: "50vh"` so the terminal panel grows with the viewport.
- xterm's `FitAddon` + `ResizeObserver` already reflow cols/rows on container resize, so no additional plumbing is needed.
- Adds a small vitest unit test (with mocked `@xterm/xterm`/`@xterm/addon-fit`) that asserts the host div's inline `min-height`, `height`, and `width`.

Closes #148

## Test plan
- [x] `npm run test` (vitest) — 23/23 passing
- [x] `npm run typecheck` — clean
- [ ] Manual: open a session, confirm the terminal panel fills ~half the viewport and reflows when the window is resized

🤖 Generated with [Claude Code](https://claude.com/claude-code)