### PR TITLE
refactor(ui): extract SSE and toast logic from App.tsx into hooks (#142)

### DIFF
--- a/crates/ao-desktop/ui/src/hooks/useSessions.test.tsx
+++ b/crates/ao-desktop/ui/src/hooks/useSessions.test.tsx
@@ -1,0 +1,276 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import type { ApiEvent, ApiSession } from "../api/client";
+
+type Handlers = {
+  onOpen?: () => void;
+  onError?: (msg: string) => void;
+  onEvent?: (evt: ApiEvent) => void;
+};
+
+const handlersRef: { current: Handlers | null } = { current: null };
+const fakeEs = { close: vi.fn() };
+const getSessionsMock = vi.fn<(baseUrl: string, opts?: { pr?: boolean }) => Promise<ApiSession[]>>();
+const connectEventsMock = vi.fn<(baseUrl: string, h: Handlers) => typeof fakeEs>((_url, h) => {
+  handlersRef.current = h;
+  return fakeEs;
+});
+
+vi.mock("../api/client", () => ({
+  getSessions: (...args: Parameters<typeof getSessionsMock>) => getSessionsMock(...args),
+  connectEvents: (...args: Parameters<typeof connectEventsMock>) => connectEventsMock(...args),
+}));
+
+// Import under test AFTER vi.mock so the mocks are in place.
+import { useSessions } from "./useSessions";
+
+function session(id: string): ApiSession {
+  return {
+    id,
+    project_id: "ao-rs",
+    status: "working",
+    activity: null,
+    branch: "main",
+    task: "do things",
+    agent: "claude",
+  };
+}
+
+beforeEach(() => {
+  vi.useFakeTimers();
+  getSessionsMock.mockReset();
+  connectEventsMock.mockReset();
+  connectEventsMock.mockImplementation((_url, h) => {
+    handlersRef.current = h;
+    return fakeEs;
+  });
+  fakeEs.close.mockReset();
+  handlersRef.current = null;
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+/** Drain pending microtasks *and* timers until the hook settles. */
+async function flush() {
+  await act(async () => {
+    await vi.runAllTimersAsync();
+  });
+}
+
+describe("useSessions", () => {
+  it("fetches fast then enriches with PR on mount", async () => {
+    const fast = [session("s1")];
+    const enriched = [{ ...session("s1"), attention_level: "review" }];
+    getSessionsMock.mockResolvedValueOnce(fast).mockResolvedValueOnce(enriched);
+
+    const { result } = renderHook(() => useSessions("http://x"));
+
+    await flush();
+
+    expect(getSessionsMock).toHaveBeenNthCalledWith(1, "http://x");
+    expect(getSessionsMock).toHaveBeenNthCalledWith(2, "http://x", { pr: true });
+    expect(result.current.sessions).toEqual(enriched);
+    expect(connectEventsMock).toHaveBeenCalledTimes(1);
+    expect(result.current.conn.kind).toBe("connecting");
+  });
+
+  it("marks connection as connected when SSE opens", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const { result } = renderHook(() => useSessions("http://x"));
+    await flush();
+
+    act(() => handlersRef.current?.onOpen?.());
+    expect(result.current.conn).toEqual({ kind: "connected" });
+  });
+
+  it("updates sessions from an SSE snapshot event", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const { result } = renderHook(() => useSessions("http://x"));
+    await flush();
+
+    const snapshot: ApiEvent = { type: "snapshot", sessions: [session("live")] };
+    act(() => handlersRef.current?.onEvent?.(snapshot));
+
+    expect(result.current.sessions).toEqual([session("live")]);
+  });
+
+  it("routes ui_notification events through onNotification", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const onNotification = vi.fn();
+    renderHook(() => useSessions("http://x", { onNotification }));
+    await flush();
+
+    const notif: ApiEvent = {
+      type: "ui_notification",
+      notification: {
+        id: "sess-123",
+        reaction_key: "respond",
+        action: "ack",
+        priority: "high",
+        message: "needs reply",
+      },
+    };
+    act(() => handlersRef.current?.onEvent?.(notif));
+
+    expect(onNotification).toHaveBeenCalledTimes(1);
+    expect(onNotification).toHaveBeenCalledWith({
+      sessionId: "sess-123",
+      reactionKey: "respond",
+      action: "ack",
+      priority: "high",
+      message: "needs reply",
+    });
+  });
+
+  it("ignores ui_notification events that lack id or reaction_key", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const onNotification = vi.fn();
+    renderHook(() => useSessions("http://x", { onNotification }));
+    await flush();
+
+    act(() =>
+      handlersRef.current?.onEvent?.({
+        type: "ui_notification",
+        notification: { id: "only-id" },
+      } as unknown as ApiEvent),
+    );
+
+    expect(onNotification).not.toHaveBeenCalled();
+  });
+
+  it("forwards non-snapshot events via onEvent", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const onEvent = vi.fn();
+    renderHook(() => useSessions("http://x", { onEvent }));
+    await flush();
+
+    const evt: ApiEvent = { type: "custom", payload: 1 } as ApiEvent;
+    act(() => handlersRef.current?.onEvent?.(evt));
+
+    expect(onEvent).toHaveBeenCalledWith(evt);
+  });
+
+  it("debounces scheduleRefresh inside a 400ms window", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const { result } = renderHook(() => useSessions("http://x"));
+    await flush();
+
+    // Clear calls from the initial fast + PR enrich + any post-event refresh.
+    getSessionsMock.mockClear();
+    getSessionsMock.mockResolvedValue([]);
+
+    act(() => {
+      result.current.scheduleRefresh();
+      result.current.scheduleRefresh();
+      result.current.scheduleRefresh();
+    });
+
+    // Nothing fires before the debounce window elapses.
+    expect(getSessionsMock).not.toHaveBeenCalled();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+
+    expect(getSessionsMock).toHaveBeenCalledTimes(1);
+    expect(getSessionsMock).toHaveBeenCalledWith("http://x");
+  });
+
+  it("schedules reconnect with exponential backoff on SSE error", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const { result } = renderHook(() => useSessions("http://x"));
+    await flush();
+    expect(connectEventsMock).toHaveBeenCalledTimes(1);
+
+    // First error → 1s delay before reconnect attempt.
+    act(() => handlersRef.current?.onError?.("boom"));
+    expect(result.current.conn.kind).toBe("error");
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(999);
+    });
+    expect(connectEventsMock).toHaveBeenCalledTimes(1); // not yet
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(connectEventsMock).toHaveBeenCalledTimes(2);
+
+    // Second error → 2s delay.
+    act(() => handlersRef.current?.onError?.("boom2"));
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1_999);
+    });
+    expect(connectEventsMock).toHaveBeenCalledTimes(2);
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(1);
+    });
+    expect(connectEventsMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("retryConnection resets retries and reconnects immediately", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const { result } = renderHook(() => useSessions("http://x"));
+    await flush();
+
+    act(() => handlersRef.current?.onError?.("down"));
+    const prevCalls = connectEventsMock.mock.calls.length;
+
+    getSessionsMock.mockClear();
+    getSessionsMock.mockResolvedValue([]);
+
+    await act(async () => {
+      await result.current.retryConnection();
+    });
+    // After retry: fast fetch (1) + wireSse invocation (+1 connectEvents) + bg pr fetch (2)
+    await flush();
+
+    expect(connectEventsMock.mock.calls.length).toBeGreaterThan(prevCalls);
+    expect(getSessionsMock).toHaveBeenCalledWith("http://x");
+    expect(getSessionsMock).toHaveBeenCalledWith("http://x", { pr: true });
+  });
+
+  it("sets conn to error when the initial fetch fails", async () => {
+    getSessionsMock.mockRejectedValueOnce(new Error("network down"));
+    const { result } = renderHook(() => useSessions("http://x"));
+
+    await flush();
+
+    expect(result.current.conn).toEqual({ kind: "error", message: "network down" });
+    expect(connectEventsMock).not.toHaveBeenCalled();
+  });
+
+  it("runs a PR refresh every 45 seconds while connected", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    renderHook(() => useSessions("http://x"));
+    await flush();
+
+    act(() => handlersRef.current?.onOpen?.());
+    getSessionsMock.mockClear();
+    getSessionsMock.mockResolvedValue([]);
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(45_000);
+    });
+    expect(getSessionsMock).toHaveBeenCalledWith("http://x", { pr: true });
+  });
+
+  it("closes SSE and clears timers on unmount", async () => {
+    getSessionsMock.mockResolvedValue([]);
+    const { unmount } = renderHook(() => useSessions("http://x"));
+    await flush();
+
+    unmount();
+    expect(fakeEs.close).toHaveBeenCalled();
+
+    // Advancing time after unmount must not throw or reconnect.
+    const before = connectEventsMock.mock.calls.length;
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(60_000);
+    });
+    expect(connectEventsMock).toHaveBeenCalledTimes(before);
+  });
+});

--- a/crates/ao-desktop/ui/src/hooks/useSessions.ts
+++ b/crates/ao-desktop/ui/src/hooks/useSessions.ts
@@ -1,0 +1,235 @@
+import { type Dispatch, type SetStateAction, useCallback, useEffect, useRef, useState } from "react";
+import {
+  type ApiEvent,
+  type ApiSession,
+  type ConnectionStatus,
+  connectEvents,
+  getSessions,
+} from "../api/client";
+
+export type UiNotificationPayload = {
+  sessionId: string;
+  reactionKey: string;
+  action: string;
+  priority?: string;
+  message?: string;
+};
+
+export type UseSessionsOptions = {
+  onNotification?: (n: UiNotificationPayload) => void;
+  onEvent?: (evt: ApiEvent) => void;
+};
+
+export type UseSessions = {
+  sessions: ApiSession[];
+  setSessions: Dispatch<SetStateAction<ApiSession[]>>;
+  conn: ConnectionStatus;
+  refreshSessionsFast: () => Promise<void>;
+  refreshSessionsWithPr: () => Promise<void>;
+  scheduleRefresh: () => void;
+  retryConnection: () => Promise<void>;
+};
+
+const PR_REFRESH_INTERVAL_MS = 45_000;
+const REFRESH_DEBOUNCE_MS = 400;
+const MAX_BACKOFF_MS = 30_000;
+const MAX_BACKOFF_EXPONENT = 5;
+
+function parseUiNotification(evt: ApiEvent): UiNotificationPayload | null {
+  if (!evt || typeof evt !== "object") return null;
+  if ((evt as { type?: unknown }).type !== "ui_notification") return null;
+  const n = (evt as unknown as Record<string, unknown>).notification;
+  if (!n || typeof n !== "object") return null;
+  const rec = n as Record<string, unknown>;
+  const sessionId = typeof rec.id === "string" ? rec.id : "";
+  const reactionKey = typeof rec.reaction_key === "string" ? rec.reaction_key : "";
+  if (!sessionId || !reactionKey) return null;
+  return {
+    sessionId,
+    reactionKey,
+    action: typeof rec.action === "string" ? rec.action : "",
+    priority: typeof rec.priority === "string" ? rec.priority : undefined,
+    message: typeof rec.message === "string" ? rec.message : undefined,
+  };
+}
+
+function isSnapshotEvent(evt: ApiEvent): evt is ApiEvent & { sessions: ApiSession[] } {
+  return (
+    evt != null &&
+    typeof evt === "object" &&
+    (evt as { type?: unknown }).type === "snapshot" &&
+    Array.isArray((evt as { sessions?: unknown }).sessions)
+  );
+}
+
+export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): UseSessions {
+  const [sessions, setSessions] = useState<ApiSession[]>([]);
+  const [conn, setConn] = useState<ConnectionStatus>({ kind: "disconnected" });
+  const esRef = useRef<EventSource | null>(null);
+  const refreshTimerRef = useRef<number | null>(null);
+  const sseReconnectTimerRef = useRef<number | null>(null);
+  const sseRetryRef = useRef(0);
+  const wireSseRef = useRef<(() => void) | null>(null);
+
+  // Keep callbacks in refs so hook consumers can change handler identity
+  // without re-running the SSE effect.
+  const onNotificationRef = useRef(opts.onNotification);
+  const onEventRef = useRef(opts.onEvent);
+  onNotificationRef.current = opts.onNotification;
+  onEventRef.current = opts.onEvent;
+
+  /** Fast list — no `gh` / PR enrichment (cheap on every SSE tick). */
+  const refreshSessionsFast = useCallback(async () => {
+    const s = await getSessions(baseUrl);
+    setSessions(s);
+  }, [baseUrl]);
+
+  /** Full list with PR + attention (heavier; use after actions or on a timer). */
+  const refreshSessionsWithPr = useCallback(async () => {
+    const s = await getSessions(baseUrl, { pr: true });
+    setSessions(s);
+  }, [baseUrl]);
+
+  const scheduleRefresh = useCallback(() => {
+    if (refreshTimerRef.current !== null) return;
+    refreshTimerRef.current = window.setTimeout(() => {
+      refreshTimerRef.current = null;
+      refreshSessionsFast().catch(() => {
+        // ignore; conn status will reflect SSE errors separately
+      });
+    }, REFRESH_DEBOUNCE_MS);
+  }, [refreshSessionsFast]);
+
+  // Periodically refresh PR/CI signals without hammering the API on every event.
+  useEffect(() => {
+    if (conn.kind !== "connected") return;
+    const id = window.setInterval(() => {
+      void refreshSessionsWithPr().catch(() => {});
+    }, PR_REFRESH_INTERVAL_MS);
+    return () => window.clearInterval(id);
+  }, [conn.kind, refreshSessionsWithPr]);
+
+  // Auto-connect on load and when baseUrl changes: sessions (with PR) + SSE with backoff reconnect.
+  useEffect(() => {
+    let cancelled = false;
+
+    const clearSseReconnect = () => {
+      if (sseReconnectTimerRef.current !== null) {
+        window.clearTimeout(sseReconnectTimerRef.current);
+        sseReconnectTimerRef.current = null;
+      }
+    };
+
+    const connectEs = () => {
+      if (cancelled) return;
+      clearSseReconnect();
+      esRef.current?.close();
+      esRef.current = connectEvents(baseUrl, {
+        onOpen: () => {
+          if (cancelled) return;
+          setConn({ kind: "connected" });
+          sseRetryRef.current = 0;
+        },
+        onError: () => {
+          if (cancelled) return;
+          setConn({ kind: "error", message: "SSE connection error" });
+          if (sseReconnectTimerRef.current !== null) return;
+          const attempt = sseRetryRef.current++;
+          const delay = Math.min(
+            MAX_BACKOFF_MS,
+            1000 * Math.pow(2, Math.min(attempt, MAX_BACKOFF_EXPONENT)),
+          );
+          sseReconnectTimerRef.current = window.setTimeout(() => {
+            sseReconnectTimerRef.current = null;
+            if (cancelled) return;
+            connectEs();
+          }, delay);
+        },
+        onEvent: (evt) => {
+          if (cancelled) return;
+          // SSE snapshot: update sessions immediately without polling.
+          if (isSnapshotEvent(evt)) {
+            setSessions(evt.sessions);
+            return;
+          }
+
+          const notification = parseUiNotification(evt);
+          if (notification) onNotificationRef.current?.(notification);
+
+          onEventRef.current?.(evt);
+          scheduleRefresh();
+        },
+      });
+    };
+
+    wireSseRef.current = connectEs;
+
+    (async () => {
+      setConn({ kind: "connecting" });
+      try {
+        // Fast path: list sessions without PR enrichment (no per-session `gh` calls).
+        // `?pr=true` is heavier (GitHub/`gh` per session). Load fast first, enrich in background.
+        const fast = await getSessions(baseUrl);
+        if (cancelled) return;
+        setSessions(fast);
+        connectEs();
+        void getSessions(baseUrl, { pr: true })
+          .then((enriched) => {
+            if (cancelled) return;
+            setSessions(enriched);
+          })
+          .catch(() => {
+            /* keep fast list; throttled refresh may retry */
+          });
+      } catch (e) {
+        if (cancelled) return;
+        const msg = e instanceof Error ? e.message : "unknown error";
+        setConn({ kind: "error", message: msg });
+      }
+    })();
+
+    return () => {
+      cancelled = true;
+      wireSseRef.current = null;
+      clearSseReconnect();
+      if (refreshTimerRef.current !== null) {
+        window.clearTimeout(refreshTimerRef.current);
+        refreshTimerRef.current = null;
+      }
+      esRef.current?.close();
+      esRef.current = null;
+    };
+  }, [baseUrl, scheduleRefresh]);
+
+  const retryConnection = useCallback(async () => {
+    sseRetryRef.current = 0;
+    if (sseReconnectTimerRef.current !== null) {
+      window.clearTimeout(sseReconnectTimerRef.current);
+      sseReconnectTimerRef.current = null;
+    }
+    esRef.current?.close();
+    esRef.current = null;
+    setConn({ kind: "connecting" });
+    try {
+      const fast = await getSessions(baseUrl);
+      setSessions(fast);
+      wireSseRef.current?.();
+      void getSessions(baseUrl, { pr: true })
+        .then(setSessions)
+        .catch(() => {});
+    } catch (e) {
+      const msg = e instanceof Error ? e.message : "unknown error";
+      setConn({ kind: "error", message: msg });
+    }
+  }, [baseUrl]);
+
+  return {
+    sessions,
+    setSessions,
+    conn,
+    refreshSessionsFast,
+    refreshSessionsWithPr,
+    scheduleRefresh,
+    retryConnection,
+  };
+}

--- a/crates/ao-desktop/ui/src/hooks/useToasts.test.ts
+++ b/crates/ao-desktop/ui/src/hooks/useToasts.test.ts
@@ -1,0 +1,99 @@
+import { act, renderHook } from "@testing-library/react";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+import { useToasts } from "./useToasts";
+
+const basePayload = {
+  sessionId: "s1",
+  reactionKey: "respond",
+  action: "ping",
+};
+
+describe("useToasts", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("pushes toasts and prepends newest first", () => {
+    const { result } = renderHook(() => useToasts());
+
+    act(() => {
+      result.current.pushToast({ ...basePayload, reactionKey: "first" });
+    });
+    act(() => {
+      result.current.pushToast({ ...basePayload, reactionKey: "second" });
+    });
+
+    expect(result.current.toasts).toHaveLength(2);
+    expect(result.current.toasts[0]?.reactionKey).toBe("second");
+    expect(result.current.toasts[1]?.reactionKey).toBe("first");
+  });
+
+  it("caps the stack at 6", () => {
+    const { result } = renderHook(() => useToasts());
+    act(() => {
+      for (let i = 0; i < 10; i++) {
+        result.current.pushToast({ ...basePayload, reactionKey: `rk-${i}` });
+      }
+    });
+    expect(result.current.toasts).toHaveLength(6);
+    // newest-first: the last pushed one wins the slot
+    expect(result.current.toasts[0]?.reactionKey).toBe("rk-9");
+  });
+
+  it("dismissToast removes the matching key immediately", () => {
+    const { result } = renderHook(() => useToasts());
+    act(() => {
+      result.current.pushToast({ ...basePayload, reactionKey: "a" });
+      result.current.pushToast({ ...basePayload, reactionKey: "b" });
+    });
+
+    const keep = result.current.toasts.find((t) => t.reactionKey === "a");
+    const drop = result.current.toasts.find((t) => t.reactionKey === "b");
+    expect(keep && drop).toBeTruthy();
+
+    act(() => {
+      result.current.dismissToast(drop!.key);
+    });
+
+    expect(result.current.toasts).toHaveLength(1);
+    expect(result.current.toasts[0]?.reactionKey).toBe("a");
+  });
+
+  it("auto-dismisses after 12 seconds", () => {
+    const { result } = renderHook(() => useToasts());
+    act(() => {
+      result.current.pushToast(basePayload);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(11_999);
+    });
+    expect(result.current.toasts).toHaveLength(1);
+
+    act(() => {
+      vi.advanceTimersByTime(1);
+    });
+    expect(result.current.toasts).toHaveLength(0);
+  });
+
+  it("clears pending auto-dismiss timers on unmount", () => {
+    const { result, unmount } = renderHook(() => useToasts());
+    act(() => {
+      result.current.pushToast(basePayload);
+    });
+
+    unmount();
+
+    // Advancing time after unmount must not blow up (no lingering setState
+    // from an auto-dismiss callback on an unmounted component).
+    expect(() => {
+      vi.advanceTimersByTime(20_000);
+    }).not.toThrow();
+  });
+});

--- a/crates/ao-desktop/ui/src/hooks/useToasts.ts
+++ b/crates/ao-desktop/ui/src/hooks/useToasts.ts
@@ -1,0 +1,65 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type ToastItem = {
+  key: string;
+  at: number;
+  sessionId: string;
+  reactionKey: string;
+  action: string;
+  priority?: string;
+  message?: string;
+};
+
+export type ToastInput = Omit<ToastItem, "key" | "at">;
+
+const MAX_TOASTS = 6;
+const AUTO_DISMISS_MS = 12_000;
+
+function makeKey(at: number): string {
+  if (typeof crypto !== "undefined" && "randomUUID" in crypto) return crypto.randomUUID();
+  return `${at}-${Math.random()}`;
+}
+
+export type UseToasts = {
+  toasts: ToastItem[];
+  pushToast: (t: ToastInput) => void;
+  dismissToast: (key: string) => void;
+};
+
+export function useToasts(): UseToasts {
+  const [toasts, setToasts] = useState<ToastItem[]>([]);
+  const timersRef = useRef<Map<string, number>>(new Map());
+
+  useEffect(() => {
+    const timers = timersRef.current;
+    return () => {
+      for (const id of timers.values()) window.clearTimeout(id);
+      timers.clear();
+    };
+  }, []);
+
+  const dismissToast = useCallback((key: string) => {
+    const timerId = timersRef.current.get(key);
+    if (timerId !== undefined) {
+      window.clearTimeout(timerId);
+      timersRef.current.delete(key);
+    }
+    setToasts((prev) => prev.filter((x) => x.key !== key));
+  }, []);
+
+  const pushToast = useCallback(
+    (t: ToastInput) => {
+      const at = Date.now();
+      const key = makeKey(at);
+      setToasts((prev) => [{ key, at, ...t }, ...prev].slice(0, MAX_TOASTS));
+      const timerId = window.setTimeout(() => {
+        timersRef.current.delete(key);
+        setToasts((prev) => prev.filter((x) => x.key !== key));
+      }, AUTO_DISMISS_MS);
+      timersRef.current.set(key, timerId);
+    },
+    [],
+  );
+
+  return { toasts, pushToast, dismissToast };
+}

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -1,20 +1,18 @@
-import { type Dispatch, lazy, type SetStateAction, Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { type Dispatch, lazy, type SetStateAction, Suspense, useCallback, useEffect, useMemo, useState } from "react";
 import {
   type ApiEvent,
   type ApiSession,
-  connectEvents,
-  getSessions,
   killSession,
   restoreSession,
   sendMessage,
-  type ConnectionStatus,
 } from "../api/client";
 import { Board } from "../components/Board";
 import { ProjectSidebar } from "../components/ProjectSidebar";
 import { SessionDetail } from "../components/SessionDetail";
+import { useSessions } from "../hooks/useSessions";
+import { useToasts } from "../hooks/useToasts";
 import { getSessionTabLabel } from "../lib/format";
 import type { DashboardSession } from "../lib/types";
-import { getAttentionLevel } from "../lib/types";
 
 const TerminalLazy = lazy(() => import("../components/TerminalView"));
 
@@ -72,33 +70,37 @@ function ActiveDetail({
 
 export function App() {
   const [baseUrl, setBaseUrl] = useState("http://127.0.0.1:3000");
-  const [conn, setConn] = useState<ConnectionStatus>({ kind: "disconnected" });
-  const [sessions, setSessions] = useState<ApiSession[]>([]);
   const [events, setEvents] = useState<Array<{ key: string; at: number; evt: ApiEvent }>>([]);
-  const [toasts, setToasts] = useState<
-    Array<{
-      key: string;
-      at: number;
-      sessionId: string;
-      reactionKey: string;
-      action: string;
-      priority?: string;
-      message?: string;
-    }>
-  >([]);
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
-  const esRef = useRef<EventSource | null>(null);
-  const refreshTimerRef = useRef<number | null>(null);
-  const sseReconnectTimerRef = useRef<number | null>(null);
-  const sseRetryRef = useRef(0);
-  const wireSseRef = useRef<(() => void) | null>(null);
   const [detailOnly, setDetailOnly] = useState(false);
   const [activeTab, setActiveTab] = useState<"dashboard" | { sessionId: string }>("dashboard");
   const [sessionTabs, setSessionTabs] = useState<string[]>([]);
   const [theme, setTheme] = useState<"light" | "dark">(() => {
     const saved = window.localStorage.getItem("ao-ui-theme");
     return saved === "dark" || saved === "light" ? saved : "light";
+  });
+
+  const { toasts, pushToast, dismissToast } = useToasts();
+
+  const logEvent = useCallback((evt: ApiEvent) => {
+    setEvents((prev) => {
+      const at = Date.now();
+      const key =
+        typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `${at}-${Math.random()}`;
+      return [{ key, at, evt }, ...prev].slice(0, 200);
+    });
+  }, []);
+
+  const {
+    sessions,
+    setSessions,
+    conn,
+    refreshSessionsWithPr,
+    retryConnection,
+  } = useSessions(baseUrl, {
+    onNotification: pushToast,
+    onEvent: logEvent,
   });
 
   const connLabel = useMemo(() => {
@@ -119,201 +121,12 @@ export function App() {
       setActiveTab({ sessionId: sid });
       setSessionTabs([sid]);
     }
-
-    return () => {
-      esRef.current?.close();
-      esRef.current = null;
-      if (refreshTimerRef.current !== null) {
-        window.clearTimeout(refreshTimerRef.current);
-        refreshTimerRef.current = null;
-      }
-      if (sseReconnectTimerRef.current !== null) {
-        window.clearTimeout(sseReconnectTimerRef.current);
-        sseReconnectTimerRef.current = null;
-      }
-    };
   }, []);
 
   useEffect(() => {
     document.body.dataset.theme = theme;
     window.localStorage.setItem("ao-ui-theme", theme);
   }, [theme]);
-
-  /** Fast list — no `gh` / PR enrichment (cheap on every SSE tick). */
-  const refreshSessionsFast = useCallback(async () => {
-    const s = await getSessions(baseUrl);
-    setSessions(s);
-  }, [baseUrl]);
-
-  /** Full list with PR + attention (heavier; use after actions or on a timer). */
-  const refreshSessionsWithPr = useCallback(async () => {
-    const s = await getSessions(baseUrl, { pr: true });
-    setSessions(s);
-  }, [baseUrl]);
-
-  const scheduleRefresh = useCallback(() => {
-    if (refreshTimerRef.current !== null) return;
-    refreshTimerRef.current = window.setTimeout(() => {
-      refreshTimerRef.current = null;
-      refreshSessionsFast().catch(() => {
-        // ignore; conn status will reflect SSE errors separately
-      });
-    }, 400);
-  }, [refreshSessionsFast]);
-
-  const pushToast = useCallback(
-    (t: Omit<(typeof toasts)[number], "key" | "at">) => {
-      const at = Date.now();
-      const key = typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `${at}-${Math.random()}`;
-      setToasts((prev) => [{ key, at, ...t }, ...prev].slice(0, 6));
-      // Auto-dismiss.
-      window.setTimeout(() => {
-        setToasts((prev) => prev.filter((x) => x.key !== key));
-      }, 12_000);
-    },
-    [setToasts],
-  );
-
-  // Periodically refresh PR/CI signals without hammering the API on every event.
-  useEffect(() => {
-    if (conn.kind !== "connected") return;
-    const id = window.setInterval(() => {
-      void refreshSessionsWithPr().catch(() => {});
-    }, 45_000);
-    return () => window.clearInterval(id);
-  }, [conn.kind, baseUrl, refreshSessionsWithPr]);
-
-  // Auto-connect on load and when baseUrl changes: sessions (with PR) + SSE with backoff reconnect.
-  useEffect(() => {
-    let cancelled = false;
-
-    const clearSseReconnect = () => {
-      if (sseReconnectTimerRef.current !== null) {
-        window.clearTimeout(sseReconnectTimerRef.current);
-        sseReconnectTimerRef.current = null;
-      }
-    };
-
-    const connectEs = () => {
-      if (cancelled) return;
-      clearSseReconnect();
-      esRef.current?.close();
-      esRef.current = connectEvents(baseUrl, {
-        onOpen: () => {
-          if (cancelled) return;
-          setConn({ kind: "connected" });
-          sseRetryRef.current = 0;
-        },
-        onError: () => {
-          if (cancelled) return;
-          setConn({ kind: "error", message: "SSE connection error" });
-          if (sseReconnectTimerRef.current !== null) return;
-          const attempt = sseRetryRef.current++;
-          const delay = Math.min(30_000, 1000 * Math.pow(2, Math.min(attempt, 5)));
-          sseReconnectTimerRef.current = window.setTimeout(() => {
-            sseReconnectTimerRef.current = null;
-            if (cancelled) return;
-            connectEs();
-          }, delay);
-        },
-        onEvent: (evt) => {
-          if (cancelled) return;
-          // SSE snapshot: update sessions immediately without polling.
-          if (
-            evt &&
-            typeof evt === "object" &&
-            (evt as { type?: unknown }).type === "snapshot" &&
-            Array.isArray((evt as { sessions?: unknown }).sessions)
-          ) {
-            setSessions((evt as { sessions: ApiSession[] }).sessions);
-            return;
-          }
-
-          // UI notification event: show a toast (and keep it in the raw event log too).
-          if (
-            evt &&
-            typeof evt === "object" &&
-            (evt as { type?: unknown }).type === "ui_notification" &&
-            (evt as { notification?: unknown }).notification &&
-            typeof (evt as { notification?: unknown }).notification === "object"
-          ) {
-            const n = (evt as unknown as Record<string, unknown>).notification as Record<string, unknown>;
-            const sessionId = typeof n.id === "string" ? n.id : "";
-            const reactionKey = typeof n.reaction_key === "string" ? n.reaction_key : "";
-            const action = typeof n.action === "string" ? n.action : "";
-            const priority = typeof n.priority === "string" ? n.priority : undefined;
-            const message = typeof n.message === "string" ? n.message : undefined;
-            if (sessionId && reactionKey) {
-              pushToast({ sessionId, reactionKey, action, priority, message });
-            }
-          }
-          setEvents((prev) => {
-            const at = Date.now();
-            const key =
-              typeof crypto !== "undefined" && "randomUUID" in crypto ? crypto.randomUUID() : `${at}-${Math.random()}`;
-            return [{ key, at, evt }, ...prev].slice(0, 200);
-          });
-          scheduleRefresh();
-        },
-      });
-    };
-
-    wireSseRef.current = connectEs;
-
-    (async () => {
-      setConn({ kind: "connecting" });
-      try {
-        // Fast path: list sessions without PR enrichment (no per-session `gh` calls).
-        // `?pr=true` is heavier (GitHub/`gh` per session). Load fast first, enrich in background.
-        const fast = await getSessions(baseUrl);
-        if (cancelled) return;
-        setSessions(fast);
-        connectEs();
-        void getSessions(baseUrl, { pr: true })
-          .then((enriched) => {
-            if (cancelled) return;
-            setSessions(enriched);
-          })
-          .catch(() => {
-            /* keep fast list; throttled refresh may retry */
-          });
-      } catch (e) {
-        if (cancelled) return;
-        const msg = e instanceof Error ? e.message : "unknown error";
-        setConn({ kind: "error", message: msg });
-      }
-    })();
-
-    return () => {
-      cancelled = true;
-      wireSseRef.current = null;
-      clearSseReconnect();
-      esRef.current?.close();
-      esRef.current = null;
-    };
-  }, [baseUrl, scheduleRefresh]);
-
-  const retryConnection = async () => {
-    sseRetryRef.current = 0;
-    if (sseReconnectTimerRef.current !== null) {
-      window.clearTimeout(sseReconnectTimerRef.current);
-      sseReconnectTimerRef.current = null;
-    }
-    esRef.current?.close();
-    esRef.current = null;
-    setConn({ kind: "connecting" });
-    try {
-      const fast = await getSessions(baseUrl);
-      setSessions(fast);
-      wireSseRef.current?.();
-      void getSessions(baseUrl, { pr: true })
-        .then(setSessions)
-        .catch(() => {});
-    } catch (e) {
-      const msg = e instanceof Error ? e.message : "unknown error";
-      setConn({ kind: "error", message: msg });
-    }
-  };
 
   const dashboardSessions: DashboardSession[] = useMemo(
     () =>
@@ -470,7 +283,7 @@ export function App() {
                   aria-label="Dismiss"
                   onClick={(e) => {
                     e.stopPropagation();
-                    setToasts((prev) => prev.filter((x) => x.key !== t.key));
+                    dismissToast(t.key);
                   }}
                 >
                   ×
@@ -734,4 +547,3 @@ export function App() {
     </div>
   );
 }
-


### PR DESCRIPTION
## Summary
- New `useSessions(baseUrl, { onNotification, onEvent })` hook owns `sessions` + `conn` state, the `EventSource` lifecycle, 400 ms refresh debounce, exponential reconnect (1 s → 30 s cap), 45 s PR enrichment interval, and exposes `refreshSessionsFast` / `refreshSessionsWithPr` / `scheduleRefresh` / `retryConnection`.
- New `useToasts()` hook owns the toast stack with per-item auto-dismiss (12 s) and a stack cap of 6; `dismissToast` clears the pending timer eagerly and `useEffect` cleanup clears any stragglers on unmount.
- `App.tsx` drops ~210 lines and is now render + tab / theme / URL-param state. Behavior is preserved byte-for-byte (backoff schedule, toast cap/duration, retry semantics).

## Test plan
- [x] `npm run typecheck`
- [x] `npm run build`
- [x] `npm test` — 39 tests pass (17 new: 5 `useToasts` + 12 `useSessions`)
- [ ] Manual: launch `ao-dashboard`, confirm connect on load, kill server → reconnect with backoff, `retryConnection`, toast auto-dismiss + click-to-dismiss.

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)