### PR TITLE
feat(ui): refactor sidebar hierarchy to Orchestrator → Projects → Issues (#204)

### DIFF
--- a/crates/ao-desktop/ui/src/api/client.ts
+++ b/crates/ao-desktop/ui/src/api/client.ts
@@ -1,3 +1,5 @@
+import type { DashboardOrchestrator } from "../lib/types";
+
 export type ConnectionStatus =
   | { kind: "disconnected" }
   | { kind: "connecting" }
@@ -18,6 +20,8 @@ export type ApiSession = {
   workspace_path?: string | null;
   issue_id?: string | null;
   issue_url?: string | null;
+  /** Set when this session was spawned by an orchestrator. Maps to `Session.spawned_by`. */
+  spawned_by?: string | null;
   // Optional enrichment when calling `/api/sessions?pr=true`
   attention_level?: string;
   pr?: ApiPr | null;
@@ -159,6 +163,23 @@ export async function spawnSession(baseUrl: string, req: SpawnSessionRequest): P
     headers: { "content-type": "application/json" },
     body: JSON.stringify(req),
   });
+}
+
+/**
+ * Fetch all orchestrator sessions from `GET /api/orchestrators`.
+ * The backend returns raw `Session` JSON; we map each to `DashboardOrchestrator`.
+ * `managedProjectIds` is derived as `[project_id]` today — the list shape
+ * ensures the UI requires no changes when the backend starts returning multiple.
+ */
+export async function listOrchestrators(baseUrl: string): Promise<DashboardOrchestrator[]> {
+  const raw = await httpJson<ApiSession[]>(joinUrl(baseUrl, "/api/orchestrators"));
+  return raw.map((s) => ({
+    id: s.id,
+    status: s.status,
+    managedProjectIds: [s.project_id],
+    primaryProjectId: s.project_id,
+    createdAt: s.created_at ?? null,
+  }));
 }
 
 export function connectEvents(

--- a/crates/ao-desktop/ui/src/components/ProjectSidebar.tsx
+++ b/crates/ao-desktop/ui/src/components/ProjectSidebar.tsx
@@ -1,6 +1,7 @@
-import { useState } from "react";
-import type { DashboardSession } from "../lib/types";
+import { useMemo, useState } from "react";
+import type { DashboardOrchestrator, DashboardSession } from "../lib/types";
 import { getDashboardLane, isTerminalSession } from "../lib/types";
+import { deriveManagedProjectIds, groupWorkersByOrchestrator } from "../lib/orchestrator";
 import { getSessionTitle } from "../lib/format";
 import { cn } from "../lib/cn";
 import { SessionCard } from "./SessionCard";
@@ -16,7 +17,44 @@ function projectLabel(id: string): string {
   return id;
 }
 
-export function ProjectSidebar({
+// ─── shared sub-components ────────────────────────────────────────────────────
+
+function SectionToggle({
+  label,
+  collapsed,
+  onToggle,
+}: {
+  label: string;
+  collapsed: boolean;
+  onToggle: () => void;
+}) {
+  return (
+    <button
+      type="button"
+      className="panel__title section-toggle"
+      onClick={onToggle}
+      aria-expanded={!collapsed}
+      style={{
+        width: "100%",
+        display: "flex",
+        justifyContent: "space-between",
+        alignItems: "center",
+        border: "none",
+        borderRadius: 0,
+        cursor: "pointer",
+      }}
+    >
+      <span>{label}</span>
+      <span className="section-toggle__caret" data-collapsed={String(collapsed)} aria-hidden="true">
+        ▾
+      </span>
+    </button>
+  );
+}
+
+// ─── project-first (fallback) tree ────────────────────────────────────────────
+
+function ProjectFirstTree({
   sessions,
   activeProjectId,
   activeSessionId,
@@ -27,12 +65,10 @@ export function ProjectSidebar({
   sessions: DashboardSession[];
   activeProjectId: string | null;
   activeSessionId: string | null;
-  onSelectProject: (projectId: string | null) => void;
-  onSelectSession: (sessionId: string) => void;
-  onOpenSession?: (session: DashboardSession) => void;
+  onSelectProject: (pid: string | null, orchId?: string) => void;
+  onSelectSession: (sid: string) => void;
+  onOpenSession?: (s: DashboardSession) => void;
 }) {
-  const [projectsCollapsed, setProjectsCollapsed] = useState(false);
-  /** Default collapsed so the main board stays primary; user can expand. */
   const [sessionsCollapsed, setSessionsCollapsed] = useState(true);
 
   const byProject = new Map<string, DashboardSession[]>();
@@ -43,15 +79,12 @@ export function ProjectSidebar({
   }
 
   const projects: ProjectInfo[] = Array.from(byProject.entries())
-    .map(([id, list]) => {
-      const activeCount = list.filter((s) => !isTerminalSession(s)).length;
-      return {
-        id,
-        name: projectLabel(id),
-        sessionCount: list.length,
-        activeCount,
-      };
-    })
+    .map(([id, list]) => ({
+      id,
+      name: projectLabel(id),
+      sessionCount: list.length,
+      activeCount: list.filter((s) => !isTerminalSession(s)).length,
+    }))
     .sort((a, b) => b.activeCount - a.activeCount || a.name.localeCompare(b.name));
 
   const visibleSessions =
@@ -60,19 +93,386 @@ export function ProjectSidebar({
       : sessions.filter((s) => s.projectId === activeProjectId);
 
   const visibleSorted = [...visibleSessions].sort((a, b) => {
-    const la = getDashboardLane(a);
-    const lb = getDashboardLane(b);
-    const order: Record<string, number> = {
-      merge: 0,
-      review: 1,
-      pending: 2,
-      working: 3,
-    };
-    return (order[la] ?? 99) - (order[lb] ?? 99);
+    const order: Record<string, number> = { merge: 0, review: 1, pending: 2, working: 3 };
+    return (order[getDashboardLane(a)] ?? 99) - (order[getDashboardLane(b)] ?? 99);
   });
 
-  /** Dense one-line rows when many sessions — easier to scan than full cards. */
   const summarySessionList = visibleSorted.length >= 10;
+
+  return (
+    <>
+      <div className="sessions" style={{ paddingTop: 8 }}>
+        <button
+          type="button"
+          className={cn("project-pill", activeProjectId === null && "project-pill--active")}
+          data-selected={String(activeProjectId === null)}
+          onClick={() => onSelectProject(null)}
+        >
+          <span className="project-pill__name">All</span>
+          <span className="project-pill__count">{sessions.length}</span>
+        </button>
+        {projects.map((p) => (
+          <button
+            key={p.id}
+            type="button"
+            className={cn("project-pill", activeProjectId === p.id && "project-pill--active")}
+            data-selected={String(activeProjectId === p.id)}
+            onClick={() => onSelectProject(p.id)}
+          >
+            <span className="project-pill__name">{p.name}</span>
+            <span className="project-pill__count">
+              {p.activeCount}/{p.sessionCount}
+            </span>
+          </button>
+        ))}
+      </div>
+
+      <SectionToggle
+        label={summarySessionList ? "Sessions (summary)" : "Sessions"}
+        collapsed={sessionsCollapsed}
+        onToggle={() => setSessionsCollapsed((v) => !v)}
+      />
+      <div
+        className={cn("sessions", summarySessionList && "sessions--summary")}
+        hidden={sessionsCollapsed}
+        style={{ overflow: "auto", flex: "1 1 auto", minHeight: 0 }}
+      >
+        {visibleSorted.map((s) => {
+          const level = getDashboardLane(s);
+          const selected = activeSessionId === s.id;
+          if (summarySessionList) {
+            const title = getSessionTitle(s);
+            return (
+              <div key={s.id} className="session-summary-row" data-level={level} data-selected={String(selected)}>
+                <button
+                  type="button"
+                  className="session-summary-row__main"
+                  onClick={() => onSelectSession(s.id)}
+                  title={title}
+                >
+                  <span className="session-summary-row__strip" aria-hidden="true" />
+                  <span className="session-summary-row__project">{s.projectId}</span>
+                  <span className="session-summary-row__title">{title}</span>
+                  <span className="session-summary-row__meta">
+                    {s.status} / {s.activity ?? "-"}
+                  </span>
+                </button>
+                {onOpenSession ? (
+                  <button
+                    type="button"
+                    className="mini-pill mini-pill--terminal session-summary-row__term"
+                    title="Open session terminal"
+                    onClick={(e) => { e.stopPropagation(); onOpenSession(s); }}
+                  >
+                    term
+                  </button>
+                ) : null}
+              </div>
+            );
+          }
+          return (
+            <div key={s.id} data-level={level} data-selected={String(selected)}>
+              <SessionCard session={s} onClick={() => onSelectSession(s.id)} onOpen={onOpenSession} />
+            </div>
+          );
+        })}
+      </div>
+    </>
+  );
+}
+
+// ─── orchestrator-first tree ──────────────────────────────────────────────────
+
+function OrchestratorTree({
+  sessions,
+  orchestrators,
+  activeOrchestratorId,
+  activeProjectId,
+  activeSessionId,
+  onSelectOrchestrator,
+  onSelectProject,
+  onSelectSession,
+  onOpenSession,
+}: {
+  sessions: DashboardSession[];
+  orchestrators: DashboardOrchestrator[];
+  activeOrchestratorId: string | null;
+  activeProjectId: string | null;
+  activeSessionId: string | null;
+  onSelectOrchestrator: (id: string | null) => void;
+  onSelectProject: (pid: string | null, orchId?: string) => void;
+  onSelectSession: (sid: string) => void;
+  onOpenSession?: (s: DashboardSession) => void;
+}) {
+  const [expandedOrchestrators, setExpandedOrchestrators] = useState<Set<string>>(
+    () => new Set(activeOrchestratorId ? [activeOrchestratorId] : []),
+  );
+  const [expandedOrchestratorProjects, setExpandedOrchestratorProjects] = useState<Set<string>>(
+    () =>
+      activeOrchestratorId && activeProjectId
+        ? new Set([`${activeOrchestratorId}:${activeProjectId}`])
+        : new Set(),
+  );
+  const [unaffiliatedCollapsed, setUnaffiliatedCollapsed] = useState(true);
+  const [expandedUnaffiliatedProjects, setExpandedUnaffiliatedProjects] = useState<Set<string>>(
+    new Set(),
+  );
+
+  const { byOrchestrator, unaffiliated } = useMemo(
+    () => groupWorkersByOrchestrator(sessions, orchestrators),
+    [sessions, orchestrators],
+  );
+
+  const toggleOrchestrator = (id: string) => {
+    setExpandedOrchestrators((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  const toggleOrchestratorProject = (key: string) => {
+    setExpandedOrchestratorProjects((prev) => {
+      const next = new Set(prev);
+      next.has(key) ? next.delete(key) : next.add(key);
+      return next;
+    });
+  };
+
+  const toggleUnaffiliatedProject = (id: string) => {
+    setExpandedUnaffiliatedProjects((prev) => {
+      const next = new Set(prev);
+      next.has(id) ? next.delete(id) : next.add(id);
+      return next;
+    });
+  };
+
+  // Build unaffiliated project groups
+  const unaffiliatedByProject = useMemo(() => {
+    const map = new Map<string, DashboardSession[]>();
+    for (const s of unaffiliated) {
+      const list = map.get(s.projectId) ?? [];
+      list.push(s);
+      map.set(s.projectId, list);
+    }
+    return map;
+  }, [unaffiliated]);
+
+  return (
+    <div style={{ overflow: "auto", flex: "1 1 auto", minHeight: 0 }}>
+      {/* Orchestrators */}
+      {orchestrators.map((orch) => {
+        const workers = byOrchestrator.get(orch.id) ?? [];
+        const managedProjectIds = deriveManagedProjectIds(orch, workers);
+        const isExpanded = expandedOrchestrators.has(orch.id);
+        const isActive = activeOrchestratorId === orch.id && activeProjectId === null;
+        const activeWorkerCount = workers.filter((s) => !isTerminalSession(s)).length;
+
+        return (
+          <div key={orch.id}>
+            {/* Orchestrator row */}
+            <button
+              type="button"
+              className={cn("project-pill", isActive && "project-pill--active")}
+              data-selected={String(isActive)}
+              style={{ width: "100%", textAlign: "left", display: "flex", alignItems: "center", gap: 6 }}
+              onClick={() => {
+                toggleOrchestrator(orch.id);
+                onSelectOrchestrator(orch.id);
+              }}
+              aria-expanded={isExpanded}
+            >
+              <span style={{ fontSize: 10, opacity: 0.6 }}>{isExpanded ? "▾" : "▸"}</span>
+              <span className="project-pill__name" style={{ fontFamily: "ui-monospace, monospace", fontSize: 12 }}>
+                {orch.id}
+              </span>
+              <span className="project-pill__count">{activeWorkerCount}/{workers.length}</span>
+            </button>
+
+            {/* Project sub-nodes under orchestrator */}
+            {isExpanded && managedProjectIds.map((projId) => {
+              const projWorkers = workers.filter((s) => s.projectId === projId);
+              const projKey = `${orch.id}:${projId}`;
+              const isProjExpanded = expandedOrchestratorProjects.has(projKey);
+              const isProjActive = activeOrchestratorId === orch.id && activeProjectId === projId;
+              const activeProjWorkers = projWorkers.filter((s) => !isTerminalSession(s)).length;
+
+              return (
+                <div key={projKey} style={{ paddingLeft: 16 }}>
+                  <button
+                    type="button"
+                    className={cn("project-pill", isProjActive && "project-pill--active")}
+                    data-selected={String(isProjActive)}
+                    style={{ width: "100%", textAlign: "left", display: "flex", alignItems: "center", gap: 6 }}
+                    onClick={() => {
+                      toggleOrchestratorProject(projKey);
+                      onSelectProject(projId, orch.id);
+                    }}
+                    aria-expanded={isProjExpanded}
+                  >
+                    <span style={{ fontSize: 10, opacity: 0.6 }}>{isProjExpanded ? "▾" : "▸"}</span>
+                    <span className="project-pill__name">{projectLabel(projId)}</span>
+                    <span className="project-pill__count">{activeProjWorkers}/{projWorkers.length}</span>
+                  </button>
+
+                  {/* Worker sessions under project */}
+                  {isProjExpanded && (
+                    <div style={{ paddingLeft: 12 }}>
+                      {projWorkers.length === 0 ? (
+                        <div className="hint" style={{ padding: "4px 8px", fontSize: 11 }}>
+                          No sessions
+                        </div>
+                      ) : (
+                        projWorkers.map((s) => {
+                          const level = getDashboardLane(s);
+                          const isSessionActive = activeSessionId === s.id;
+                          return (
+                            <div
+                              key={s.id}
+                              className="session-summary-row"
+                              data-level={level}
+                              data-selected={String(isSessionActive)}
+                            >
+                              <button
+                                type="button"
+                                className="session-summary-row__main"
+                                onClick={() => onSelectSession(s.id)}
+                                title={getSessionTitle(s)}
+                              >
+                                <span className="session-summary-row__strip" aria-hidden="true" />
+                                <span className="session-summary-row__title">{getSessionTitle(s)}</span>
+                                <span className="session-summary-row__meta">{s.status}</span>
+                              </button>
+                              {onOpenSession ? (
+                                <button
+                                  type="button"
+                                  className="mini-pill mini-pill--terminal session-summary-row__term"
+                                  title="Open session terminal"
+                                  onClick={(e) => { e.stopPropagation(); onOpenSession(s); }}
+                                >
+                                  term
+                                </button>
+                              ) : null}
+                            </div>
+                          );
+                        })
+                      )}
+                    </div>
+                  )}
+                </div>
+              );
+            })}
+          </div>
+        );
+      })}
+
+      {/* Unaffiliated sessions */}
+      {unaffiliated.length > 0 && (
+        <div style={{ borderTop: "1px solid var(--border, rgba(0,0,0,0.1))", marginTop: 8 }}>
+          <SectionToggle
+            label={`Unaffiliated (${unaffiliated.length})`}
+            collapsed={unaffiliatedCollapsed}
+            onToggle={() => setUnaffiliatedCollapsed((v) => !v)}
+          />
+          {!unaffiliatedCollapsed && (
+            <div style={{ paddingLeft: 0 }}>
+              {Array.from(unaffiliatedByProject.entries()).map(([projId, projSessions]) => {
+                const isExpanded = expandedUnaffiliatedProjects.has(projId);
+                const isActive = activeOrchestratorId === null && activeProjectId === projId;
+                const activeCount = projSessions.filter((s) => !isTerminalSession(s)).length;
+
+                return (
+                  <div key={projId}>
+                    <button
+                      type="button"
+                      className={cn("project-pill", isActive && "project-pill--active")}
+                      data-selected={String(isActive)}
+                      style={{ width: "100%", textAlign: "left", display: "flex", alignItems: "center", gap: 6 }}
+                      onClick={() => {
+                        toggleUnaffiliatedProject(projId);
+                        onSelectProject(projId, undefined);
+                      }}
+                      aria-expanded={isExpanded}
+                    >
+                      <span style={{ fontSize: 10, opacity: 0.6 }}>{isExpanded ? "▾" : "▸"}</span>
+                      <span className="project-pill__name">{projectLabel(projId)}</span>
+                      <span className="project-pill__count">{activeCount}/{projSessions.length}</span>
+                    </button>
+
+                    {isExpanded && (
+                      <div style={{ paddingLeft: 16 }}>
+                        {projSessions.map((s) => {
+                          const level = getDashboardLane(s);
+                          const isSessionActive = activeSessionId === s.id;
+                          return (
+                            <div
+                              key={s.id}
+                              className="session-summary-row"
+                              data-level={level}
+                              data-selected={String(isSessionActive)}
+                            >
+                              <button
+                                type="button"
+                                className="session-summary-row__main"
+                                onClick={() => onSelectSession(s.id)}
+                                title={getSessionTitle(s)}
+                              >
+                                <span className="session-summary-row__strip" aria-hidden="true" />
+                                <span className="session-summary-row__title">{getSessionTitle(s)}</span>
+                                <span className="session-summary-row__meta">{s.status}</span>
+                              </button>
+                              {onOpenSession ? (
+                                <button
+                                  type="button"
+                                  className="mini-pill mini-pill--terminal session-summary-row__term"
+                                  title="Open session terminal"
+                                  onClick={(e) => { e.stopPropagation(); onOpenSession(s); }}
+                                >
+                                  term
+                                </button>
+                              ) : null}
+                            </div>
+                          );
+                        })}
+                      </div>
+                    )}
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── public component ─────────────────────────────────────────────────────────
+
+export function ProjectSidebar({
+  sessions,
+  orchestrators,
+  activeProjectId,
+  activeSessionId,
+  activeOrchestratorId,
+  onSelectOrchestrator,
+  onSelectProject,
+  onSelectSession,
+  onOpenSession,
+}: {
+  sessions: DashboardSession[];
+  orchestrators: DashboardOrchestrator[];
+  activeProjectId: string | null;
+  activeSessionId: string | null;
+  activeOrchestratorId: string | null;
+  onSelectOrchestrator: (id: string | null) => void;
+  onSelectProject: (pid: string | null, orchId?: string) => void;
+  onSelectSession: (sid: string) => void;
+  onOpenSession?: (session: DashboardSession) => void;
+}) {
+  const [projectsCollapsed, setProjectsCollapsed] = useState(false);
+
+  const useOrchestratorView = orchestrators.length > 0;
 
   return (
     <aside
@@ -85,122 +485,36 @@ export function ProjectSidebar({
         minHeight: 0,
       }}
     >
-      <button
-        type="button"
-        className="panel__title section-toggle"
-        onClick={() => setProjectsCollapsed((v) => !v)}
-        aria-expanded={!projectsCollapsed}
-        title={projectsCollapsed ? "Expand Projects" : "Collapse Projects"}
-        style={{ width: "100%", display: "flex", justifyContent: "space-between", alignItems: "center", border: "none", borderRadius: 0, cursor: "pointer" }}
-      >
-        <span>Projects</span>
-        <span className="section-toggle__caret" data-collapsed={String(projectsCollapsed)} aria-hidden="true">
-          ▾
-        </span>
-      </button>
-      <div className="sessions" style={{ paddingTop: 8 }} hidden={projectsCollapsed}>
-          <button
-            type="button"
-            className={cn("project-pill", activeProjectId === null && "project-pill--active")}
-            data-selected={String(activeProjectId === null)}
-            onClick={() => onSelectProject(null)}
-          >
-            <span className="project-pill__name">All</span>
-            <span className="project-pill__count">{sessions.length}</span>
-          </button>
-          {projects.map((p) => (
-            <button
-              key={p.id}
-              type="button"
-              className={cn("project-pill", activeProjectId === p.id && "project-pill--active")}
-              data-selected={String(activeProjectId === p.id)}
-              onClick={() => onSelectProject(p.id)}
-            >
-              <span className="project-pill__name">{p.name}</span>
-              <span className="project-pill__count">
-                {p.activeCount}/{p.sessionCount}
-              </span>
-            </button>
-          ))}
-      </div>
+      <SectionToggle
+        label={useOrchestratorView ? "Orchestrators" : "Projects"}
+        collapsed={projectsCollapsed}
+        onToggle={() => setProjectsCollapsed((v) => !v)}
+      />
 
-      <button
-        type="button"
-        className="panel__title section-toggle"
-        onClick={() => setSessionsCollapsed((v) => !v)}
-        aria-expanded={!sessionsCollapsed}
-        title={sessionsCollapsed ? "Expand Sessions" : "Collapse Sessions"}
-        style={{ width: "100%", display: "flex", justifyContent: "space-between", alignItems: "center", border: "none", borderRadius: 0, cursor: "pointer" }}
-      >
-        <span>
-          Sessions
-          {summarySessionList ? (
-            <span className="hint" style={{ marginLeft: 8, fontWeight: 500, fontSize: 11 }}>
-              (summary)
-            </span>
-          ) : null}
-        </span>
-        <span className="section-toggle__caret" data-collapsed={String(sessionsCollapsed)} aria-hidden="true">
-          ▾
-        </span>
-      </button>
-      <div
-        className={cn("sessions", summarySessionList && "sessions--summary")}
-        hidden={sessionsCollapsed}
-        style={{
-          overflow: "auto",
-          flex: "1 1 auto",
-          minHeight: 0,
-        }}
-      >
-          {visibleSorted.map((s) => {
-            const level = getDashboardLane(s);
-            const selected = activeSessionId === s.id;
-            if (summarySessionList) {
-              const title = getSessionTitle(s);
-              return (
-                <div key={s.id} className="session-summary-row" data-level={level} data-selected={String(selected)}>
-                  <button
-                    type="button"
-                    className="session-summary-row__main"
-                    onClick={() => onSelectSession(s.id)}
-                    title={title}
-                  >
-                    <span className="session-summary-row__strip" aria-hidden="true" />
-                    <span className="session-summary-row__project">{s.projectId}</span>
-                    <span className="session-summary-row__title">{title}</span>
-                    <span className="session-summary-row__meta">
-                      {s.status} / {s.activity ?? "-"}
-                    </span>
-                  </button>
-                  {onOpenSession ? (
-                    <button
-                      type="button"
-                      className="mini-pill mini-pill--terminal session-summary-row__term"
-                      title="Open session terminal"
-                      onClick={(e) => {
-                        e.stopPropagation();
-                        onOpenSession(s);
-                      }}
-                    >
-                      term
-                    </button>
-                  ) : null}
-                </div>
-              );
-            }
-            return (
-              <div key={s.id} data-level={level} data-selected={String(selected)}>
-                <SessionCard
-                  session={s}
-                  onClick={() => onSelectSession(s.id)}
-                  onOpen={onOpenSession}
-                />
-              </div>
-            );
-          })}
-      </div>
+      {!projectsCollapsed && (
+        useOrchestratorView ? (
+          <OrchestratorTree
+            sessions={sessions}
+            orchestrators={orchestrators}
+            activeOrchestratorId={activeOrchestratorId}
+            activeProjectId={activeProjectId}
+            activeSessionId={activeSessionId}
+            onSelectOrchestrator={onSelectOrchestrator}
+            onSelectProject={onSelectProject}
+            onSelectSession={onSelectSession}
+            onOpenSession={onOpenSession}
+          />
+        ) : (
+          <ProjectFirstTree
+            sessions={sessions}
+            activeProjectId={activeProjectId}
+            activeSessionId={activeSessionId}
+            onSelectProject={onSelectProject}
+            onSelectSession={onSelectSession}
+            onOpenSession={onOpenSession}
+          />
+        )
+      )}
     </aside>
   );
 }
-

--- a/crates/ao-desktop/ui/src/components/SessionDetail.test.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionDetail.test.tsx
@@ -22,6 +22,7 @@ function makeSession(partial: Partial<DashboardSession> = {}): DashboardSession 
     attentionLevel: "working",
     metadata: {},
     ...partial,
+    spawnedBy: partial.spawnedBy ?? null,
   };
 }
 

--- a/crates/ao-desktop/ui/src/components/projectAccent.ui.test.tsx
+++ b/crates/ao-desktop/ui/src/components/projectAccent.ui.test.tsx
@@ -23,6 +23,7 @@ function makeSession(partial: Partial<DashboardSession>): DashboardSession {
     attentionLevel: "working",
     metadata: {},
     ...partial,
+    spawnedBy: partial.spawnedBy ?? null,
   };
 }
 

--- a/crates/ao-desktop/ui/src/hooks/useSessions.ts
+++ b/crates/ao-desktop/ui/src/hooks/useSessions.ts
@@ -5,7 +5,9 @@ import {
   type ConnectionStatus,
   connectEvents,
   getSessions,
+  listOrchestrators,
 } from "../api/client";
+import type { DashboardOrchestrator } from "../lib/types";
 
 export type UiNotificationPayload = {
   sessionId: string;
@@ -23,6 +25,7 @@ export type UseSessionsOptions = {
 export type UseSessions = {
   sessions: ApiSession[];
   setSessions: Dispatch<SetStateAction<ApiSession[]>>;
+  orchestrators: DashboardOrchestrator[];
   conn: ConnectionStatus;
   refreshSessionsFast: () => Promise<void>;
   refreshSessionsWithPr: () => Promise<void>;
@@ -64,6 +67,7 @@ function isSnapshotEvent(evt: ApiEvent): evt is ApiEvent & { sessions: ApiSessio
 
 export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): UseSessions {
   const [sessions, setSessions] = useState<ApiSession[]>([]);
+  const [orchestrators, setOrchestrators] = useState<DashboardOrchestrator[]>([]);
   const [conn, setConn] = useState<ConnectionStatus>({ kind: "disconnected" });
   const esRef = useRef<EventSource | null>(null);
   const refreshTimerRef = useRef<number | null>(null);
@@ -78,17 +82,26 @@ export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): Use
   onNotificationRef.current = opts.onNotification;
   onEventRef.current = opts.onEvent;
 
+  const refreshOrchestrators = useCallback(async () => {
+    try {
+      const o = await listOrchestrators(baseUrl);
+      setOrchestrators(o);
+    } catch {
+      // Keep stale list on error; conn status reflects SSE errors separately.
+    }
+  }, [baseUrl]);
+
   /** Fast list — no `gh` / PR enrichment (cheap on every SSE tick). */
   const refreshSessionsFast = useCallback(async () => {
-    const s = await getSessions(baseUrl);
+    const [s] = await Promise.all([getSessions(baseUrl), refreshOrchestrators()]);
     setSessions(s);
-  }, [baseUrl]);
+  }, [baseUrl, refreshOrchestrators]);
 
   /** Full list with PR + attention (heavier; use after actions or on a timer). */
   const refreshSessionsWithPr = useCallback(async () => {
-    const s = await getSessions(baseUrl, { pr: true });
+    const [s] = await Promise.all([getSessions(baseUrl, { pr: true }), refreshOrchestrators()]);
     setSessions(s);
-  }, [baseUrl]);
+  }, [baseUrl, refreshOrchestrators]);
 
   const scheduleRefresh = useCallback(() => {
     if (refreshTimerRef.current !== null) return;
@@ -169,7 +182,7 @@ export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): Use
       try {
         // Fast path: list sessions without PR enrichment (no per-session `gh` calls).
         // `?pr=true` is heavier (GitHub/`gh` per session). Load fast first, enrich in background.
-        const fast = await getSessions(baseUrl);
+        const [fast] = await Promise.all([getSessions(baseUrl), refreshOrchestrators()]);
         if (cancelled) return;
         setSessions(fast);
         connectEs();
@@ -199,7 +212,7 @@ export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): Use
       esRef.current?.close();
       esRef.current = null;
     };
-  }, [baseUrl, scheduleRefresh]);
+  }, [baseUrl, scheduleRefresh, refreshOrchestrators]);
 
   const retryConnection = useCallback(async () => {
     sseRetryRef.current = 0;
@@ -211,7 +224,7 @@ export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): Use
     esRef.current = null;
     setConn({ kind: "connecting" });
     try {
-      const fast = await getSessions(baseUrl);
+      const [fast] = await Promise.all([getSessions(baseUrl), refreshOrchestrators()]);
       setSessions(fast);
       wireSseRef.current?.();
       void getSessions(baseUrl, { pr: true })
@@ -221,11 +234,12 @@ export function useSessions(baseUrl: string, opts: UseSessionsOptions = {}): Use
       const msg = e instanceof Error ? e.message : "unknown error";
       setConn({ kind: "error", message: msg });
     }
-  }, [baseUrl]);
+  }, [baseUrl, refreshOrchestrators]);
 
   return {
     sessions,
     setSessions,
+    orchestrators,
     conn,
     refreshSessionsFast,
     refreshSessionsWithPr,

--- a/crates/ao-desktop/ui/src/lib/__tests__/orchestrator.test.ts
+++ b/crates/ao-desktop/ui/src/lib/__tests__/orchestrator.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect } from "vitest";
+import {
+  deriveManagedProjectIds,
+  groupWorkersByOrchestrator,
+  isUnaffiliated,
+} from "../orchestrator";
+import type { DashboardOrchestrator, DashboardSession } from "../types";
+
+// ─── test data builders ───────────────────────────────────────────────────────
+
+function makeOrch(overrides: Partial<DashboardOrchestrator> = {}): DashboardOrchestrator {
+  return {
+    id: "ao-rs-orchestrator-1",
+    status: "working",
+    managedProjectIds: ["ao-rs"],
+    primaryProjectId: "ao-rs",
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+function makeSession(overrides: Partial<DashboardSession> = {}): DashboardSession {
+  return {
+    id: "ao-rs-1",
+    projectId: "ao-rs",
+    status: "working",
+    activity: null,
+    agent: null,
+    branch: null,
+    summary: null,
+    summaryIsFallback: false,
+    issueTitle: null,
+    issueId: null,
+    issueUrl: null,
+    userPrompt: null,
+    pr: null,
+    attentionLevel: null,
+    metadata: {},
+    spawnedBy: null,
+    ...overrides,
+  };
+}
+
+// ─── deriveManagedProjectIds ──────────────────────────────────────────────────
+
+describe("deriveManagedProjectIds", () => {
+  it("returns primaryProjectId when no workers", () => {
+    const orch = makeOrch({ primaryProjectId: "ao-rs" });
+    expect(deriveManagedProjectIds(orch, [])).toEqual(["ao-rs"]);
+  });
+
+  it("includes worker project ids beyond primaryProjectId", () => {
+    const orch = makeOrch({ primaryProjectId: "ao-rs" });
+    const workers = [
+      makeSession({ projectId: "ao-rs" }),
+      makeSession({ id: "golf-1", projectId: "golf-coach" }),
+    ];
+    const result = deriveManagedProjectIds(orch, workers);
+    expect(result).toContain("ao-rs");
+    expect(result).toContain("golf-coach");
+    expect(result).toHaveLength(2);
+  });
+
+  it("deduplicates project ids", () => {
+    const orch = makeOrch({ primaryProjectId: "ao-rs" });
+    const workers = [
+      makeSession({ projectId: "ao-rs" }),
+      makeSession({ id: "ao-rs-2", projectId: "ao-rs" }),
+    ];
+    expect(deriveManagedProjectIds(orch, workers)).toEqual(["ao-rs"]);
+  });
+});
+
+// ─── groupWorkersByOrchestrator ───────────────────────────────────────────────
+
+describe("groupWorkersByOrchestrator", () => {
+  it("excludes orchestrator sessions from all groups", () => {
+    const orch = makeOrch({ id: "ao-rs-orchestrator-1" });
+    const orchSession = makeSession({ id: "ao-rs-orchestrator-1", spawnedBy: null });
+    const { byOrchestrator, unaffiliated } = groupWorkersByOrchestrator([orchSession], [orch]);
+    expect(byOrchestrator.get("ao-rs-orchestrator-1")).toEqual([]);
+    expect(unaffiliated).toEqual([]);
+  });
+
+  it("places worker with spawnedBy into correct orchestrator bucket", () => {
+    const orch = makeOrch({ id: "ao-rs-orchestrator-1" });
+    const worker = makeSession({ id: "ao-rs-194", spawnedBy: "ao-rs-orchestrator-1" });
+    const { byOrchestrator, unaffiliated } = groupWorkersByOrchestrator([worker], [orch]);
+    expect(byOrchestrator.get("ao-rs-orchestrator-1")).toContain(worker);
+    expect(unaffiliated).toEqual([]);
+  });
+
+  it("places session with no spawnedBy into unaffiliated", () => {
+    const orch = makeOrch();
+    const orphan = makeSession({ id: "manual-1", spawnedBy: null });
+    const { byOrchestrator, unaffiliated } = groupWorkersByOrchestrator([orphan], [orch]);
+    expect(byOrchestrator.get(orch.id)).toEqual([]);
+    expect(unaffiliated).toContain(orphan);
+  });
+
+  it("correctly splits workers across two orchestrators", () => {
+    const orch1 = makeOrch({ id: "ao-rs-orchestrator-1" });
+    const orch2 = makeOrch({ id: "ao-rs-orchestrator-2" });
+    const w1 = makeSession({ id: "w1", spawnedBy: "ao-rs-orchestrator-1" });
+    const w2 = makeSession({ id: "w2", spawnedBy: "ao-rs-orchestrator-2" });
+    const { byOrchestrator } = groupWorkersByOrchestrator([w1, w2], [orch1, orch2]);
+    expect(byOrchestrator.get("ao-rs-orchestrator-1")).toContain(w1);
+    expect(byOrchestrator.get("ao-rs-orchestrator-2")).toContain(w2);
+  });
+
+  it("(a) orchestrator with workers in 2 projects builds separate buckets", () => {
+    const orch = makeOrch({ id: "ao-rs-orchestrator-4" });
+    const w1 = makeSession({ id: "ao-rs-194", projectId: "ao-rs", spawnedBy: "ao-rs-orchestrator-4" });
+    const w2 = makeSession({ id: "golf-7", projectId: "golf-coach", spawnedBy: "ao-rs-orchestrator-4" });
+    const { byOrchestrator } = groupWorkersByOrchestrator([w1, w2], [orch]);
+    const workers = byOrchestrator.get("ao-rs-orchestrator-4")!;
+    const projectIds = [...new Set(workers.map((s) => s.projectId))];
+    expect(projectIds).toContain("ao-rs");
+    expect(projectIds).toContain("golf-coach");
+  });
+
+  it("(b) orchestrator with 0 workers still appears in map", () => {
+    const orch = makeOrch({ id: "ao-rs-orchestrator-4" });
+    const { byOrchestrator } = groupWorkersByOrchestrator([], [orch]);
+    expect(byOrchestrator.has("ao-rs-orchestrator-4")).toBe(true);
+    expect(byOrchestrator.get("ao-rs-orchestrator-4")).toEqual([]);
+  });
+
+  it("(c) unaffiliated-only: all sessions go to unaffiliated when no orchestrators", () => {
+    const session = makeSession({ id: "s1", spawnedBy: null });
+    const { byOrchestrator, unaffiliated } = groupWorkersByOrchestrator([session], []);
+    expect(byOrchestrator.size).toBe(0);
+    expect(unaffiliated).toContain(session);
+  });
+
+  it("(d) mixed: orchestrator workers and unaffiliated sessions are correctly split", () => {
+    const orch = makeOrch({ id: "ao-rs-orchestrator-4" });
+    const orchSelf = makeSession({ id: "ao-rs-orchestrator-4", spawnedBy: null });
+    const worker = makeSession({ id: "ao-rs-194", spawnedBy: "ao-rs-orchestrator-4" });
+    const manual = makeSession({ id: "ao-rs-168", spawnedBy: null });
+    const { byOrchestrator, unaffiliated } = groupWorkersByOrchestrator(
+      [orchSelf, worker, manual],
+      [orch],
+    );
+    expect(byOrchestrator.get("ao-rs-orchestrator-4")).toContain(worker);
+    expect(unaffiliated).toContain(manual);
+    expect(unaffiliated).not.toContain(orchSelf);
+    expect(unaffiliated).not.toContain(worker);
+  });
+});
+
+// ─── isUnaffiliated ───────────────────────────────────────────────────────────
+
+describe("isUnaffiliated", () => {
+  it("returns true for session with no spawnedBy and not an orchestrator", () => {
+    const orch = makeOrch();
+    const s = makeSession({ id: "manual", spawnedBy: null });
+    expect(isUnaffiliated(s, [orch])).toBe(true);
+  });
+
+  it("returns false for session that is itself an orchestrator", () => {
+    const orch = makeOrch({ id: "ao-rs-orchestrator-1" });
+    const s = makeSession({ id: "ao-rs-orchestrator-1", spawnedBy: null });
+    expect(isUnaffiliated(s, [orch])).toBe(false);
+  });
+
+  it("returns false for session with spawnedBy set", () => {
+    const orch = makeOrch();
+    const s = makeSession({ spawnedBy: orch.id });
+    expect(isUnaffiliated(s, [orch])).toBe(false);
+  });
+});

--- a/crates/ao-desktop/ui/src/lib/format.test.ts
+++ b/crates/ao-desktop/ui/src/lib/format.test.ts
@@ -22,6 +22,7 @@ describe("getSessionTabLabel", () => {
       pr: null,
       attentionLevel: null,
       metadata: {},
+      spawnedBy: null,
     };
 
     expect(getSessionTabLabel(s)).toBe("ao-rs - #70: working");

--- a/crates/ao-desktop/ui/src/lib/orchestrator.ts
+++ b/crates/ao-desktop/ui/src/lib/orchestrator.ts
@@ -1,0 +1,58 @@
+import type { DashboardOrchestrator, DashboardSession } from "./types";
+
+/**
+ * Derive the full list of managed project IDs for an orchestrator.
+ * Today the backend only gives `primaryProjectId`; this function also folds in
+ * the project IDs of all worker sessions so the sidebar is ready for the future
+ * multi-project case without any API changes.
+ */
+export function deriveManagedProjectIds(
+  orchestrator: DashboardOrchestrator,
+  workers: DashboardSession[],
+): string[] {
+  const ids = new Set([orchestrator.primaryProjectId]);
+  for (const w of workers) ids.add(w.projectId);
+  return Array.from(ids);
+}
+
+/**
+ * Partition sessions into two groups:
+ * - `byOrchestrator`: workers keyed by the orchestrator id they were spawned by.
+ *   Orchestrator sessions themselves are excluded from both groups.
+ * - `unaffiliated`: sessions with no `spawnedBy` that are also not orchestrators.
+ *
+ * Source of truth: `worker.spawnedBy === orchestrator.id`.
+ */
+export function groupWorkersByOrchestrator(
+  sessions: DashboardSession[],
+  orchestrators: DashboardOrchestrator[],
+): {
+  byOrchestrator: Map<string, DashboardSession[]>;
+  unaffiliated: DashboardSession[];
+} {
+  const orchIds = new Set(orchestrators.map((o) => o.id));
+  const byOrchestrator = new Map<string, DashboardSession[]>(
+    orchestrators.map((o) => [o.id, []]),
+  );
+  const unaffiliated: DashboardSession[] = [];
+
+  for (const s of sessions) {
+    if (orchIds.has(s.id)) continue; // orchestrator session itself — not a worker
+    if (s.spawnedBy && byOrchestrator.has(s.spawnedBy)) {
+      byOrchestrator.get(s.spawnedBy)!.push(s);
+    } else {
+      unaffiliated.push(s);
+    }
+  }
+
+  return { byOrchestrator, unaffiliated };
+}
+
+/** True when a session was not spawned by any known orchestrator and is not itself an orchestrator. */
+export function isUnaffiliated(
+  session: DashboardSession,
+  orchestrators: DashboardOrchestrator[],
+): boolean {
+  const orchIds = new Set(orchestrators.map((o) => o.id));
+  return !session.spawnedBy && !orchIds.has(session.id);
+}

--- a/crates/ao-desktop/ui/src/lib/types.ts
+++ b/crates/ao-desktop/ui/src/lib/types.ts
@@ -39,6 +39,23 @@ export type DashboardSession = {
   pr: DashboardPR | null;
   attentionLevel?: AttentionLevel | null;
   metadata: Record<string, string>;
+  /** Session id of the orchestrator that spawned this session, if any. */
+  spawnedBy: string | null;
+};
+
+/**
+ * View model for an orchestrator session in the dashboard sidebar.
+ * `managedProjectIds` is always at least `[primaryProjectId]`; the list
+ * grows when the same orchestrator spawns workers in multiple projects.
+ * Using a list keeps the UI ready for multi-project orchestrators without
+ * requiring a backend change.
+ */
+export type DashboardOrchestrator = {
+  id: string;
+  status: string;
+  managedProjectIds: string[];
+  primaryProjectId: string;
+  createdAt: number | null;
 };
 
 export const TERMINAL_STATUSES = new Set([

--- a/crates/ao-desktop/ui/src/ui/App.tsx
+++ b/crates/ao-desktop/ui/src/ui/App.tsx
@@ -98,6 +98,7 @@ export function App() {
   const {
     sessions,
     setSessions,
+    orchestrators,
     conn,
     refreshSessionsWithPr,
     retryConnection,
@@ -105,6 +106,8 @@ export function App() {
     onNotification: pushToast,
     onEvent: logEvent,
   });
+
+  const [selectedOrchestratorId, setSelectedOrchestratorId] = useState<string | null>(null);
 
   const connLabel = useMemo(() => {
     if (conn.kind === "connected") return "connected";
@@ -173,14 +176,23 @@ export function App() {
             ? s.attention_level
             : null,
         metadata: {},
+        spawnedBy: s.spawned_by ?? null,
       })),
     [sessions],
   );
 
   const visibleSessions = useMemo(() => {
-    if (selectedProjectId === null) return dashboardSessions;
-    return dashboardSessions.filter((s) => s.projectId === selectedProjectId);
-  }, [dashboardSessions, selectedProjectId]);
+    // Orchestrator sessions are never shown as workers on the board.
+    const orchIds = new Set(orchestrators.map((o) => o.id));
+    let filtered = dashboardSessions.filter((s) => !orchIds.has(s.id));
+    if (selectedOrchestratorId) {
+      filtered = filtered.filter((s) => s.spawnedBy === selectedOrchestratorId);
+    }
+    if (selectedProjectId !== null) {
+      filtered = filtered.filter((s) => s.projectId === selectedProjectId);
+    }
+    return filtered;
+  }, [dashboardSessions, orchestrators, selectedOrchestratorId, selectedProjectId]);
 
   const activeCount = useMemo(
     () => dashboardSessions.filter((s) => !isTerminalSession(s)).length,
@@ -227,6 +239,7 @@ export function App() {
   const goToDashboard = () => {
     setActiveTab("dashboard");
     setDetailOnly(false);
+    setSelectedOrchestratorId(null);
     setSelectedProjectId(null);
     setSelectedSessionId(null);
     const params = new URLSearchParams(window.location.search);
@@ -380,11 +393,18 @@ export function App() {
         {detailOnly ? null : (
           <ProjectSidebar
             sessions={dashboardSessions}
+            orchestrators={orchestrators}
             activeProjectId={selectedProjectId}
             activeSessionId={activeSessionId}
-            onSelectProject={(pid) => {
+            activeOrchestratorId={selectedOrchestratorId}
+            onSelectOrchestrator={(oid) => {
+              setSelectedOrchestratorId(oid);
+              setSelectedProjectId(null);
+              setSelectedSessionId(null);
+            }}
+            onSelectProject={(pid, oid) => {
+              setSelectedOrchestratorId(oid ?? null);
               setSelectedProjectId(pid);
-              // Clear selection if it no longer exists in the filtered view
               if (pid !== null && selectedSessionId) {
                 const exists = dashboardSessions.some((s) => s.projectId === pid && s.id === selectedSessionId);
                 if (!exists) setSelectedSessionId(null);


### PR DESCRIPTION
Closes #204

## Summary

- **New 3-level sidebar hierarchy**: Orchestrators → Projects → Workers, replacing the old flat Projects → Sessions view
- **Soft fallback**: when no orchestrators exist the sidebar renders the original project-first tree (no empty-state regression)
- **Unaffiliated section**: sessions with no `spawnedBy` appear under a separate collapsible "Unaffiliated" section grouped by project
- **Board filtering**: clicking an orchestrator node filters the Board to all its workers; clicking a project sub-node narrows to that orchestrator × project

## Files changed

| File | Change |
|---|---|
| `api/client.ts` | Add `spawned_by` to `ApiSession`; add `listOrchestrators()` mapping `/api/orchestrators` → `DashboardOrchestrator[]` |
| `lib/types.ts` | Add `spawnedBy: string \| null` to `DashboardSession`; add `DashboardOrchestrator` type (multi-project ready) |
| `lib/orchestrator.ts` | **New** — pure helpers: `deriveManagedProjectIds`, `groupWorkersByOrchestrator`, `isUnaffiliated` |
| `hooks/useSessions.ts` | Fetch `/api/orchestrators` in parallel with sessions; expose `orchestrators` in return |
| `components/ProjectSidebar.tsx` | Full rewrite: orchestrator-first tree + unaffiliated fallback + project-first fallback |
| `ui/App.tsx` | Add `selectedOrchestratorId`; map `spawnedBy`; update `visibleSessions` to exclude orchestrator sessions from board |
| `lib/__tests__/orchestrator.test.ts` | **New** — 14 unit tests covering acceptance criteria (a)–(d) |

## Test plan

- [x] `npm run test` — 79 tests pass (10 test files)
- [x] `npm run typecheck` — clean
- [x] `npm run build` — clean
- [x] `cargo t --workspace` — 837/839 pass (2 pre-existing `workspace-clone` git-init failures unrelated to this PR)

Acceptance criteria covered by tests:
- (a) Orchestrator with workers in 2 projects → both project sub-nodes present
- (b) Orchestrator with 0 workers → still renders in map
- (c) Unaffiliated-only: all sessions → `unaffiliated` list, `byOrchestrator` empty
- (d) Mixed orchestrator workers + unaffiliated sessions correctly partitioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)