### PR TITLE
feat(ui): strip orchestrator/ prefix in humanizeBranch + sessionId fallback

### DIFF
--- a/crates/ao-desktop/ui/src/lib/format.test.ts
+++ b/crates/ao-desktop/ui/src/lib/format.test.ts
@@ -1,7 +1,14 @@
 import { describe, expect, it } from "vitest";
 
 import type { ApiEvent } from "../api/client";
-import { formatCiStatus, formatEvent, formatReviewDecision, getSessionTabLabel } from "./format";
+import {
+  formatCiStatus,
+  formatEvent,
+  formatReviewDecision,
+  getSessionTabLabel,
+  getSessionTitle,
+  humanizeBranch,
+} from "./format";
 import type { DashboardSession } from "./types";
 
 describe("getSessionTabLabel", () => {
@@ -29,6 +36,81 @@ describe("getSessionTabLabel", () => {
     };
 
     expect(getSessionTabLabel(s)).toBe("ao-rs - #70: working");
+  });
+});
+
+describe("humanizeBranch", () => {
+  it("strips feat/ prefix and title-cases", () => {
+    expect(humanizeBranch("feat/infer-project-id")).toBe("Infer Project Id");
+  });
+
+  it("strips orchestrator/ prefix and title-cases", () => {
+    expect(humanizeBranch("orchestrator/foo-bar")).toBe("Foo Bar");
+  });
+
+  it("returns null when stripped branch equals sessionId", () => {
+    expect(humanizeBranch("orchestrator/ao-orchestrator-8", "ao-orchestrator-8")).toBeNull();
+  });
+
+  it("returns null when session/ stripped branch equals sessionId", () => {
+    expect(humanizeBranch("session/ao-52", "ao-52")).toBeNull();
+  });
+
+  it("returns humanized when sessionId does not match stripped branch", () => {
+    expect(humanizeBranch("orchestrator/fix-auth", "ao-orchestrator-8")).toBe("Fix Auth");
+  });
+
+  it("works without sessionId arg", () => {
+    expect(humanizeBranch("orchestrator/some-feature")).toBe("Some Feature");
+  });
+});
+
+describe("getSessionTitle", () => {
+  const base: DashboardSession = {
+    id: "ao-orchestrator-8",
+    projectId: "ao-rs",
+    status: "working",
+    activity: null,
+    agent: null,
+    branch: null,
+    summary: null,
+    summaryIsFallback: false,
+    issueTitle: null,
+    issueId: null,
+    issueUrl: null,
+    userPrompt: null,
+    pr: null,
+    claimedPrNumber: null,
+    claimedPrUrl: null,
+    attentionLevel: null,
+    metadata: {},
+    spawnedBy: null,
+    createdAt: null,
+  };
+
+  it("returns pr title when present", () => {
+    const s = { ...base, pr: { number: 1, url: "", title: "My PR" } as DashboardSession["pr"] };
+    expect(getSessionTitle(s)).toBe("My PR");
+  });
+
+  it("falls through branch to summary when branch matches session id", () => {
+    const s = {
+      ...base,
+      branch: "orchestrator/ao-orchestrator-8",
+      summary: "Doing work",
+      summaryIsFallback: false,
+    };
+    expect(getSessionTitle(s)).toBe("Doing work");
+  });
+
+  it("returns humanized branch when branch is a real task name", () => {
+    const s = { ...base, branch: "orchestrator/fix-auth-bug" };
+    expect(getSessionTitle(s)).toBe("Fix Auth Bug");
+  });
+
+  it("falls through to status when branch matches session id and no summary", () => {
+    const s = { ...base, branch: "orchestrator/ao-orchestrator-8" };
+    expect(getSessionTitle(s)).toBe("working");
   });
 });
 

--- a/crates/ao-desktop/ui/src/lib/format.ts
+++ b/crates/ao-desktop/ui/src/lib/format.ts
@@ -42,11 +42,16 @@ export function formatReviewDecision(raw: string): PillFormat {
   }
 }
 
-export function humanizeBranch(branch: string): string {
+export function humanizeBranch(branch: string, sessionId?: string): string | null {
   const withoutPrefix = branch.replace(
-    /^(?:feat|fix|chore|refactor|docs|test|ci|session|release|hotfix|feature|bugfix|build|wip|improvement)\//,
+    /^(?:feat|fix|chore|refactor|docs|test|ci|session|release|hotfix|feature|bugfix|build|wip|improvement|orchestrator)\//,
     "",
   );
+
+  if (sessionId && withoutPrefix === sessionId) {
+    return null;
+  }
+
   return withoutPrefix
     .replace(/[-_]/g, " ")
     .replace(/\b\w/g, (c) => c.toUpperCase())
@@ -146,7 +151,10 @@ export function getSessionTitle(session: DashboardSession): string {
   if (session.issueId && session.issueTitle) return `#${session.issueId} ${session.issueTitle}`;
   if (session.issueTitle) return session.issueTitle;
   if (session.userPrompt) return session.userPrompt;
-  if (session.branch) return humanizeBranch(session.branch);
+  if (session.branch) {
+    const humanized = humanizeBranch(session.branch, session.id);
+    if (humanized) return humanized;
+  }
   const pinned = session.metadata["pinnedSummary"];
   if (pinned) return pinned;
   if (session.summary && !session.summaryIsFallback) return session.summary;


### PR DESCRIPTION
## Summary

- Add `orchestrator` to prefix-strip regex in `humanizeBranch` — branches like `orchestrator/foo-bar` now render as `Foo Bar`
- Accept optional `sessionId` arg; when stripped branch equals the session ID (e.g. `orchestrator/ao-orchestrator-8`), return `null` so the fallback chain in `getSessionTitle` continues to summary/status
- Thread `session.id` into `humanizeBranch` call in `getSessionTitle`

Closes #210. Port of upstream agent-orchestrator PR #1224.

## Test plan

- [x] `humanizeBranch("orchestrator/foo-bar")` → `"Foo Bar"`
- [x] `humanizeBranch("orchestrator/ao-orchestrator-8", "ao-orchestrator-8")` → `null`
- [x] `humanizeBranch("session/ao-52", "ao-52")` → `null`
- [x] `getSessionTitle` with `orchestrator/ao-orchestrator-8` branch falls through to summary
- [x] `getSessionTitle` with `orchestrator/fix-auth-bug` returns `"Fix Auth Bug"`
- [x] All 37 existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)