### PR TITLE
docs(contrib): adopt cargo-nextest + per-module test scope (#168)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,202 @@
+# Contributing to ao-rs
+
+This is the contributor-facing source of truth for how we build,
+test, and ship ao-rs. Agents spawned by Claude Code inherit these
+conventions via the project rules in
+[`ao-rs.yaml`](ao-rs.yaml) — keep the two in sync; this file is
+authoritative.
+
+Companion docs:
+
+- [`README.md`](README.md) — what ao-rs is, quick start, CLI usage.
+- [`docs/architecture.md`](docs/architecture.md) — crate layout and
+  design principles.
+- [`docs/DEV.md`](docs/DEV.md) — local dashboard + desktop UI setup.
+- [`docs/RELEASE.md`](docs/RELEASE.md) — release + distribution flow.
+
+## Running tests
+
+We use [`cargo-nextest`](https://nexte.st) as the standard runner.
+It runs each test in an isolated process and parallelises across
+logical CPUs — typically 2–3× faster than `cargo test` on multi-core
+machines.
+
+`cargo t` is aliased to `cargo nextest run` in
+[`.cargo/config.toml`](.cargo/config.toml), so:
+
+```bash
+# Fast workspace run (the default for the inner dev loop):
+cargo t
+
+# Scoped to one crate (fastest inner loop):
+cargo t -p ao-core
+cargo t -p ao-cli
+
+# Filter by test name:
+cargo t -p ao-core lifecycle
+
+# Cap threads if the laptop is getting warm:
+cargo t --workspace --test-threads=2
+```
+
+### Doctests
+
+`cargo nextest` does **not** run doctests by design. Run them with
+`cargo test --doc`:
+
+```bash
+cargo test --doc --workspace
+```
+
+This is the only thing plain `cargo test` is used for in this repo.
+
+### Installing nextest (first time)
+
+```bash
+cargo install cargo-nextest --locked
+```
+
+After that, `cargo t` just works.
+
+## Per-module test scope rule
+
+Source: [issue #168](https://github.com/duonghb53/ao-rs/issues/168).
+
+**Test scope = what changed, not the entire codebase.**
+
+| Situation                      | What to test                                                                |
+|--------------------------------|-----------------------------------------------------------------------------|
+| New module added               | Public interface of that module only                                        |
+| Bug fixed                      | Write a failing test that reproduces the bug first, then fix it             |
+| Refactor (behaviour unchanged) | Existing tests must pass — do **not** add new ones                          |
+| Port feature from ao-ts        | Business logic of the ported code; skip type-plumbing                       |
+| Config field added             | One round-trip serde test for that field                                    |
+
+When you touch an existing module, add tests **for what you
+changed**, not for what was already there.
+
+### What Rust already proves — do NOT write tests for these
+
+- `Option<T>` / `Result<T, E>` handling — the compiler enforces.
+- Exhaustive enum matching — compile error if missed.
+- Type mismatches — caught at compile time.
+- Borrow / mutation safety — borrow checker.
+
+A test that "exercises" one of the above is test-theatre: it fails
+at compile time if it's ever wrong, and passes without running
+otherwise. Skip it.
+
+### Target coverage by layer
+
+| Layer                                                   | Target | Reason                                  |
+|---------------------------------------------------------|--------|-----------------------------------------|
+| Pure business logic (state machines, parsers, slugs)    | High   | High value, cheap to test               |
+| I/O wrappers (file, YAML r/w)                           | Medium | One happy-path + one error case         |
+| Plugin trait impls (agent launch, runtime)              | Low    | Integration tested via CLI              |
+| API route handlers                                      | Low    | Tested via dashboard integration tests  |
+| `serde` derive structs                                  | Skip   | `serde` itself is proven                |
+
+### Where tests live
+
+- **Unit tests** — co-located as `#[cfg(test)] mod tests { … }` at
+  the bottom of the module they cover. Matches existing files in
+  `crates/ao-core/src/`.
+- **Integration tests** — under the crate's `tests/` directory, one
+  file per scenario. Example: `crates/plugins/scm-github/tests/`.
+- **Doctests** — in `///` comments on public items. Useful when the
+  example is short and the code is part of the public contract.
+
+## Inner dev loop
+
+```bash
+# Fast type-check only (no binary, 3-5x faster than a full build):
+cargo check -p <crate>
+
+# Watch + re-run tests for the crate you're working in:
+cargo watch -x "nextest run -p ao-core"
+
+# Full suite before opening a PR (same as the manual release check):
+cargo t --workspace
+cargo test --doc --workspace
+cargo clippy --workspace --all-targets -- -D warnings
+cargo fmt --all -- --check
+```
+
+`cargo check` is the right tool when you just want to know "does
+this compile?". It skips codegen and linking, so it's 3–5× faster
+than `cargo build` for the same feedback on type errors.
+
+## Pre-PR checklist
+
+Before pushing:
+
+- [ ] `cargo fmt --all -- --check` clean.
+- [ ] `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- [ ] `cargo t --workspace` clean.
+- [ ] `cargo test --doc --workspace` clean.
+- [ ] Tests for **what you changed** are present (see scope rule
+      above). No new tests in modules you didn't touch.
+- [ ] Manual smoke if touching UI — see
+      [`docs/SMOKE.md`](docs/SMOKE.md).
+
+## Working on a dev-lifecycle feature
+
+When an issue is large enough to need a plan, scaffold the
+dev-lifecycle docs under `docs/ai/` and work through the phases:
+
+```
+docs/ai/requirements/feature-<slug>.md
+docs/ai/design/feature-<slug>.md
+docs/ai/planning/feature-<slug>.md
+docs/ai/implementation/feature-<slug>.md   # optional
+docs/ai/testing/feature-<slug>.md           # optional
+```
+
+See `docs/ai/*/README.md` for the phase templates and existing
+features (e.g. `feature-agent-stuck-detection`, `feature-notifier-
+routing`) for worked examples.
+
+## Agent-specific rules
+
+Agents spawned via `ao-rs spawn` inherit the rules from
+[`ao-rs.yaml`](ao-rs.yaml) (the `ao-rs` project block). Keep those
+in sync with this file — the content here is authoritative.
+
+Current agent rules worth calling out:
+
+- Source-port reference: `~/study/agent-orchestrator`. Check its
+  logic when implementing or porting a feature.
+- When spawned from an issue, follow the dev-lifecycle flow
+  (requirements → design → planning → implement → verify).
+- If stuck for more than 5 minutes, explain what's blocking you.
+
+## Where things live
+
+- **`crates/ao-core/`** — types, traits, state machine, reaction
+  engine. Business logic lives here. High test coverage target.
+- **`crates/ao-cli/`** — `ao-rs` binary (clap). Low-coverage target;
+  tested via integration tests where it matters.
+- **`crates/ao-dashboard/`** — axum REST + SSE. Low-coverage target;
+  route handlers tested via integration tests.
+- **`crates/plugins/`** — one crate per plugin impl (runtime, agent,
+  workspace, SCM, tracker, notifier). Trait-impl smoke tests only —
+  plugins are integration-tested through `ao-cli`.
+- **`docs/`** — architecture, state machine, reactions, CLI ref,
+  plugin spec, dev-lifecycle feature docs.
+
+## CI
+
+There are currently no CI workflows in this repo (the previous
+`.github/workflows/ci.yml` and `release-artifacts.yml` were removed
+in commit `e8e4c54`). When CI is re-introduced, the Rust job should
+run:
+
+```bash
+cargo fmt --all -- --check
+cargo clippy --workspace --all-targets -- -D warnings
+cargo nextest run --workspace
+cargo test --doc --workspace
+```
+
+(Substitute `cargo nextest run` for `cargo test` — the `cargo t`
+alias only exists locally via `.cargo/config.toml`.)

--- a/docs/ai/design/feature-nextest-test-scope.md
+++ b/docs/ai/design/feature-nextest-test-scope.md
@@ -1,0 +1,172 @@
+---
+phase: design
+title: nextest adoption + per-module test scope — design
+description: Where each piece of guidance lives, and how the docs cross-link so nothing drifts.
+---
+
+# Design — nextest adoption + per-module test scope
+
+## Architecture Overview
+
+This is a docs-only change. The "architecture" is which file owns
+which piece of guidance and how they reference each other.
+
+```
+┌───────────────────────────────────────────────────────────────┐
+│  CONTRIBUTING.md (repo root)   ← SOURCE OF TRUTH                    │
+│  ─ How to run tests (cargo t + cargo test --doc)              │
+│  ─ Per-module test scope rule (table)                         │
+│  ─ What Rust already proves (don't test)                      │
+│  ─ Target coverage by layer                                   │
+│  ─ Inner dev loop command cheat-sheet                         │
+└───────────────────────────────────────────────────────────────┘
+        ▲                          ▲                   ▲
+        │ link                     │ link              │ link
+        │                          │                   │
+┌───────┴────────┐  ┌──────────────┴────┐  ┌──────────┴───────┐
+│ README.md      │  │ docs/RELEASE.md   │  │ docs/ai/impl…/   │
+│ dev commands   │  │ release checklist │  │ README.md        │
+│ (already uses  │  │ (already uses     │  │ test-scope       │
+│  cargo t)      │  │  cargo t)         │  │ pointer          │
+└────────────────┘  └───────────────────┘  └──────────────────┘
+```
+
+Only the root `CONTRIBUTING.md` holds the full rule. Everything else
+links to it.
+
+## Data Models
+
+N/A — no code change.
+
+## API Design
+
+N/A — no code change.
+
+## Component Breakdown
+
+| Piece | File | Change type |
+|---|---|---|
+| Source-of-truth runner + scope doc | `CONTRIBUTING.md` (new, repo root) | Create |
+| Pointer from dev-lifecycle implementation phase | `docs/ai/implementation/README.md` | Add "Testing conventions" section pointing at `CONTRIBUTING.md` |
+| Dev-commands section alignment | `README.md` | Already correct (uses `cargo t`). No change needed. |
+| Release checklist alignment | `docs/RELEASE.md` | Already correct (uses `cargo t` + `cargo test --doc`). No change needed. |
+| CI workflow | `.github/workflows/*.yml` | **Does not exist** — issue criterion N/A. Record the canonical commands in `CONTRIBUTING.md` so the next workflow lands right. |
+
+**Files added:** 1 (`CONTRIBUTING.md`).
+**Files modified:** 1 (`docs/ai/implementation/README.md`).
+**Files deleted:** 0.
+**Rust code touched:** none.
+
+## Design Decisions
+
+### 1. `CONTRIBUTING.md` over `CLAUDE.md`
+
+The issue offered both as candidates. `CLAUDE.md` at the repo root
+is in `.gitignore` (treated as per-user Claude Code settings), so
+committing one would be a dead letter. `CONTRIBUTING.md` is the
+conventional GitHub contributor doc and is picked up by the
+"Community Standards" sidebar. Ship `CONTRIBUTING.md`.
+
+Agents spawned by Claude Code already get the essential test-runner
+rules through `ao-rs.yaml`'s project `rules:` block (landed in
+commit `e1cff9d`). `CONTRIBUTING.md` is the fuller, authoritative
+version; `ao-rs.yaml` is the short agent-injection form.
+
+Rejected alternatives:
+- **Un-ignore `CLAUDE.md` and ship both.** The gitignore entry is
+  there so users can keep their own CLAUDE.md customisations
+  private. Removing it invites churn for zero benefit — the
+  content has a good home in `CONTRIBUTING.md`.
+- **Ship both with one pointing at the other.** Extra hop, extra
+  drift surface. Re-open if a contributor specifically asks.
+
+### 2. Copy the test-scope table verbatim from the issue
+
+The issue body is the agreed spec. Re-phrasing it into a new doc
+invites drift. The CONTRIBUTING.md section labels its source:
+"source: [issue #168](...)". If the spec changes, the issue and
+doc move together.
+
+### 3. Don't add a `.config/nextest.toml` profile
+
+The repo ships a minimal nextest setup:
+- `.cargo/config.toml` aliases `cargo t` to `nextest run`.
+- `.cargo/config.toml` sets `[build] jobs = 2` to keep laptop CPU
+  reasonable.
+
+No need for a `nextest.toml` profile yet:
+- Default nextest settings (parallel-by-logical-CPU, per-test
+  process isolation) are what we want.
+- A profile file would add a place for values to drift without
+  clear need.
+- `--test-threads N` works on the command line for operators who
+  want to throttle, and `README.md` already documents that.
+
+Add one only when we hit a concrete need (a flaky integration
+test that needs `retries = 2`, a slow-test bucket, CI-specific
+reporter).
+
+### 4. Don't modify `docs/RELEASE.md`
+
+It already says `cargo t --workspace` and `cargo test --doc
+--workspace`. The section "Automated CI (PRs + main)" still
+references `.github/workflows/` but that section is forward-looking
+("when we re-add CI"). Leaving it in place keeps the intent on
+record.
+
+### 5. Don't resurrect deleted CI workflows
+
+Commit `e8e4c54` ("chore: remove obsolete CI and release artifact
+workflows") deleted them on purpose. Re-adding them is out of
+scope for this issue — **and** the issue's CI criterion can't be
+met mechanically (no files to modify). Document the intended
+command in `CONTRIBUTING.md` so the next workflow author starts right.
+
+### 6. Keep `ao-rs.yaml` project rules
+
+`ao-rs.yaml` already includes, for the `ao-rs` project:
+
+```yaml
+rules: |-
+  - Testing: use `cargo t` (nextest alias) — NOT `cargo test`.
+  - Run `cargo test --doc` separately for doctests (nextest skips them).
+  - When implementing a new feature, add a `#[cfg(test)] mod tests`
+    module alongside the code (or under `tests/` for integration) …
+```
+
+These lines came from commit `e1cff9d`. Don't duplicate them in
+`CONTRIBUTING.md` — reference them and expand on the scope rule. The
+agent-rules channel and the contributor doc channel cover the
+same idea in different voices; `CONTRIBUTING.md` is the authoritative
+source, `ao-rs.yaml` is the agent-injection shorthand.
+
+## State Machine Deltas
+
+N/A.
+
+## Non-Functional Requirements
+
+- **Freshness.** Update CONTRIBUTING.md whenever the workflow changes.
+  The release-checklist commands in `docs/RELEASE.md` and the
+  agent rules in `ao-rs.yaml` should re-link to CONTRIBUTING.md (not
+  re-list commands) on next edit.
+
+## Intentional Divergences from Issue #168
+
+| Issue says | This design | Why |
+|---|---|---|
+| "CI `.github/workflows/*.yml` updated to use `cargo nextest run --workspace`" | No CI file edited | `.github/workflows/` was deleted in `e8e4c54`. The command is recorded in `CONTRIBUTING.md` for the next CI re-introduction. |
+| "Install: `cargo install cargo-nextest`" | `CONTRIBUTING.md` documents install and links to the nextest site | Just covering the install path for first-time contributors. |
+
+## Test Strategy preview
+
+No Rust code changes — no new tests.
+
+Verification steps (see planning doc):
+
+1. `cargo fmt --all -- --check`.
+2. `cargo clippy --workspace --all-targets -- -D warnings`.
+3. `cargo t --workspace`.
+4. `cargo test --doc --workspace`.
+5. Manual: open `CONTRIBUTING.md` in the repo root and sanity-check
+   that every command runs.

--- a/docs/ai/implementation/README.md
+++ b/docs/ai/implementation/README.md
@@ -6,6 +6,14 @@ description: Technical implementation notes, patterns, and code guidelines
 
 # Implementation Guide
 
+## Testing conventions
+
+Repo-wide test conventions — runner, per-module test scope rule, and
+inner dev loop commands — live in the root
+[`CONTRIBUTING.md`](../../../CONTRIBUTING.md). Read that before
+writing new tests; every feature's implementation phase should
+follow it.
+
 ## Development Setup
 **How do we get started?**
 

--- a/docs/ai/planning/feature-nextest-test-scope.md
+++ b/docs/ai/planning/feature-nextest-test-scope.md
@@ -1,0 +1,111 @@
+---
+phase: planning
+title: nextest adoption + per-module test scope — planning
+description: Task list for landing the docs change for issue #168.
+---
+
+# Planning — nextest adoption + per-module test scope
+
+## Milestones
+
+- [ ] **M1: `CONTRIBUTING.md` landed.** Root-level contributor doc exists,
+      contains the nextest commands, the per-module scope rule, and
+      the inner dev loop cheat-sheet.
+- [ ] **M2: Cross-links in place.** `docs/ai/implementation/README.md`
+      points at `CONTRIBUTING.md` for testing conventions.
+- [ ] **M3: Quality gates pass.** `cargo fmt --check`, `cargo clippy
+      -D warnings`, `cargo t --workspace`, `cargo test --doc
+      --workspace` all clean on this branch.
+- [ ] **M4: PR merged.** Branch pushed, PR opened against `main`
+      referencing issue #168.
+
+## Task Breakdown
+
+### Phase 1 — Write
+
+- [ ] **Task 1.1 — Draft `CONTRIBUTING.md`.** Sections:
+  1. Project orientation (one paragraph: what ao-rs is).
+  2. Build + test commands (`cargo t`, `cargo test --doc`, `cargo
+     clippy`, `cargo fmt`).
+  3. Installing nextest if missing.
+  4. Per-module test scope rule (table from issue body).
+  5. What Rust already proves — do NOT test.
+  6. Target coverage by layer (table from issue body).
+  7. Inner dev loop cheat-sheet (`cargo check`, `cargo watch`).
+  8. Pre-PR checklist.
+
+- [ ] **Task 1.2 — Update `docs/ai/implementation/README.md`.** Add
+      a short "Testing conventions" pointer at the top that links to
+      `CONTRIBUTING.md` — so the dev-lifecycle implementation phase picks
+      up the scope rule via the existing scaffold.
+
+### Phase 2 — Verify
+
+- [ ] **Task 2.1 — Run `cargo fmt --all -- --check`.** Expect no
+      output (no Rust code changed). Confirms tooling works.
+- [ ] **Task 2.2 — Run `cargo clippy --workspace --all-targets
+      -- -D warnings`.** Same — no code changed, clean pass.
+- [ ] **Task 2.3 — Run `cargo t --workspace`.** Confirms the test
+      suite still passes. If any test was already flaky on `main`,
+      note it explicitly (don't swallow).
+- [ ] **Task 2.4 — Run `cargo test --doc --workspace`.** Doctests
+      pass.
+
+### Phase 3 — Ship
+
+- [ ] **Task 3.1 — Commit.** One focused commit:
+      `docs(contrib): adopt cargo-nextest + per-module test scope (#168)`.
+- [ ] **Task 3.2 — Push branch.** `git push -u origin
+      feature/168-chore-test-adopt-cargo-nextest-establish-per`.
+- [ ] **Task 3.3 — Open PR.** Title references issue #168. Body
+      calls out the N/A CI criterion with a link to the removal
+      commit `e8e4c54`.
+
+## Dependencies
+
+```
+Task 1.1 (CONTRIBUTING.md draft) ─┬─> Task 1.2 (cross-link)
+                            └─> Task 2.* (verification)
+All of Phase 1 + Phase 2    ───> Task 3.* (ship)
+```
+
+## Timeline & Estimates
+
+| Task | Effort |
+|---|---|
+| 1.1 draft CONTRIBUTING.md | ~30 min |
+| 1.2 cross-link | ~5 min |
+| 2.1–2.4 verification | ~5 min wall-clock (most time is cargo cache warm-up) |
+| 3.1 commit | ~2 min |
+| 3.2 push | ~1 min |
+| 3.3 open PR | ~5 min |
+
+Total: about an hour.
+
+## Risks & Mitigation
+
+| Risk | Impact | Mitigation |
+|---|---|---|
+| **CONTRIBUTING.md duplicates content from README/ao-rs.yaml and drifts** | Contributors follow stale command | Pin CONTRIBUTING.md as the authoritative source; other docs link, don't copy. The design doc records this decision. |
+| **Contributor expects a CONTRIBUTING.md and misses CONTRIBUTING.md** | Friction on first PR | GitHub surfaces `CONTRIBUTING.md` in the Community Standards sidebar when it's the only candidate, and README's "Development" section already shows the right commands. Re-open the CONTRIBUTING.md question if a real contributor asks. |
+| **Issue's CI acceptance criterion reads as "must update workflow"** | PR reviewer thinks we punted | PR description explicitly calls out that workflows were deleted in `e8e4c54` and that the CONTRIBUTING.md captures the canonical commands for the next CI re-intro. |
+| **Agent rules in `ao-rs.yaml` get out of sync with CONTRIBUTING.md** | Spawned agent follows stale rule | Low — `ao-rs.yaml` only lists the two commands we standardized on. If they change, both files move together. The `ao-rs` project rules already say `cargo t` as of commit `e1cff9d`. |
+
+## Resources Needed
+
+- Issue body from [#168](https://github.com/duonghb53/ao-rs/issues/168)
+  — the test scope rule table is authoritative there.
+- Existing references: `.cargo/config.toml`, `README.md` "Development"
+  section, `docs/RELEASE.md` release-checklist section, `ao-rs.yaml`
+  project rules.
+
+## Exit Criteria
+
+Issue #168 is closeable when:
+
+1. `CONTRIBUTING.md` exists at repo root with all sections from Task 1.1.
+2. `docs/ai/implementation/README.md` links to `CONTRIBUTING.md` for
+   testing conventions.
+3. Verification commands (2.1–2.4) pass clean.
+4. Branch is pushed, PR is open, PR body records the N/A CI
+   criterion + link to `e8e4c54`.

--- a/docs/ai/requirements/feature-nextest-test-scope.md
+++ b/docs/ai/requirements/feature-nextest-test-scope.md
@@ -1,0 +1,123 @@
+---
+phase: requirements
+title: nextest adoption + per-module test scope guidelines (issue #168)
+description: Formalize cargo-nextest as the standard runner and document the scope rule contributors should follow when adding or changing tests.
+---
+
+# Requirements — nextest adoption + per-module test scope
+
+## Problem Statement
+
+Two related pains from issue
+[#168](https://github.com/duonghb53/ao-rs/issues/168):
+
+1. **`cargo test --workspace` is slow.** Cold builds take 60–90 s for a
+   one-line change and serial execution dominates the inner dev loop.
+2. **No explicit test-scope rule.** Contributors (humans and spawned
+   agents) lack clear guidance on *what* to test when adding or
+   changing a module, leading to either overtesting (slow, brittle
+   suites) or undertesting (gaps in business-logic coverage).
+
+Current state in this repo:
+
+- `cargo t` is already wired to `nextest run` via
+  `.cargo/config.toml`. README, `docs/RELEASE.md`, and `ao-rs.yaml`
+  already reference `cargo t` as the default. So **part A of the
+  issue is mostly landed** — we still need a single contributor-
+  facing page that states the convention plainly.
+- There is **no `CONTRIBUTING.md` or `CONTRIBUTING.md`** at the repo root.
+  Spawned agents rely on `ao-rs.yaml` project rules; human
+  contributors have nothing.
+- There is **no per-module scope rule** written down anywhere.
+- `.github/workflows/` was deleted in commit `e8e4c54`; there is
+  currently no CI to retarget. The issue's CI acceptance criterion
+  is therefore N/A for this repo state — document the intended
+  runner so the next CI workflow lands on nextest from the start.
+
+## Goals & Objectives
+
+### Primary goals
+
+1. Ship a `CONTRIBUTING.md` at the repo root that documents, as the
+   contributor-facing source of truth:
+   - `cargo-nextest` as the standard test runner (plus the `cargo t`
+     alias and the `cargo test --doc` carve-out).
+   - The per-module test scope rule from the issue body.
+   - The inner dev loop command cheat-sheet.
+2. Make the test-scope rule discoverable from the dev-lifecycle docs
+   (`docs/ai/implementation/`) so the existing `new-requirement` /
+   `writing-test` skills pick it up.
+3. Ensure the CI-command guidance in `docs/RELEASE.md` stays
+   consistent with the CONTRIBUTING.md — so whoever re-adds the workflow
+   copy-pastes the right commands.
+
+### Secondary goals
+
+- Spot-check that no new `tests/` module was added to an untouched
+  module by this change (the issue's "no new test files for existing
+  untouched modules" criterion) — this change is docs-only.
+
+### Non-goals
+
+- **Re-adding CI workflows.** `e8e4c54` removed them deliberately.
+  Restoring them is a separate decision.
+- **Rewriting the nextest config.** `.cargo/config.toml` is already
+  a minimal, working setup (`jobs = 2` + `t = nextest run`). No
+  `.config/nextest.toml` profile is added unless a concrete need
+  shows up.
+- **Retrofitting existing tests.** The scope rule applies going
+  forward; existing tests are grandfathered.
+
+## User Stories & Use Cases
+
+1. **Human contributor clones the repo.** They expect a root-level
+   `CONTRIBUTING.md` (or `CONTRIBUTING.md`) that tells them the canonical
+   commands and the test-scope rule. They get it in one file.
+2. **Agent spawned from issue #168 reads `CONTRIBUTING.md`.** The
+   dev-lifecycle flow pulls the scope rule into its requirements
+   drafting step — the agent doesn't invent ad-hoc coverage goals.
+3. **Reviewer on a PR.** When someone adds a broad integration test
+   for a refactor (behaviour unchanged), the reviewer can link to
+   the "Refactor → existing tests must pass — do not add new ones"
+   row in `CONTRIBUTING.md`.
+
+## Success Criteria
+
+Acceptance (mapped to the issue):
+
+- [x] `cargo-nextest` documented in a root-level contributor file
+      (`CONTRIBUTING.md`) as the standard runner.
+- [~] CI workflows updated — **N/A**, repo currently has no
+      `.github/workflows/*.yml` (removed in `e8e4c54`). The
+      CONTRIBUTING.md records the intended command so the next workflow
+      lands right.
+- [x] Per-module test scope rule documented (copied from the issue
+      body and cross-linked from `docs/ai/implementation/`).
+- [x] No new test files added for existing untouched modules —
+      enforced by this change being docs-only; verified in the PR
+      diff.
+
+Quality gates:
+
+- `cargo fmt --all -- --check` clean.
+- `cargo clippy --workspace --all-targets -- -D warnings` clean.
+- `cargo t --workspace` clean.
+- `cargo test --doc --workspace` clean.
+
+## Constraints & Assumptions
+
+- **Docs-only change.** No Rust code touched, no `Cargo.toml`
+  touched.
+- **Single source of truth = `CONTRIBUTING.md` at repo root.** Other docs
+  (`README.md`, `docs/RELEASE.md`, `ao-rs.yaml`) cross-reference it
+  rather than duplicate.
+- **Assume the next CI re-introduction uses nextest.** The issue
+  body is the spec; CONTRIBUTING.md records the exact command.
+
+## Questions & Open Items
+
+- Should `CONTRIBUTING.md` also exist as a GitHub-idiomatic pointer
+  to `CONTRIBUTING.md`? **Decision:** ship `CONTRIBUTING.md` only for now.
+  GitHub will surface a `CONTRIBUTING.md` in the "Contributing" sidebar
+  if it's the only candidate, and duplicating content invites drift.
+  Re-open if a contributor specifically asks.


### PR DESCRIPTION
## Summary

Closes #168.

- Add root-level `CONTRIBUTING.md` as the contributor-facing source of truth: `cargo-nextest` as the standard runner (`cargo t` alias), the per-module test scope rule from the issue body, "what Rust already proves — do NOT test", target coverage-by-layer, and the inner dev loop command cheat-sheet.
- Cross-link from `docs/ai/implementation/README.md` so the dev-lifecycle flow picks up the scope rule.
- Scaffold dev-lifecycle requirements/design/planning docs for this change under `docs/ai/` (force-added; `docs/ai/` is `.gitignore`d but precedent — e.g. `feature-agent-stuck-detection.md` — is to track these for posterity).

## Acceptance criteria (from issue #168)

- [x] `cargo-nextest` documented in the contributor doc as the standard runner — in `CONTRIBUTING.md`.
- [ ] ~~CI `.github/workflows/*.yml` updated to use `cargo nextest run --workspace`~~ — **N/A**: this repo has no CI workflow files. They were removed in [`e8e4c54`](https://github.com/duonghb53/ao-rs/commit/e8e4c54) ("chore: remove obsolete CI and release artifact workflows"). `CONTRIBUTING.md` records the canonical commands so the next CI re-intro lands on nextest from the start.
- [x] Per-module test scope rule documented — table copied verbatim from the issue body to `CONTRIBUTING.md`.
- [x] No new test files added for existing untouched modules — docs-only change.

## Design decisions (see `docs/ai/design/feature-nextest-test-scope.md`)

- **`CONTRIBUTING.md`, not `CLAUDE.md`.** The issue offered both as candidates, but `CLAUDE.md` is in `.gitignore` (treated as per-user Claude Code settings), so it would be a dead letter. `CONTRIBUTING.md` is the conventional GitHub contributor doc and surfaces in the Community Standards sidebar.
- **No `.config/nextest.toml` yet.** `.cargo/config.toml` already aliases `cargo t` to `nextest run` and sets `[build] jobs = 2`. A profile file would add a drift surface for no concrete benefit. Add one if we hit a real need (flaky-test retries, CI-specific reporter).
- **Don't re-add CI.** Commit `e8e4c54` deleted workflows deliberately. Re-introducing them is a separate call.

## Verification

Ran on this branch:

- `cargo check --workspace --all-targets` — clean.
- `cargo t --workspace` — **812 tests passed, 0 failed**.
- `cargo test --doc --workspace` — clean.
- `cargo clippy --workspace --all-targets -- -D warnings` — clean.
- `cargo fmt --all -- --check` — **pre-existing failures** on `crates/plugins/scm-gitlab/src/{webhook,graphql_batch,…}.rs` (unrelated to this PR; already present on `main`). Flagging so it doesn't get lost.

## Test plan

- [x] `cargo t --workspace` passes.
- [x] `cargo test --doc --workspace` passes.
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes.
- [ ] Reviewer sanity-checks that every command in the `CONTRIBUTING.md` "Inner dev loop" and "Pre-PR checklist" sections runs locally.
- [ ] Reviewer decides whether to open a follow-up for the pre-existing `cargo fmt` drift in `scm-gitlab`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)