### PR TITLE
feat(ui): format SSE events panel instead of raw JSON (#145)

### DIFF
--- a/crates/ao-desktop/ui/src/lib/format.test.ts
+++ b/crates/ao-desktop/ui/src/lib/format.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 
-import { formatCiStatus, formatReviewDecision, getSessionTabLabel } from "./format";
+import type { ApiEvent } from "../api/client";
+import { formatCiStatus, formatEvent, formatReviewDecision, getSessionTabLabel } from "./format";
 import type { DashboardSession } from "./types";
 
 describe("getSessionTabLabel", () => {
@@ -83,6 +84,129 @@ describe("formatReviewDecision", () => {
       label: "Review dismissed",
       tone: "neutral",
     });
+  });
+});
+
+describe("formatEvent", () => {
+  it("summarises snapshot with session count (plural)", () => {
+    const evt = { type: "snapshot", sessions: [{}, {}, {}] } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe("snapshot · 3 sessions");
+  });
+
+  it("summarises snapshot with session count (singular)", () => {
+    const evt = { type: "snapshot", sessions: [{}] } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe("snapshot · 1 session");
+  });
+
+  it("summarises snapshot with zero sessions", () => {
+    const evt = { type: "snapshot", sessions: [] } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe("snapshot · 0 sessions");
+  });
+
+  it("summarises spawned with project_id", () => {
+    const evt = { type: "spawned", id: "s1", project_id: "ao-rs" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("spawned in ao-rs");
+  });
+
+  it("summarises spawned without project_id", () => {
+    const evt = { type: "spawned", id: "s1" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("spawned");
+  });
+
+  it("summarises session_restored with status and project", () => {
+    const evt = {
+      type: "session_restored",
+      id: "s1",
+      project_id: "ao-rs",
+      status: "working",
+    } as ApiEvent;
+    expect(formatEvent(evt)).toBe("restored · working · ao-rs");
+  });
+
+  it("summarises status_changed with from → to", () => {
+    const evt = { type: "status_changed", id: "s1", from: "working", to: "pr_open" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("working → pr_open");
+  });
+
+  it("falls back when status_changed is missing to", () => {
+    const evt = { type: "status_changed", id: "s1", from: "working" } as ApiEvent;
+    expect(formatEvent(evt)).toBe(JSON.stringify(evt));
+  });
+
+  it("summarises activity_changed with prev → next", () => {
+    const evt = { type: "activity_changed", id: "s1", prev: "idle", next: "active" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("idle → active");
+  });
+
+  it("summarises activity_changed with null prev using ∅", () => {
+    const evt = { type: "activity_changed", id: "s1", prev: null, next: "active" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("∅ → active");
+  });
+
+  it("summarises terminated with reason", () => {
+    const evt = { type: "terminated", id: "s1", reason: "runtime_gone" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("terminated · runtime_gone");
+  });
+
+  it("summarises tick_error with message", () => {
+    const evt = { type: "tick_error", id: "s1", message: "poll failed" } as ApiEvent;
+    expect(formatEvent(evt)).toBe("tick error · poll failed");
+  });
+
+  it("summarises reaction_triggered with key and action", () => {
+    const evt = {
+      type: "reaction_triggered",
+      id: "s1",
+      reaction_key: "stale-pr",
+      action: "notify",
+    } as ApiEvent;
+    expect(formatEvent(evt)).toBe("reaction · stale-pr → notify");
+  });
+
+  it("summarises reaction_escalated with key and attempts", () => {
+    const evt = {
+      type: "reaction_escalated",
+      id: "s1",
+      reaction_key: "stale-pr",
+      attempts: 3,
+    } as ApiEvent;
+    expect(formatEvent(evt)).toBe("escalated · stale-pr (attempts: 3)");
+  });
+
+  it("summarises ui_notification with message", () => {
+    const evt = {
+      type: "ui_notification",
+      notification: {
+        id: "s1",
+        reaction_key: "stale-pr",
+        action: "notify",
+        message: "PR has been idle for 24h",
+      },
+    } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe("notify · stale-pr → notify · PR has been idle for 24h");
+  });
+
+  it("summarises ui_notification without message", () => {
+    const evt = {
+      type: "ui_notification",
+      notification: { id: "s1", reaction_key: "stale-pr", action: "notify" },
+    } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe("notify · stale-pr → notify");
+  });
+
+  it("falls back to JSON for unknown event types", () => {
+    const evt = { type: "future_event", foo: "bar" } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe(JSON.stringify(evt));
+  });
+
+  it("falls back to JSON when required fields are wrong type", () => {
+    const evt = {
+      type: "reaction_triggered",
+      id: "s1",
+      reaction_key: 42,
+      action: "notify",
+    } as unknown as ApiEvent;
+    expect(formatEvent(evt)).toBe(JSON.stringify(evt));
   });
 });
 

--- a/crates/ao-desktop/ui/src/lib/format.ts
+++ b/crates/ao-desktop/ui/src/lib/format.ts
@@ -1,3 +1,4 @@
+import type { ApiEvent } from "../api/client";
 import type { DashboardSession } from "./types";
 
 export type PillTone = "ok" | "bad" | "neutral";
@@ -60,6 +61,84 @@ export function getSessionTabLabel(session: DashboardSession): string {
     session.id.slice(-4);
   const status = session.status || "unknown";
   return `${project} - #${issueOrPr}: ${status}`;
+}
+
+function str(rec: Record<string, unknown>, key: string): string | null {
+  const v = rec[key];
+  return typeof v === "string" ? v : null;
+}
+
+function num(rec: Record<string, unknown>, key: string): number | null {
+  const v = rec[key];
+  return typeof v === "number" ? v : null;
+}
+
+export function formatEvent(evt: ApiEvent): string {
+  const rec = evt as unknown as Record<string, unknown>;
+  const fallback = () => JSON.stringify(evt);
+
+  switch (evt.type) {
+    case "snapshot": {
+      const sessions = rec.sessions;
+      const count = Array.isArray(sessions) ? sessions.length : 0;
+      return `snapshot · ${count} session${count === 1 ? "" : "s"}`;
+    }
+    case "spawned": {
+      const project = str(rec, "project_id");
+      return project ? `spawned in ${project}` : "spawned";
+    }
+    case "session_restored": {
+      const status = str(rec, "status");
+      const project = str(rec, "project_id");
+      const parts = ["restored", status, project].filter(Boolean) as string[];
+      return parts.length > 1 ? parts.join(" · ") : fallback();
+    }
+    case "status_changed": {
+      const from = str(rec, "from");
+      const to = str(rec, "to");
+      return from && to ? `${from} → ${to}` : fallback();
+    }
+    case "activity_changed": {
+      const next = str(rec, "next");
+      if (!next) return fallback();
+      const prev = str(rec, "prev") ?? "∅";
+      return `${prev} → ${next}`;
+    }
+    case "terminated": {
+      const reason = str(rec, "reason");
+      return reason ? `terminated · ${reason}` : "terminated";
+    }
+    case "tick_error": {
+      const message = str(rec, "message");
+      return message ? `tick error · ${message}` : "tick error";
+    }
+    case "reaction_triggered": {
+      const key = str(rec, "reaction_key");
+      const action = str(rec, "action");
+      return key && action ? `reaction · ${key} → ${action}` : fallback();
+    }
+    case "reaction_escalated": {
+      const key = str(rec, "reaction_key");
+      const attempts = num(rec, "attempts");
+      return key && attempts !== null
+        ? `escalated · ${key} (attempts: ${attempts})`
+        : fallback();
+    }
+    case "ui_notification": {
+      const n = rec.notification;
+      if (!n || typeof n !== "object") return fallback();
+      const nr = n as Record<string, unknown>;
+      const key = str(nr, "reaction_key");
+      const action = str(nr, "action");
+      if (!key || !action) return fallback();
+      const message = str(nr, "message");
+      return message
+        ? `notify · ${key} → ${action} · ${message}`
+        : `notify · ${key} → ${action}`;
+    }
+    default:
+      return fallback();
+  }
 }
 
 export function getSessionTitle(session: DashboardSession): string {

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -12,7 +12,7 @@ import {
 import { Board } from "../components/Board";
 import { ProjectSidebar } from "../components/ProjectSidebar";
 import { SessionDetail } from "../components/SessionDetail";
-import { getSessionTabLabel } from "../lib/format";
+import { formatEvent, getSessionTabLabel } from "../lib/format";
 import type { DashboardSession } from "../lib/types";
 import { getAttentionLevel, isTerminalSession } from "../lib/types";
 
@@ -674,7 +674,7 @@ export function App() {
                                   </div>
                                 ) : null}
                               </div>
-                              <div className="evt__meta">{JSON.stringify(evt)}</div>
+                              <div className="evt__meta">{formatEvent(evt)}</div>
                             </div>
                           );
                         })


### PR DESCRIPTION
## Summary
- Replace `JSON.stringify(evt)` in the Events panel (`App.tsx`) with a type-aware `formatEvent` helper in `lib/format.ts`.
- Known `OrchestratorEvent` variants render concise summaries (e.g. `working → pr_open`, `reaction · stale-pr → notify`, `snapshot · 3 sessions`); unknown or malformed payloads fall back to JSON so new server events stay visible.
- Pure function — unit-tested in `lib/format.test.ts` with 15 cases covering every variant + the fallback.

Closes #145.

## Test plan
- [x] `pnpm run typecheck` clean
- [x] `pnpm test` passes (42/42)
- [x] `pnpm run build` produces a bundle
- [x] `cargo check --workspace` clean
- [ ] Manually eyeball the Events panel in the dashboard with a live session

🤖 Generated with [Claude Code](https://claude.com/claude-code)