### PR TITLE
feat(ui): issues backlog card with per-issue Spawn (#163)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -156,6 +156,7 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "ao-core",
+ "ao-plugin-tracker-github",
  "ao-plugin-workspace-worktree",
  "async-trait",
  "axum",

--- a/crates/ao-cli/src/commands/dashboard.rs
+++ b/crates/ao-cli/src/commands/dashboard.rs
@@ -48,6 +48,7 @@ fn build_dashboard_state() -> Result<ao_dashboard::state::AppState, Box<dyn std:
         scm,
         agent,
         workspace,
+        config_path: Some(config_path),
     })
 }
 
@@ -171,6 +172,7 @@ pub async fn dashboard(
         scm,
         agent,
         workspace,
+        config_path: Some(config_path),
     };
 
     println!(

--- a/crates/ao-dashboard/Cargo.toml
+++ b/crates/ao-dashboard/Cargo.toml
@@ -8,6 +8,7 @@ rust-version.workspace = true
 [dependencies]
 ao-core = { workspace = true }
 ao-plugin-workspace-worktree = { workspace = true }
+ao-plugin-tracker-github = { path = "../plugins/tracker-github" }
 axum = { workspace = true }
 tokio = { workspace = true }
 tokio-stream = { workspace = true }

--- a/crates/ao-dashboard/src/lib.rs
+++ b/crates/ao-dashboard/src/lib.rs
@@ -28,6 +28,7 @@ async fn dashboard_root() -> Html<&'static str> {
   <ul>
     <li><a href="/api/sessions"><code>GET /api/sessions</code></a> — list sessions</li>
     <li><a href="/api/sessions?pr=true"><code>GET /api/sessions?pr=true</code></a> — list with PR enrichment</li>
+    <li><a href="/api/issues"><code>GET /api/issues</code></a> — open issues across configured projects</li>
     <li><code>GET /api/events</code> — SSE event stream</li>
     <li><code>GET /health</code> — liveness JSON</li>
   </ul>
@@ -59,6 +60,7 @@ pub fn router(state: AppState) -> Router {
             "/api/orchestrators",
             get(routes::list_orchestrators).post(routes::spawn_orchestrator_route),
         )
+        .route("/api/issues", get(routes::list_issues_route))
         .route("/api/events", get(sse::event_stream))
         .layer(CorsLayer::permissive())
         .with_state(state)
@@ -129,6 +131,7 @@ mod tests {
             scm,
             agent,
             workspace,
+            config_path: None,
         }
     }
 
@@ -592,6 +595,110 @@ mod tests {
         let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
         assert_eq!(json.as_array().unwrap().len(), 1);
         assert_eq!(json[0]["id"], "demo-orchestrator-1");
+    }
+
+    #[tokio::test]
+    async fn issues_route_without_config_path_returns_422() {
+        // Default test_state leaves config_path = None.
+        let app = router(test_state());
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/issues")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["error"].as_str().is_some_and(|s| s.contains("config")),
+            "expected config-related error, got {:?}",
+            json
+        );
+    }
+
+    #[tokio::test]
+    async fn issues_route_with_empty_config_returns_empty_array() {
+        // Write a valid but project-less config file and point the dashboard at it.
+        let mut state = test_state();
+        let dir = std::env::temp_dir().join(format!(
+            "ao-dashboard-issues-{}-{}",
+            std::process::id(),
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)
+                .unwrap()
+                .as_nanos()
+        ));
+        std::fs::create_dir_all(&dir).unwrap();
+        let config_path = dir.join("ao-rs.yaml");
+        std::fs::write(&config_path, "port: 3000\nprojects: {}\n").unwrap();
+        state.config_path = Some(config_path);
+
+        let app = router(state);
+        let resp = app
+            .oneshot(
+                Request::builder()
+                    .uri("/api/issues")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert_eq!(json, serde_json::json!([]));
+    }
+
+    #[tokio::test]
+    async fn spawn_without_repo_path_and_without_config_returns_422() {
+        // Default test_state has config_path = None.
+        let app = router(test_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/sessions/spawn")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"project_id":"demo","task":"x","no_prompt":true,"issue_id":"42"}"#,
+            ))
+            .unwrap();
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
+        let body = axum::body::to_bytes(resp.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        let json: serde_json::Value = serde_json::from_slice(&body).unwrap();
+        assert!(
+            json["error"]
+                .as_str()
+                .is_some_and(|s| s.contains("repo_path")),
+            "expected repo_path error, got {:?}",
+            json
+        );
+    }
+
+    #[tokio::test]
+    async fn spawn_accepts_issue_id_and_url_fields() {
+        let app = router(test_state());
+        let req = Request::builder()
+            .method("POST")
+            .uri("/api/sessions/spawn")
+            .header("content-type", "application/json")
+            .body(Body::from(
+                r#"{"project_id":"demo","repo_path":"/tmp/not-a-repo","task":"x","no_prompt":true,"issue_id":"42","issue_url":"https://example.com/1"}"#,
+            ))
+            .unwrap();
+        // Still 422 because repo_path is not a git repo; the assertion is
+        // that the body *parses* with the new optional fields.
+        let resp = app.oneshot(req).await.unwrap();
+        assert_eq!(resp.status(), StatusCode::UNPROCESSABLE_ENTITY);
     }
 
     #[tokio::test]

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -2,11 +2,13 @@
 
 use crate::state::AppState;
 use ao_core::{
-    is_orchestrator_session, now_ms, restore_session as restore_core_session,
-    spawn_orchestrator as core_spawn_orchestrator, AoConfig, AoError, CiStatus, LoadedConfig,
-    MergeReadiness, OrchestratorSpawnConfig, PrState, PullRequest, ReviewDecision, Scm, Session,
-    SessionId, SessionStatus, Workspace, WorkspaceCreateConfig,
+    is_orchestrator_session, now_ms, rate_limit as ao_rate_limit,
+    restore_session as restore_core_session, spawn_orchestrator as core_spawn_orchestrator,
+    AoConfig, AoError, CiStatus, IssueFilters, LoadedConfig, MergeReadiness,
+    OrchestratorSpawnConfig, PrState, PullRequest, ReviewDecision, Scm, Session, SessionId,
+    SessionStatus, Tracker, Workspace, WorkspaceCreateConfig,
 };
+use ao_plugin_tracker_github::GitHubTracker;
 use axum::extract::ws::{Message, WebSocket, WebSocketUpgrade};
 use axum::{
     extract::{Path, Query as AxumQuery, State},
@@ -76,7 +78,13 @@ pub async fn list_sessions(
 #[derive(Debug, Deserialize)]
 pub struct SpawnSessionBody {
     pub project_id: String,
-    pub repo_path: String,
+    /// Absolute path to the source repo.
+    ///
+    /// Optional since #163 — when absent (e.g. spawning from the
+    /// Backlog card in the UI), the dashboard falls back to
+    /// `config.projects[project_id].path` from the loaded `ao-rs.yaml`.
+    #[serde(default)]
+    pub repo_path: Option<String>,
     pub task: String,
     #[serde(default = "default_default_branch")]
     pub default_branch: String,
@@ -88,6 +96,14 @@ pub struct SpawnSessionBody {
     /// loop can notify it when this worker changes state. See issue #169.
     #[serde(default)]
     pub spawned_by: Option<String>,
+    /// Tracker issue identifier this session was spawned from, e.g. `"42"`.
+    /// Persisted on the resulting `Session` so reactions and status views
+    /// can correlate session → issue. See issue #163.
+    #[serde(default)]
+    pub issue_id: Option<String>,
+    /// Canonical issue URL (e.g. `https://github.com/owner/repo/issues/42`).
+    #[serde(default)]
+    pub issue_url: Option<String>,
 }
 
 fn default_default_branch() -> String {
@@ -98,12 +114,66 @@ fn default_agent() -> String {
     "claude-code".to_string()
 }
 
+/// Resolve `repo_path` for a spawn request.
+///
+/// Order of precedence:
+/// 1. Explicit `repo_path` in the body (original behavior).
+/// 2. `config.projects[project_id].path` when the dashboard was started
+///    with a config (`AppState.config_path`) and the project is known.
+///
+/// Returns a 422 with a structured error if neither source resolves.
+fn resolve_spawn_repo_path(
+    state: &AppState,
+    project_id: &str,
+    body_repo_path: Option<&str>,
+) -> Result<PathBuf, (StatusCode, Json<ApiErrorBody>)> {
+    if let Some(p) = body_repo_path {
+        let trimmed = p.trim();
+        if !trimmed.is_empty() {
+            return Ok(PathBuf::from(trimmed));
+        }
+    }
+
+    let Some(config_path) = state.config_path.as_ref() else {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiErrorBody {
+                error: "repo_path missing and dashboard was started without a config file"
+                    .to_string(),
+            }),
+        ));
+    };
+
+    let LoadedConfig { config, .. } = AoConfig::load_from_or_default_with_warnings(config_path)
+        .map_err(|e| {
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ApiErrorBody {
+                    error: format!("failed to load {}: {e}", config_path.display()),
+                }),
+            )
+        })?;
+
+    let project = config.projects.get(project_id).ok_or_else(|| {
+        (
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiErrorBody {
+                error: format!(
+                    "repo_path missing and project '{project_id}' is not in {}",
+                    config_path.display()
+                ),
+            }),
+        )
+    })?;
+    Ok(PathBuf::from(&project.path))
+}
+
 /// POST /api/sessions/spawn — create a new session (worktree + tmux runtime).
 pub async fn spawn_session(
     State(state): State<AppState>,
     Json(body): Json<SpawnSessionBody>,
 ) -> Result<Json<serde_json::Value>, (StatusCode, Json<ApiErrorBody>)> {
-    let repo_path = PathBuf::from(body.repo_path);
+    let repo_path = resolve_spawn_repo_path(&state, &body.project_id, body.repo_path.as_deref())?;
     if !repo_path.join(".git").exists() {
         return Err((
             StatusCode::UNPROCESSABLE_ENTITY,
@@ -147,8 +217,8 @@ pub async fn spawn_session(
         activity: None,
         created_at: now_ms(),
         cost: None,
-        issue_id: None,
-        issue_url: None,
+        issue_id: body.issue_id.clone(),
+        issue_url: body.issue_url.clone(),
         claimed_pr_number: None,
         claimed_pr_url: None,
         initial_prompt_override: None,
@@ -824,6 +894,177 @@ pub async fn spawn_orchestrator_route(
     })
 }
 
+// ---------------------------------------------------------------------------
+// Issues backlog route (issue #163)
+// ---------------------------------------------------------------------------
+
+#[derive(Debug, Deserialize)]
+pub struct ListIssuesQuery {
+    /// Limit to a single project. Omitted → aggregate across all
+    /// configured projects.
+    #[serde(default)]
+    pub project_id: Option<String>,
+    /// `"open"`, `"closed"`, or `"all"`. Defaults to `"open"`.
+    #[serde(default)]
+    pub state: Option<String>,
+    /// Comma-separated labels, forwarded to the tracker.
+    #[serde(default)]
+    pub labels: Option<String>,
+    /// Per-project cap on issues returned. Tracker picks a default (30)
+    /// when absent.
+    #[serde(default)]
+    pub limit: Option<u32>,
+}
+
+#[derive(Debug, Clone, serde::Serialize, PartialEq, Eq)]
+pub struct DashboardIssue {
+    pub project_id: String,
+    pub number: u64,
+    pub title: String,
+    pub url: String,
+    pub labels: Vec<String>,
+    /// `owner/repo` slug the issue belongs to.
+    pub repo: String,
+    /// `"open"`, `"closed"`, `"cancelled"`, `"in_progress"` (tracker-dependent).
+    pub state: String,
+}
+
+/// Split `owner/repo` into `(owner, repo)`. Returns `None` if the slug
+/// does not match that shape — mirrors the validation in
+/// `AoConfig::validate`. Split into a helper so the new issues route
+/// and future Tracker-fan-out callers share the same rule (and we can
+/// unit-test it without a full config fixture).
+fn parse_repo_slug(slug: &str) -> Option<(String, String)> {
+    let mut parts = slug.splitn(2, '/');
+    let owner = parts.next()?.trim();
+    let repo = parts.next()?.trim();
+    if owner.is_empty() || repo.is_empty() || repo.contains('/') {
+        return None;
+    }
+    Some((owner.to_string(), repo.to_string()))
+}
+
+fn issue_state_label(state: ao_core::IssueState) -> &'static str {
+    match state {
+        ao_core::IssueState::Open => "open",
+        ao_core::IssueState::InProgress => "in_progress",
+        ao_core::IssueState::Closed => "closed",
+        ao_core::IssueState::Cancelled => "cancelled",
+    }
+}
+
+fn issue_filters_from_query(q: &ListIssuesQuery) -> IssueFilters {
+    let labels = q
+        .labels
+        .as_deref()
+        .map(|s| {
+            s.split(',')
+                .map(|p| p.trim().to_string())
+                .filter(|p| !p.is_empty())
+                .collect::<Vec<_>>()
+        })
+        .unwrap_or_default();
+    IssueFilters {
+        state: q.state.clone(),
+        labels,
+        assignee: None,
+        limit: q.limit,
+    }
+}
+
+/// GET /api/issues — aggregate open issues across configured projects.
+///
+/// Loads `ao-rs.yaml` on every call so newly added projects show up
+/// without restarting the dashboard. If a single project errors
+/// (invalid repo slug, cooldown active, missing `gh`), we log and skip
+/// it so the rest of the list still loads.
+pub async fn list_issues_route(
+    State(state): State<AppState>,
+    AxumQuery(query): AxumQuery<ListIssuesQuery>,
+) -> Result<Json<Vec<DashboardIssue>>, (StatusCode, Json<ApiErrorBody>)> {
+    let Some(config_path) = state.config_path.as_ref() else {
+        return Err((
+            StatusCode::UNPROCESSABLE_ENTITY,
+            Json(ApiErrorBody {
+                error: "dashboard was started without a config path; \
+                        GET /api/issues requires a loaded ao-rs.yaml"
+                    .to_string(),
+            }),
+        ));
+    };
+
+    let LoadedConfig { config, .. } = AoConfig::load_from_or_default_with_warnings(config_path)
+        .map_err(|e| {
+            (
+                StatusCode::UNPROCESSABLE_ENTITY,
+                Json(ApiErrorBody {
+                    error: format!("failed to load {}: {e}", config_path.display()),
+                }),
+            )
+        })?;
+
+    if ao_rate_limit::in_cooldown_now() {
+        tracing::debug!(
+            "/api/issues: rate-limit cooldown active; returning empty list to avoid hammering gh"
+        );
+        return Ok(Json(Vec::new()));
+    }
+
+    let filters = issue_filters_from_query(&query);
+    let mut out: Vec<DashboardIssue> = Vec::new();
+    for (project_id, project) in config.projects.iter() {
+        if let Some(filter_id) = query.project_id.as_deref() {
+            if filter_id != project_id.as_str() {
+                continue;
+            }
+        }
+
+        let Some((owner, repo)) = parse_repo_slug(&project.repo) else {
+            tracing::warn!(
+                "/api/issues: skipping project {} with invalid repo slug {:?}",
+                project_id,
+                project.repo
+            );
+            continue;
+        };
+
+        let tracker = GitHubTracker::new(owner, repo);
+        let issues = match tracker.list_issues(&filters).await {
+            Ok(v) => v,
+            Err(e) => {
+                tracing::warn!(
+                    "/api/issues: tracker.list_issues failed for {}: {}",
+                    project_id,
+                    e
+                );
+                continue;
+            }
+        };
+
+        for issue in issues {
+            let number = issue.id.parse::<u64>().unwrap_or(0);
+            out.push(DashboardIssue {
+                project_id: project_id.clone(),
+                number,
+                title: issue.title,
+                url: issue.url,
+                labels: issue.labels,
+                repo: project.repo.clone(),
+                state: issue_state_label(issue.state).to_string(),
+            });
+        }
+    }
+
+    // Stable order: project_id asc, then issue number desc (newest first within a project).
+    out.sort_by(|a, b| {
+        a.project_id
+            .cmp(&b.project_id)
+            .then_with(|| b.number.cmp(&a.number))
+    });
+
+    Ok(Json(out))
+}
+
 #[cfg(test)]
 mod attention_tests {
     use super::{attention_level, DashboardPr};
@@ -960,5 +1201,54 @@ mod terminal_ws_tests {
     fn resize_missing_fields_is_ignored() {
         let msg = Message::Text(r#"{"type":"resize","cols":80}"#.into());
         assert_eq!(parse_terminal_client_action(msg), None);
+    }
+}
+
+#[cfg(test)]
+mod issues_route_tests {
+    use super::{issue_filters_from_query, parse_repo_slug, ListIssuesQuery};
+
+    #[test]
+    fn parse_repo_slug_happy_path() {
+        assert_eq!(
+            parse_repo_slug("owner/repo"),
+            Some(("owner".to_string(), "repo".to_string()))
+        );
+    }
+
+    #[test]
+    fn parse_repo_slug_rejects_malformed() {
+        assert!(parse_repo_slug("no-slash").is_none());
+        assert!(parse_repo_slug("/trailing").is_none());
+        assert!(parse_repo_slug("leading/").is_none());
+        assert!(parse_repo_slug("  /  ").is_none());
+        // Extra path segments (would break `--repo`) are rejected.
+        assert!(parse_repo_slug("owner/repo/extra").is_none());
+    }
+
+    #[test]
+    fn issue_filters_parses_comma_separated_labels() {
+        let q = ListIssuesQuery {
+            project_id: None,
+            state: Some("open".into()),
+            labels: Some("bug, good first issue , ,enhancement".into()),
+            limit: Some(10),
+        };
+        let f = issue_filters_from_query(&q);
+        assert_eq!(f.state.as_deref(), Some("open"));
+        assert_eq!(f.labels, vec!["bug", "good first issue", "enhancement"]);
+        assert_eq!(f.limit, Some(10));
+    }
+
+    #[test]
+    fn issue_filters_empty_labels_when_absent() {
+        let q = ListIssuesQuery {
+            project_id: None,
+            state: None,
+            labels: None,
+            limit: None,
+        };
+        let f = issue_filters_from_query(&q);
+        assert!(f.labels.is_empty());
     }
 }

--- a/crates/ao-dashboard/src/state.rs
+++ b/crates/ao-dashboard/src/state.rs
@@ -1,6 +1,7 @@
 //! Shared application state for the dashboard API.
 
 use ao_core::{Agent, OrchestratorEvent, Runtime, Scm, SessionManager, Workspace};
+use std::path::PathBuf;
 use std::sync::Arc;
 use tokio::sync::broadcast;
 
@@ -15,4 +16,11 @@ pub struct AppState {
     /// Workspace plugin used by `restore` to probe `exists()` on the
     /// persisted `workspace_path` before attempting to respawn.
     pub workspace: Arc<dyn Workspace>,
+    /// Path to the `ao-rs.yaml` the dashboard was started with.
+    ///
+    /// Reloaded per request by routes that need project→repo mapping
+    /// (`GET /api/issues`) so config edits take effect without a restart.
+    /// `None` in unit tests that construct `AppState` without a real
+    /// config on disk.
+    pub config_path: Option<PathBuf>,
 }

--- a/crates/ao-desktop/ui/src/api/client.ts
+++ b/crates/ao-desktop/ui/src/api/client.ts
@@ -114,12 +114,44 @@ export async function restoreSession(baseUrl: string, id: string): Promise<ApiSe
 
 export type SpawnSessionRequest = {
   project_id: string;
-  repo_path: string;
+  /** Absolute path to the repo on disk.
+   *  Optional since issue #163: when omitted, the dashboard falls back to
+   *  `config.projects[project_id].path` from the loaded `ao-rs.yaml`. */
+  repo_path?: string;
   task: string;
   agent?: string;
   default_branch?: string;
   no_prompt?: boolean;
+  /** Tracker issue identifier, e.g. `"42"`. Persisted on the Session. */
+  issue_id?: string;
+  /** Canonical issue URL, e.g. `https://github.com/owner/repo/issues/42`. */
+  issue_url?: string;
 };
+
+/** One row from `GET /api/issues`. Matches `ao_dashboard::routes::DashboardIssue`. */
+export type BacklogIssue = {
+  project_id: string;
+  number: number;
+  title: string;
+  url: string;
+  labels: string[];
+  repo: string;
+  state: string;
+};
+
+export async function listIssues(
+  baseUrl: string,
+  opts?: { projectId?: string | null; state?: string; labels?: string[]; limit?: number },
+): Promise<BacklogIssue[]> {
+  const params = new URLSearchParams();
+  if (opts?.projectId) params.set("project_id", opts.projectId);
+  if (opts?.state) params.set("state", opts.state);
+  if (opts?.labels && opts.labels.length > 0) params.set("labels", opts.labels.join(","));
+  if (opts?.limit !== undefined) params.set("limit", String(opts.limit));
+  const qs = params.toString();
+  const path = qs ? `/api/issues?${qs}` : "/api/issues";
+  return await httpJson<BacklogIssue[]>(joinUrl(baseUrl, path));
+}
 
 export async function spawnSession(baseUrl: string, req: SpawnSessionRequest): Promise<ApiSession> {
   return await httpJson<ApiSession>(joinUrl(baseUrl, "/api/sessions/spawn"), {

--- a/crates/ao-desktop/ui/src/components/IssuesPanel.test.tsx
+++ b/crates/ao-desktop/ui/src/components/IssuesPanel.test.tsx
@@ -1,0 +1,130 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+import { IssuesPanel } from "./IssuesPanel";
+import type { BacklogIssue } from "../api/client";
+
+const BASE = "http://dash.test";
+
+function okResponse(body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status: 200,
+    headers: { "content-type": "application/json" },
+  });
+}
+
+const FIXTURE: BacklogIssue[] = [
+  {
+    project_id: "demo",
+    number: 42,
+    title: "Add dark mode",
+    url: "https://github.com/acme/demo/issues/42",
+    labels: ["enhancement", "ui"],
+    repo: "acme/demo",
+    state: "open",
+  },
+  {
+    project_id: "demo",
+    number: 7,
+    title: "Fix flaky test",
+    url: "https://github.com/acme/demo/issues/7",
+    labels: [],
+    repo: "acme/demo",
+    state: "open",
+  },
+];
+
+describe("IssuesPanel", () => {
+  const fetchMock = vi.fn();
+
+  beforeEach(() => {
+    fetchMock.mockReset();
+    vi.stubGlobal("fetch", fetchMock);
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+    cleanup();
+  });
+
+  it("renders issues returned by /api/issues and a Spawn button per row", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse(FIXTURE));
+    render(<IssuesPanel baseUrl={BASE} projectId={null} onSpawn={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add dark mode")).toBeInTheDocument();
+    });
+    expect(screen.getByText("Fix flaky test")).toBeInTheDocument();
+    const spawnButtons = screen.getAllByRole("button", { name: /Spawn/ });
+    expect(spawnButtons).toHaveLength(2);
+
+    // URL should be built without `?project_id=` when projectId is null.
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/api/issues`);
+  });
+
+  it("passes ?project_id= to the API when projectId is set", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse([]));
+    render(<IssuesPanel baseUrl={BASE} projectId="demo" onSpawn={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    expect(fetchMock.mock.calls[0][0]).toBe(`${BASE}/api/issues?project_id=demo`);
+  });
+
+  it("shows the empty state when the list is empty", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse([]));
+    render(<IssuesPanel baseUrl={BASE} projectId={null} onSpawn={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("No open issues.")).toBeInTheDocument();
+    });
+  });
+
+  it("invokes onSpawn with the clicked issue", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse([FIXTURE[0]]));
+    const onSpawn = vi.fn().mockResolvedValue(undefined);
+    render(<IssuesPanel baseUrl={BASE} projectId={null} onSpawn={onSpawn} />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Add dark mode")).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /Spawn/ }));
+    expect(onSpawn).toHaveBeenCalledTimes(1);
+    expect(onSpawn.mock.calls[0][0]).toEqual(FIXTURE[0]);
+  });
+
+  it("disables Spawn and shows the reason when spawnDisabledReason is set", async () => {
+    fetchMock.mockResolvedValueOnce(okResponse([FIXTURE[0]]));
+    render(
+      <IssuesPanel
+        baseUrl={BASE}
+        projectId={null}
+        onSpawn={vi.fn()}
+        spawnDisabledReason="Open a session in this project first"
+      />,
+    );
+
+    await waitFor(() => {
+      expect(screen.getByText("Add dark mode")).toBeInTheDocument();
+    });
+    const btn = screen.getByRole("button", { name: /Spawn/ });
+    expect(btn).toBeDisabled();
+    expect(screen.getByText("Open a session in this project first")).toBeInTheDocument();
+  });
+
+  it("renders a retry banner and refetches when fetch fails", async () => {
+    fetchMock.mockRejectedValueOnce(new Error("boom"));
+    render(<IssuesPanel baseUrl={BASE} projectId={null} onSpawn={vi.fn()} />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("alert")).toHaveTextContent(/Failed to load issues: boom/);
+    });
+
+    fetchMock.mockResolvedValueOnce(okResponse(FIXTURE));
+    fireEvent.click(screen.getByRole("button", { name: "Retry" }));
+    await waitFor(() => {
+      expect(screen.getByText("Add dark mode")).toBeInTheDocument();
+    });
+  });
+});

--- a/crates/ao-desktop/ui/src/components/IssuesPanel.tsx
+++ b/crates/ao-desktop/ui/src/components/IssuesPanel.tsx
@@ -1,0 +1,201 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+import { type BacklogIssue, listIssues } from "../api/client";
+
+const POLL_INTERVAL_MS = 60_000;
+
+type FetchState =
+  | { kind: "idle" }
+  | { kind: "loading" }
+  | { kind: "ready"; issues: BacklogIssue[] }
+  | { kind: "error"; message: string };
+
+export function IssuesPanel({
+  baseUrl,
+  projectId,
+  onSpawn,
+  spawnDisabledReason,
+}: {
+  baseUrl: string;
+  projectId: string | null;
+  /** Called when the user clicks Spawn on an issue. The parent owns the
+   *  actual `spawnSession` call (it's the one that knows `repo_path`). */
+  onSpawn: (issue: BacklogIssue) => Promise<void> | void;
+  /** If provided, the Spawn button is disabled and this message is shown
+   *  as a hint (e.g. "open a session in this project first"). */
+  spawnDisabledReason?: string | null;
+}) {
+  const [state, setState] = useState<FetchState>({ kind: "idle" });
+  const [pending, setPending] = useState<number | null>(null);
+  /** Ref instead of state so we don't re-trigger the effect on each tick. */
+  const timerRef = useRef<number | null>(null);
+
+  const refresh = useCallback(async () => {
+    setState((prev) => (prev.kind === "ready" ? prev : { kind: "loading" }));
+    try {
+      const issues = await listIssues(baseUrl, { projectId });
+      setState({ kind: "ready", issues });
+    } catch (e) {
+      const message = e instanceof Error ? e.message : String(e);
+      setState({ kind: "error", message });
+    }
+  }, [baseUrl, projectId]);
+
+  useEffect(() => {
+    let cancelled = false;
+
+    void (async () => {
+      if (cancelled) return;
+      await refresh();
+    })();
+
+    timerRef.current = window.setInterval(() => {
+      void refresh();
+    }, POLL_INTERVAL_MS);
+
+    return () => {
+      cancelled = true;
+      if (timerRef.current !== null) {
+        window.clearInterval(timerRef.current);
+        timerRef.current = null;
+      }
+    };
+  }, [refresh]);
+
+  const handleSpawn = async (issue: BacklogIssue) => {
+    setPending(issue.number);
+    try {
+      await onSpawn(issue);
+    } finally {
+      setPending((prev) => (prev === issue.number ? null : prev));
+    }
+  };
+
+  return (
+    <section className="panel" aria-label="Issues backlog">
+      <div
+        className="panel__title"
+        style={{ display: "flex", alignItems: "center", justifyContent: "space-between", gap: 10 }}
+      >
+        <span>Backlog{projectId ? ` — ${projectId}` : ""}</span>
+        <button
+          type="button"
+          className="hint"
+          onClick={() => void refresh()}
+          aria-label="Refresh issues"
+          title="Refresh"
+        >
+          Refresh
+        </button>
+      </div>
+
+      {state.kind === "loading" ? (
+        <div className="hint" style={{ padding: 12 }}>
+          Loading issues…
+        </div>
+      ) : null}
+
+      {state.kind === "error" ? (
+        <div className="error-banner" role="alert" style={{ margin: 8 }}>
+          <span>Failed to load issues: {state.message}</span>
+          <button type="button" onClick={() => void refresh()}>
+            Retry
+          </button>
+        </div>
+      ) : null}
+
+      {state.kind === "ready" && state.issues.length === 0 ? (
+        <div className="hint" style={{ padding: 16 }}>
+          No open issues.
+        </div>
+      ) : null}
+
+      {state.kind === "ready" && state.issues.length > 0 ? (
+        <ul
+          style={{
+            listStyle: "none",
+            margin: 0,
+            padding: 0,
+            display: "grid",
+            gap: 0,
+          }}
+        >
+          {state.issues.map((issue) => (
+            <li
+              key={`${issue.project_id}#${issue.number}`}
+              style={{
+                display: "grid",
+                gridTemplateColumns: "1fr auto",
+                alignItems: "center",
+                gap: 10,
+                padding: "10px 12px",
+                borderTop: "1px solid var(--border-subtle)",
+              }}
+            >
+              <div style={{ display: "grid", gap: 4, minWidth: 0 }}>
+                <div style={{ display: "flex", alignItems: "center", gap: 8, flexWrap: "wrap" }}>
+                  <span className="mini-pill" title={`Project: ${issue.project_id}`}>
+                    {issue.project_id}
+                  </span>
+                  <span className="mini-pill" title={`Repo: ${issue.repo}`}>
+                    {issue.repo}
+                  </span>
+                  <a
+                    href={issue.url}
+                    target="_blank"
+                    rel="noreferrer"
+                    className="hint mono"
+                    style={{ fontSize: 11 }}
+                    title={issue.url}
+                  >
+                    #{issue.number}
+                  </a>
+                </div>
+                <div
+                  style={{
+                    fontWeight: 600,
+                    overflow: "hidden",
+                    textOverflow: "ellipsis",
+                    whiteSpace: "nowrap",
+                  }}
+                  title={issue.title}
+                >
+                  {issue.title}
+                </div>
+                {issue.labels.length > 0 ? (
+                  <div style={{ display: "flex", gap: 6, flexWrap: "wrap" }}>
+                    {issue.labels.map((label) => (
+                      <span
+                        key={label}
+                        className="mini-pill"
+                        style={{ fontSize: 10 }}
+                        title={`Label: ${label}`}
+                      >
+                        {label}
+                      </span>
+                    ))}
+                  </div>
+                ) : null}
+              </div>
+              <div style={{ display: "grid", gap: 4, justifyItems: "end" }}>
+                <button
+                  type="button"
+                  className="primary"
+                  disabled={pending === issue.number || Boolean(spawnDisabledReason)}
+                  onClick={() => void handleSpawn(issue)}
+                  title={spawnDisabledReason ?? "Spawn a session on this issue"}
+                >
+                  {pending === issue.number ? "Spawning…" : "Spawn"}
+                </button>
+                {spawnDisabledReason ? (
+                  <span className="hint" style={{ fontSize: 10, maxWidth: 180, textAlign: "right" }}>
+                    {spawnDisabledReason}
+                  </span>
+                ) : null}
+              </div>
+            </li>
+          ))}
+        </ul>
+      ) : null}
+    </section>
+  );
+}

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -2,11 +2,14 @@ import { type Dispatch, lazy, type SetStateAction, Suspense, useCallback, useEff
 import {
   type ApiEvent,
   type ApiSession,
+  type BacklogIssue,
   killSession,
   restoreSession,
   sendMessage,
+  spawnSession,
 } from "../api/client";
 import { Board } from "../components/Board";
+import { IssuesPanel } from "../components/IssuesPanel";
 import { ProjectSidebar } from "../components/ProjectSidebar";
 import { SessionDetail } from "../components/SessionDetail";
 import { useSessions } from "../hooks/useSessions";
@@ -74,7 +77,7 @@ export function App() {
   const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);
   const [detailOnly, setDetailOnly] = useState(false);
-  const [activeTab, setActiveTab] = useState<"dashboard" | { sessionId: string }>("dashboard");
+  const [activeTab, setActiveTab] = useState<"dashboard" | "backlog" | { sessionId: string }>("dashboard");
   const [sessionTabs, setSessionTabs] = useState<string[]>([]);
   const [theme, setTheme] = useState<"light" | "dark">(() => {
     const saved = window.localStorage.getItem("ao-ui-theme");
@@ -190,7 +193,7 @@ export function App() {
   }, [dashboardSessions, selectedSessionId]);
 
   const activeSessionId = useMemo(() => {
-    if (activeTab === "dashboard") return selectedSessionId;
+    if (activeTab === "dashboard" || activeTab === "backlog") return selectedSessionId;
     return activeTab.sessionId;
   }, [activeTab, selectedSessionId]);
 
@@ -200,7 +203,7 @@ export function App() {
   }, [dashboardSessions, activeSessionId]);
 
   useEffect(() => {
-    if (activeTab === "dashboard" || !activeSession) {
+    if (activeTab === "dashboard" || activeTab === "backlog" || !activeSession) {
       document.title = "Ao Dashboard";
       return;
     }
@@ -216,7 +219,7 @@ export function App() {
   const closeSessionTab = (id: string) => {
     setSessionTabs((prev) => prev.filter((t) => t !== id));
     setActiveTab((prev) => {
-      if (prev !== "dashboard" && prev.sessionId === id) return "dashboard";
+      if (prev !== "dashboard" && prev !== "backlog" && prev.sessionId === id) return "dashboard";
       return prev;
     });
   };
@@ -247,10 +250,30 @@ export function App() {
     setSessionTabs((prev) => prev.filter((sid) => sessionById.has(sid)));
     setSelectedSessionId((prev) => (prev && sessionById.has(prev) ? prev : null));
     setActiveTab((prev) => {
-      if (prev === "dashboard") return prev;
+      if (prev === "dashboard" || prev === "backlog") return prev;
       return sessionById.has(prev.sessionId) ? prev : "dashboard";
     });
   }, [sessionById]);
+
+  const spawnFromIssue = useCallback(
+    async (issue: BacklogIssue) => {
+      const created = await spawnSession(baseUrl, {
+        project_id: issue.project_id,
+        task: issue.title,
+        issue_id: String(issue.number),
+        issue_url: issue.url,
+      });
+      setSessions((prev) => {
+        const existing = prev.findIndex((s) => s.id === created.id);
+        if (existing === -1) return [created, ...prev];
+        const copy = prev.slice();
+        copy[existing] = created;
+        return copy;
+      });
+      await refreshSessionsWithPr();
+    },
+    [baseUrl, refreshSessionsWithPr, setSessions],
+  );
 
   return (
     <div className="app">
@@ -379,6 +402,9 @@ export function App() {
                 <button type="button" className={activeTab === "dashboard" ? "mini-pill" : "hint"} onClick={() => setActiveTab("dashboard")}>
                   Dashboard
                 </button>
+                <button type="button" className={activeTab === "backlog" ? "mini-pill" : "hint"} onClick={() => setActiveTab("backlog")}>
+                  Backlog
+                </button>
                 {sessionTabs.map((sid) => (
                   <span key={sid} style={{ display: "inline-flex", gap: 6, alignItems: "center" }}>
                     {(() => {
@@ -394,7 +420,7 @@ export function App() {
                     })()}
                     <button
                       type="button"
-                      className={activeTab !== "dashboard" && activeTab.sessionId === sid ? "mini-pill" : "hint"}
+                      className={activeTab !== "dashboard" && activeTab !== "backlog" && activeTab.sessionId === sid ? "mini-pill" : "hint"}
                       onClick={() => {
                         setActiveTab({ sessionId: sid });
                         setSelectedSessionId(sid);
@@ -496,6 +522,13 @@ export function App() {
                   )}
                 </section>
               </>
+            ) : activeTab === "backlog" ? (
+              <section className="panel">
+                <div className="panel__title">Backlog</div>
+                <div style={{ padding: 10 }}>
+                  <IssuesPanel baseUrl={baseUrl} projectId={selectedProjectId} onSpawn={spawnFromIssue} />
+                </div>
+              </section>
             ) : (
               <>
                 <section className="panel">


### PR DESCRIPTION
## Summary
- New **Backlog** tab in the desktop dashboard listing all open GitHub issues across configured repos, with a **Spawn** button per issue that starts an agent session pre-linked to the issue.
- `GET /api/issues` in `ao-dashboard` loads `AoConfig` per-request and fans out across projects with a GitHub tracker — respects `ao_core::rate_limit` cooldown, accepts `?project_id=`/`?state=`/`?labels=`/`?limit=` filters, and skips bad repo slugs without 500ing the response.
- `POST /api/sessions/spawn` now accepts optional `repo_path` (falls back to `config.projects[project_id].path`) plus `issue_id`/`issue_url`, so the UI can spawn from an issue with only a `project_id` + the issue payload.

Closes #163.

## Test plan
- [x] `cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo t` — 820 tests pass (includes 4 new `ao-dashboard` route tests and 4 new lib tests covering `/api/issues` + spawn body)
- [x] `cargo test --doc`
- [x] `pnpm --filter ao-desktop-ui test` — 30 tests pass (6 new `IssuesPanel` tests)
- [x] `pnpm --filter ao-desktop-ui typecheck`
- [x] `pnpm --filter ao-desktop-ui build`
- [ ] Manual: run `ao dashboard`, open the UI, click **Backlog**, verify rows render and clicking **Spawn** creates a session tagged with `issue_id`/`issue_url`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)