### PR TITLE
feat(lifecycle): dispatch detailed bugbot review comments to worker agent

### DIFF
--- a/crates/ao-cli/src/commands/kill.rs
+++ b/crates/ao-cli/src/commands/kill.rs
@@ -125,6 +125,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-cli/src/commands/spawn.rs
+++ b/crates/ao-cli/src/commands/spawn.rs
@@ -295,6 +295,8 @@ pub async fn spawn(
             spawned_by: resolved_spawned_by.clone(),
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
 
         let manager = SessionManager::with_default();

--- a/crates/ao-cli/src/commands/status.rs
+++ b/crates/ao-cli/src/commands/status.rs
@@ -398,6 +398,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
 
         let opts = StatusOptions {

--- a/crates/ao-cli/src/commands/verify.rs
+++ b/crates/ao-cli/src/commands/verify.rs
@@ -307,6 +307,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-cli/src/session/remap.rs
+++ b/crates/ao-cli/src/session/remap.rs
@@ -128,6 +128,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         sm.save(&session).await.unwrap();
         session

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -109,6 +109,8 @@ fn session_display_title_prefixes_issue_sessions() {
         spawned_by: None,
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     };
     assert_eq!(
         session_display_title(&s),
@@ -546,6 +548,8 @@ fn fake_session() -> Session {
         spawned_by: None,
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     }
 }
 

--- a/crates/ao-core/src/lifecycle/mod.rs
+++ b/crates/ao-core/src/lifecycle/mod.rs
@@ -923,6 +923,8 @@ pub(super) fn all_complete_sentinel() -> Session {
         spawned_by: None,
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     }
 }
 
@@ -930,8 +932,8 @@ pub(super) fn all_complete_sentinel() -> Session {
 pub(crate) mod tests {
     use super::*;
     use crate::scm::{
-        CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest, Review,
-        ReviewComment, ReviewDecision,
+        AutomatedComment, CheckRun, CiStatus, MergeMethod, MergeReadiness, PrState, PullRequest,
+        Review, ReviewComment, ReviewDecision,
     };
     use crate::types::{now_ms, SessionId};
     use async_trait::async_trait;
@@ -973,6 +975,8 @@ pub(crate) mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 
@@ -1096,6 +1100,8 @@ pub(crate) mod tests {
         // Issue #195: scriptable pending_comments and ci_checks for H2/H3 tests.
         pub(crate) pending_comments_result: Mutex<Vec<ReviewComment>>,
         pub(crate) ci_checks_result: Mutex<Vec<CheckRun>>,
+        // Issue #212: scriptable automated_comments for bugbot dispatch tests.
+        pub(crate) automated_comments_result: Mutex<Vec<AutomatedComment>>,
     }
 
     impl MockScm {
@@ -1122,6 +1128,7 @@ pub(crate) mod tests {
                 merge_calls: Mutex::new(Vec::new()),
                 pending_comments_result: Mutex::new(vec![]),
                 ci_checks_result: Mutex::new(vec![]),
+                automated_comments_result: Mutex::new(vec![]),
             }
         }
         pub(crate) fn merges(&self) -> Vec<(u32, Option<MergeMethod>)> {
@@ -1132,6 +1139,9 @@ pub(crate) mod tests {
         }
         pub(crate) fn set_ci_checks(&self, checks: Vec<CheckRun>) {
             *self.ci_checks_result.lock().unwrap() = checks;
+        }
+        pub(crate) fn set_automated_comments(&self, comments: Vec<AutomatedComment>) {
+            *self.automated_comments_result.lock().unwrap() = comments;
         }
         pub(crate) fn set_pr(&self, pr: Option<PullRequest>) {
             *self.pr.lock().unwrap() = pr;
@@ -1190,6 +1200,9 @@ pub(crate) mod tests {
         }
         async fn pending_comments(&self, _pr: &PullRequest) -> Result<Vec<ReviewComment>> {
             Ok(self.pending_comments_result.lock().unwrap().clone())
+        }
+        async fn automated_comments(&self, _pr: &PullRequest) -> Result<Vec<AutomatedComment>> {
+            Ok(self.automated_comments_result.lock().unwrap().clone())
         }
         async fn mergeability(&self, _pr: &PullRequest) -> Result<MergeReadiness> {
             if self.mergeability_errors.load(Ordering::SeqCst) {

--- a/crates/ao-core/src/lifecycle/scm_poll.rs
+++ b/crates/ao-core/src/lifecycle/scm_poll.rs
@@ -211,6 +211,16 @@ impl LifecycleManager {
             }
         }
 
+        // ---- 8. Bugbot comments dispatch (issue #212) ----
+        // When new automated bot comments appear on the PR, dispatch a
+        // detailed `bugbot-comments` reaction so the agent knows exactly
+        // which checks flagged which lines.
+        if let Some(ref pr) = pr_saved {
+            if self.reaction_engine.is_some() {
+                self.check_bugbot_comments(session, pr).await?;
+            }
+        }
+
         Ok(())
     }
 
@@ -364,6 +374,151 @@ impl LifecycleManager {
 
         Ok(())
     }
+
+    /// Port of `maybeDispatchAutomatedReview` from the TS reference
+    /// (`lifecycle-manager.ts:1487-1532`).
+    ///
+    /// Fetches the current `automated_comments` set from the SCM plugin,
+    /// fingerprints the result, and dispatches a detailed `bugbot-comments`
+    /// reaction when the set has changed since the last dispatch. Same-set
+    /// ticks are silent (de-dup via `last_automated_review_dispatch_hash`).
+    ///
+    /// When the fingerprint changes from the previous tick the reaction
+    /// tracker is cleared so a fresh attempt counter starts. This mirrors
+    /// TS line 1493–1495.
+    pub(super) async fn check_bugbot_comments(
+        &self,
+        session: &mut Session,
+        pr: &PullRequest,
+    ) -> Result<()> {
+        let Some(engine) = self.reaction_engine.as_ref() else {
+            return Ok(());
+        };
+        let Some(scm) = self.scm.as_ref() else {
+            return Ok(());
+        };
+
+        let comments = match scm.automated_comments(pr).await {
+            Ok(c) => c,
+            Err(e) => {
+                tracing::warn!(
+                    session = %session.id,
+                    error = %e,
+                    "automated_comments failed; skipping bugbot check"
+                );
+                return Ok(());
+            }
+        };
+
+        let fingerprint = fingerprint_automated_comments(&comments);
+
+        // When the fingerprint has changed, clear the tracker so the next
+        // dispatch starts with a fresh attempt count (mirrors TS 1493-1495).
+        if session.last_automated_review_fingerprint != Some(fingerprint) {
+            engine.clear_tracker(&session.id, "bugbot-comments");
+            session.last_automated_review_fingerprint = Some(fingerprint);
+        }
+
+        // No bot comments — nothing to dispatch; reset dispatch hash.
+        if comments.is_empty() {
+            if session.last_automated_review_dispatch_hash.is_some() {
+                session.last_automated_review_dispatch_hash = None;
+                self.sessions.save(session).await?;
+            }
+            return Ok(());
+        }
+
+        // Already dispatched this exact set — skip.
+        if session.last_automated_review_dispatch_hash == Some(fingerprint) {
+            return Ok(());
+        }
+
+        let msg = format_automated_comments_message(&comments);
+
+        engine
+            .dispatch_with_message(session, "bugbot-comments", msg)
+            .await?;
+
+        session.last_automated_review_dispatch_hash = Some(fingerprint);
+        self.sessions.save(session).await?;
+
+        Ok(())
+    }
+}
+
+/// Stable hash fingerprint of an `AutomatedComment` slice.
+///
+/// Sorts by `(id, bot_name, url)` for determinism, then folds through
+/// `DefaultHasher`. Used by `check_bugbot_comments` to detect when the
+/// bot-comment set has changed between ticks.
+pub(super) fn fingerprint_automated_comments(comments: &[crate::scm::AutomatedComment]) -> u64 {
+    use std::collections::hash_map::DefaultHasher;
+    let mut keys: Vec<(&str, &str, &str)> = comments
+        .iter()
+        .map(|c| (c.id.as_str(), c.bot_name.as_str(), c.url.as_str()))
+        .collect();
+    keys.sort_unstable();
+    let mut h = DefaultHasher::new();
+    keys.hash(&mut h);
+    h.finish()
+}
+
+/// Format a detailed dispatch message from a slice of `AutomatedComment`s.
+///
+/// Ports `formatAutomatedCommentsMessage` from
+/// `packages/core/src/format-automated-comments.ts` (PR #1334). The
+/// message includes:
+/// - A preamble warning that the data came from a previous API call
+/// - Per-comment: severity label, `path:line`, bot name, excerpt, URL
+/// - Explicit API guidance for paginated re-fetching so the agent doesn't
+///   rely on a stale first-page scan
+pub(super) fn format_automated_comments_message(
+    comments: &[crate::scm::AutomatedComment],
+) -> String {
+    use crate::scm::AutomatedCommentSeverity;
+
+    let mut msg = String::from(
+        "Automated bot review comments on your PR \
+         (fetched at reaction time — verify via API before acting):\n\n",
+    );
+
+    for (i, c) in comments.iter().enumerate() {
+        let severity = match c.severity {
+            AutomatedCommentSeverity::Error => "ERROR",
+            AutomatedCommentSeverity::Warning => "WARNING",
+            AutomatedCommentSeverity::Info => "INFO",
+        };
+        let location = match (&c.path, c.line) {
+            (Some(p), Some(l)) => format!(" {}:{}", p, l),
+            (Some(p), None) => format!(" {}", p),
+            _ => String::new(),
+        };
+        // Truncate long bodies to keep the message readable.
+        let excerpt: String = c.body.chars().take(200).collect();
+        let ellipsis = if c.body.len() > 200 { "…" } else { "" };
+
+        msg.push_str(&format!(
+            "{}. [{}] {}{}\n   {}{}\n   {}\n\n",
+            i + 1,
+            severity,
+            c.bot_name,
+            location,
+            excerpt,
+            ellipsis,
+            c.url,
+        ));
+    }
+
+    msg.push_str(
+        "To verify this data is current and complete, use the GitHub API directly:\n\
+         - GET /repos/{owner}/{repo}/pulls/{pr}/reviews\n\
+         - GET /repos/{owner}/{repo}/pulls/{pr}/reviews/{review_id}/comments\n\
+         - GET /repos/{owner}/{repo}/pulls/{pr}/comments?per_page=100&page=N \
+           (paginate; check in_reply_to_id for reply threads)\n\
+         Fix each issue, push, and confirm the bot re-checks pass.",
+    );
+
+    msg
 }
 
 #[cfg(test)]
@@ -1234,5 +1389,199 @@ mod tests {
         );
 
         let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // ---------- Issue #212: bugbot comments dispatch + de-dup ---------- //
+
+    #[tokio::test]
+    async fn bugbot_comments_dispatches_on_new_bot_comments() {
+        use crate::lifecycle::tests::unique_temp_dir;
+        use crate::reactions::ReactionConfig;
+        use crate::scm::{
+            AutomatedComment, AutomatedCommentSeverity, CiStatus, PrState, ReviewDecision,
+        };
+        use crate::session_manager::SessionManager;
+
+        let base = unique_temp_dir("bugbot-new");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let lifecycle_runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let scm = Arc::new(MockScm::new());
+
+        let lifecycle = LifecycleManager::new(sessions.clone(), lifecycle_runtime, agent);
+        let engine_runtime = Arc::new(MockRuntime::new(true));
+        let mut cfg = ReactionConfig::new(ReactionAction::SendToAgent);
+        cfg.message = Some("Fix bot comments".into());
+        let mut map = std::collections::HashMap::new();
+        map.insert("bugbot-comments".into(), cfg);
+        let engine = Arc::new(ReactionEngine::new(
+            map,
+            engine_runtime.clone() as Arc<dyn Runtime>,
+            lifecycle.events_sender(),
+        ));
+        let lifecycle = Arc::new(
+            lifecycle
+                .with_reaction_engine(engine.clone())
+                .with_scm(scm.clone() as Arc<dyn Scm>),
+        );
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::PrOpen;
+        sessions.save(&s).await.unwrap();
+
+        scm.set_pr(Some(fake_pr(30, "ao-s1")));
+        scm.set_state(PrState::Open);
+        scm.set_ci(CiStatus::Pending);
+        scm.set_review(ReviewDecision::None);
+        scm.set_automated_comments(vec![AutomatedComment {
+            id: "bot-c1".into(),
+            bot_name: "sonarcloud[bot]".into(),
+            body: "Potential null pointer dereference".into(),
+            path: Some("src/main.rs".into()),
+            line: Some(42),
+            severity: AutomatedCommentSeverity::Error,
+            url: "https://github.com/a/b/pull/30#pullrequestreviewcomment-1".into(),
+        }]);
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let sends = engine_runtime.sends();
+        assert_eq!(
+            sends.len(),
+            1,
+            "expected exactly 1 bugbot send, got {sends:?}"
+        );
+        let msg = &sends[0].1;
+        assert!(
+            msg.contains("sonarcloud[bot]"),
+            "message must include bot name"
+        );
+        assert!(
+            msg.contains("src/main.rs:42"),
+            "message must include path:line"
+        );
+        assert!(msg.contains("ERROR"), "message must include severity");
+        assert!(
+            msg.contains("Potential null pointer"),
+            "message must include excerpt"
+        );
+        assert!(msg.contains("reviews"), "message must include API guidance");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn bugbot_comments_no_redispatch_on_same_comment_set() {
+        use crate::lifecycle::tests::unique_temp_dir;
+        use crate::reactions::ReactionConfig;
+        use crate::scm::{
+            AutomatedComment, AutomatedCommentSeverity, CiStatus, PrState, ReviewDecision,
+        };
+        use crate::session_manager::SessionManager;
+
+        let base = unique_temp_dir("bugbot-dedup");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let lifecycle_runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let scm = Arc::new(MockScm::new());
+
+        let lifecycle = LifecycleManager::new(sessions.clone(), lifecycle_runtime, agent);
+        let engine_runtime = Arc::new(MockRuntime::new(true));
+        let mut cfg = ReactionConfig::new(ReactionAction::SendToAgent);
+        cfg.message = Some("Fix bot comments".into());
+        let mut map = std::collections::HashMap::new();
+        map.insert("bugbot-comments".into(), cfg);
+        let engine = Arc::new(ReactionEngine::new(
+            map,
+            engine_runtime.clone() as Arc<dyn Runtime>,
+            lifecycle.events_sender(),
+        ));
+        let lifecycle = Arc::new(
+            lifecycle
+                .with_reaction_engine(engine.clone())
+                .with_scm(scm.clone() as Arc<dyn Scm>),
+        );
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::PrOpen;
+        sessions.save(&s).await.unwrap();
+
+        scm.set_pr(Some(fake_pr(31, "ao-s1")));
+        scm.set_state(PrState::Open);
+        scm.set_ci(CiStatus::Pending);
+        scm.set_review(ReviewDecision::None);
+        scm.set_automated_comments(vec![AutomatedComment {
+            id: "bot-c2".into(),
+            bot_name: "codecov[bot]".into(),
+            body: "Coverage dropped below threshold".into(),
+            path: None,
+            line: None,
+            severity: AutomatedCommentSeverity::Warning,
+            url: "https://github.com/a/b/pull/31#pullrequestreviewcomment-2".into(),
+        }]);
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+        assert_eq!(
+            engine_runtime.sends().len(),
+            1,
+            "tick 1 should dispatch once"
+        );
+
+        lifecycle.tick(&mut seen).await.unwrap();
+        assert_eq!(
+            engine_runtime.sends().len(),
+            1,
+            "tick 2 with same comments must NOT dispatch again"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[test]
+    fn format_automated_comments_message_includes_all_fields() {
+        use crate::scm::{AutomatedComment, AutomatedCommentSeverity};
+
+        let comments = vec![
+            AutomatedComment {
+                id: "1".into(),
+                bot_name: "sonarcloud[bot]".into(),
+                body: "Null check missing".into(),
+                path: Some("src/lib.rs".into()),
+                line: Some(10),
+                severity: AutomatedCommentSeverity::Error,
+                url: "https://example.com/c/1".into(),
+            },
+            AutomatedComment {
+                id: "2".into(),
+                bot_name: "codecov[bot]".into(),
+                body: "Coverage low".into(),
+                path: None,
+                line: None,
+                severity: AutomatedCommentSeverity::Warning,
+                url: "https://example.com/c/2".into(),
+            },
+        ];
+
+        let msg = format_automated_comments_message(&comments);
+
+        assert!(msg.contains("ERROR"), "must include ERROR severity");
+        assert!(msg.contains("WARNING"), "must include WARNING severity");
+        assert!(msg.contains("src/lib.rs:10"), "must include path:line");
+        assert!(msg.contains("sonarcloud[bot]"), "must include bot name");
+        assert!(
+            msg.contains("Null check missing"),
+            "must include body excerpt"
+        );
+        assert!(msg.contains("https://example.com/c/1"), "must include URL");
+        assert!(
+            msg.contains("per_page=100"),
+            "must include pagination API hint"
+        );
+        assert!(
+            msg.contains("in_reply_to_id"),
+            "must include reply thread hint"
+        );
     }
 }

--- a/crates/ao-core/src/orchestrator_spawn.rs
+++ b/crates/ao-core/src/orchestrator_spawn.rs
@@ -191,6 +191,8 @@ pub async fn spawn_orchestrator(
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         sessions.save(&session).await?;
 
@@ -364,6 +366,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-core/src/prompt_builder.rs
+++ b/crates/ao-core/src/prompt_builder.rs
@@ -248,6 +248,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-core/src/reaction_engine/mod.rs
+++ b/crates/ao-core/src/reaction_engine/mod.rs
@@ -596,6 +596,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-core/src/restore.rs
+++ b/crates/ao-core/src/restore.rs
@@ -307,6 +307,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         manager.save(&session).await.unwrap();
         session

--- a/crates/ao-core/src/session_manager.rs
+++ b/crates/ao-core/src/session_manager.rs
@@ -260,6 +260,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-core/src/traits.rs
+++ b/crates/ao-core/src/traits.rs
@@ -468,6 +468,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/ao-core/src/types.rs
+++ b/crates/ao-core/src/types.rs
@@ -281,6 +281,22 @@ pub struct Session {
     /// fingerprint matches the stored value does nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub last_review_backlog_fingerprint: Option<u64>,
+    /// Hash fingerprint of the last-seen `automated_comments` set.
+    /// `None` until the first bugbot check runs.
+    ///
+    /// Ports `lastAutomatedReviewFingerprint` from the TS reference
+    /// (`lifecycle-manager.ts:1347`). When a tick observes a changed
+    /// fingerprint the `bugbot-comments` reaction tracker is cleared so
+    /// the next dispatch fires fresh. De-dup sentinel.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_automated_review_fingerprint: Option<u64>,
+    /// Hash fingerprint of the comment set for which `bugbot-comments` was
+    /// last dispatched. Compared against `last_automated_review_fingerprint`
+    /// to prevent re-dispatching the same set of bot comments on every tick.
+    ///
+    /// Ports `lastAutomatedReviewDispatchHash` from the TS reference.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub last_automated_review_dispatch_hash: Option<u64>,
 }
 
 impl Session {
@@ -480,6 +496,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         assert!(!base.is_terminal());
 
@@ -519,6 +537,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         assert!(merged.is_terminal());
         assert!(!merged.is_restorable());
@@ -547,6 +567,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 
@@ -722,6 +744,8 @@ created_at: 1700000000000
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         let yaml = serde_yaml::to_string(&session).unwrap();
         let parsed: Session = serde_yaml::from_str(&yaml).unwrap();
@@ -774,6 +798,8 @@ created_at: 0
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         let yaml = serde_yaml::to_string(&session).unwrap();
         let parsed: Session = serde_yaml::from_str(&yaml).unwrap();

--- a/crates/ao-core/tests/notification_flow.rs
+++ b/crates/ao-core/tests/notification_flow.rs
@@ -63,6 +63,8 @@ fn fake_session(short: &str, project: &str) -> Session {
         spawned_by: None,
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     }
 }
 

--- a/crates/ao-core/tests/parity_test_utils.rs
+++ b/crates/ao-core/tests/parity_test_utils.rs
@@ -38,5 +38,7 @@ pub fn fake_session(id: &str) -> Session {
         spawned_by: None,
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     }
 }

--- a/crates/ao-core/tests/reaction_engine_issue24_retry_escalation.rs
+++ b/crates/ao-core/tests/reaction_engine_issue24_retry_escalation.rs
@@ -64,6 +64,8 @@ fn fake_session(id: &str, project: &str) -> Session {
         spawned_by: None,
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     }
 }
 

--- a/crates/ao-dashboard/src/lib.rs
+++ b/crates/ao-dashboard/src/lib.rs
@@ -589,6 +589,8 @@ mod tests {
                 spawned_by: None,
                 last_merge_conflict_dispatched: None,
                 last_review_backlog_fingerprint: None,
+                last_automated_review_fingerprint: None,
+                last_automated_review_dispatch_hash: None,
             };
             state.sessions.save(&s).await.unwrap();
         }
@@ -641,6 +643,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         // Orchestrator session should be included.
         let orch = Session {
@@ -665,6 +669,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         };
         state.sessions.save(&worker).await.unwrap();
         state.sessions.save(&orch).await.unwrap();

--- a/crates/ao-dashboard/src/routes.rs
+++ b/crates/ao-dashboard/src/routes.rs
@@ -273,9 +273,7 @@ fn shorten_slug(slug: &str) -> String {
 /// - nothing           → `ao-<short_id>` (legacy fallback)
 fn build_session_branch(task: &str, issue_id: Option<&str>, short_id: &str) -> String {
     let slug = shorten_slug(&slugify_for_branch(task));
-    let issue = issue_id
-        .map(str::trim)
-        .filter(|s| !s.is_empty());
+    let issue = issue_id.map(str::trim).filter(|s| !s.is_empty());
     match (issue, slug.as_str()) {
         (Some(id), "") => format!("ao/{id}-{short_id}"),
         (Some(id), s) => format!("ao/{id}-{s}"),
@@ -360,6 +358,8 @@ pub async fn spawn_session(
         spawned_by: body.spawned_by.clone().map(ao_core::SessionId),
         last_merge_conflict_dispatched: None,
         last_review_backlog_fingerprint: None,
+        last_automated_review_fingerprint: None,
+        last_automated_review_dispatch_hash: None,
     };
 
     state
@@ -1444,6 +1444,8 @@ mod attention_tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 
@@ -1632,10 +1634,7 @@ mod branch_name_tests {
 
     #[test]
     fn empty_task_falls_back_to_short_id() {
-        assert_eq!(
-            build_session_branch("", None, "7f9e1657"),
-            "ao-7f9e1657"
-        );
+        assert_eq!(build_session_branch("", None, "7f9e1657"), "ao-7f9e1657");
     }
 
     #[test]
@@ -1656,7 +1655,8 @@ mod branch_name_tests {
 
     #[test]
     fn long_task_truncates_at_word_boundary() {
-        let task = "this is a very long task description that goes on and on coordinating multiple agents";
+        let task =
+            "this is a very long task description that goes on and on coordinating multiple agents";
         let b = build_session_branch(task, None, "abcd1234");
         assert!(b.starts_with("ao/"));
         assert!(b.ends_with("-abcd1234"));

--- a/crates/plugins/agent-aider/src/lib.rs
+++ b/crates/plugins/agent-aider/src/lib.rs
@@ -211,6 +211,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/plugins/agent-claude-code/src/lib.rs
+++ b/crates/plugins/agent-claude-code/src/lib.rs
@@ -383,6 +383,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/plugins/agent-codex/src/lib.rs
+++ b/crates/plugins/agent-codex/src/lib.rs
@@ -364,6 +364,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 

--- a/crates/plugins/agent-cursor/src/lib.rs
+++ b/crates/plugins/agent-cursor/src/lib.rs
@@ -321,6 +321,8 @@ mod tests {
             spawned_by: None,
             last_merge_conflict_dispatched: None,
             last_review_backlog_fingerprint: None,
+            last_automated_review_fingerprint: None,
+            last_automated_review_dispatch_hash: None,
         }
     }
 


### PR DESCRIPTION
## Summary

Port of upstream agent-orchestrator PR #1334 — *fix(core): dispatch detailed bugbot review comments to agents*.

- **Wire `bugbot-comments` reaction** in `poll_scm` (step 8) — calls `scm.automated_comments(pr)` on each tick when a PR is in hand and a reaction engine is configured
- **Rich dispatch message** via `format_automated_comments_message`: numbered list with `[severity] bot_name path:line`, 200-char excerpt, URL, plus explicit API guidance for paginated `GET /pulls/{pr}/comments`, `GET /reviews`, and `GET /reviews/{id}/comments` with `in_reply_to_id` note
- **De-dup fingerprint** — two new `Session` fields (`last_automated_review_fingerprint`, `last_automated_review_dispatch_hash`) track the last-seen and last-dispatched comment sets; same-set ticks are silent
- **Tracker clearing** — when the fingerprint changes, the reaction engine tracker is cleared so a fresh attempt count starts (mirrors TS lines 1493–1495)

## Files changed

| File | Change |
|---|---|
| `crates/ao-core/src/types.rs` | +2 session fields for dedup |
| `crates/ao-core/src/lifecycle/scm_poll.rs` | `check_bugbot_comments`, `format_automated_comments_message`, `fingerprint_automated_comments`, step 8 in `poll_scm`, 3 tests |
| `crates/ao-core/src/lifecycle/mod.rs` | `MockScm.automated_comments_result`, `all_complete_sentinel` update |
| All other crates | Session struct initializers updated (+2 `None` fields) |

## Test plan

- [x] `bugbot_comments_dispatches_on_new_bot_comments` — new bot comments fire one dispatch with correct message fields (severity, path:line, bot name, excerpt, API guidance)
- [x] `bugbot_comments_no_redispatch_on_same_comment_set` — second tick with identical comment set fires no second dispatch
- [x] `format_automated_comments_message_includes_all_fields` — formatter includes all required fields + pagination hints
- [x] `cargo t --workspace` — all pre-existing tests pass (1 pre-existing failure in `agent-claude-code` unrelated to this PR)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean

Closes #212

🤖 Generated with [Claude Code](https://claude.com/claude-code)