### PR TITLE
feat(config): add $schema support for ao-rs.yaml (#213)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -103,6 +103,7 @@ version = "0.1.0"
 dependencies = [
  "async-trait",
  "libc",
+ "schemars 0.8.22",
  "serde",
  "serde_ignored",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ serde = { version = "1", features = ["derive"] }
 serde_yaml = "0.9"
 serde_json = "1"
 serde_ignored = "0.1"
+schemars = "0.8"
 thiserror = "1"
 async-trait = "0.1"
 tracing = "0.1"

--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -596,6 +596,7 @@ fn spawn_resolves_project_id_from_ao_rs_yaml_by_matching_repo_path() {
         },
     );
     let cfg = AoConfig {
+        schema_url: None,
         port: 3000,
         ready_threshold_ms: 300_000,
         poll_interval: 10,

--- a/crates/ao-core/Cargo.toml
+++ b/crates/ao-core/Cargo.toml
@@ -17,6 +17,7 @@ serde = { workspace = true }
 serde_json = { workspace = true }
 serde_yaml = { workspace = true }
 serde_ignored = { workspace = true }
+schemars = { workspace = true }
 thiserror = { workspace = true }
 async-trait = { workspace = true }
 uuid = { workspace = true }

--- a/crates/ao-core/src/config/agent.rs
+++ b/crates/ao-core/src/config/agent.rs
@@ -2,6 +2,7 @@
 //! default rules, and the `install_skills` helper.
 
 use crate::error::{AoError, Result};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
 
@@ -12,7 +13,7 @@ pub(super) fn default_permissions() -> PermissionsMode {
 /// Permission mode for agent execution.
 ///
 /// Strict serde deserialization — unknown values fail at load time (TS parity: M4).
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum PermissionsMode {
     #[default]
@@ -35,7 +36,7 @@ impl std::fmt::Display for PermissionsMode {
 }
 
 /// Agent-level overrides per project.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct AgentConfig {
     /// Permission mode: permissionless, default, auto-edit, suggest.
     #[serde(default = "default_permissions")]

--- a/crates/ao-core/src/config/mod.rs
+++ b/crates/ao-core/src/config/mod.rs
@@ -31,8 +31,16 @@ use crate::{
     reaction_engine::parse_duration,
     reactions::{EscalateAfter, EventPriority, ReactionConfig},
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path};
+
+/// Canonical URL for the committed JSON Schema file.
+///
+/// Editors (VS Code + YAML extension, JetBrains) use this to provide
+/// IntelliSense and validation on `ao-rs.yaml` files.
+pub const SCHEMA_URL: &str =
+    "https://raw.githubusercontent.com/duonghb53/ao-rs/main/schema/ao-rs.schema.json";
 
 // ---------------------------------------------------------------------------
 // Diagnostics + validation
@@ -213,8 +221,13 @@ impl AoConfig {
 
 /// Top-level ao-rs config file shape. All fields use `#[serde(default)]`
 /// so partial config files parse without error.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct AoConfig {
+    /// JSON Schema URL for editor IntelliSense/validation.
+    #[serde(rename = "$schema", default, skip_serializing_if = "Option::is_none")]
+    #[schemars(rename = "$schema")]
+    pub schema_url: Option<String>,
+
     /// Dashboard port (TS: `port`).
     #[serde(default = "project::default_port")]
     pub port: u16,
@@ -276,12 +289,14 @@ pub struct AoConfig {
 
     /// External plugins list (installer-managed). Currently stored for parity only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(skip)]
     pub plugins: Vec<HashMap<String, serde_yaml::Value>>,
 }
 
 impl Default for AoConfig {
     fn default() -> Self {
         Self {
+            schema_url: None,
             port: project::default_port(),
             ready_threshold_ms: project::default_ready_threshold_ms(),
             poll_interval: project::default_poll_interval_secs(),
@@ -401,11 +416,19 @@ impl AoConfig {
     }
 
     /// Write this config to disk as YAML, creating parent dirs if needed.
+    ///
+    /// Always stamps `$schema:` so editors get IntelliSense. Existing
+    /// non-empty schema URLs are preserved; absent or blank values are
+    /// replaced with `SCHEMA_URL`.
     pub fn save_to(&self, path: &Path) -> Result<()> {
         if let Some(parent) = path.parent() {
             std::fs::create_dir_all(parent)?;
         }
-        let yaml = serde_yaml::to_string(self).map_err(|e| AoError::Yaml(e.to_string()))?;
+        let mut to_write = self.clone();
+        if to_write.schema_url.as_deref().map_or(true, str::is_empty) {
+            to_write.schema_url = Some(SCHEMA_URL.to_string());
+        }
+        let yaml = serde_yaml::to_string(&to_write).map_err(|e| AoError::Yaml(e.to_string()))?;
         std::fs::write(path, yaml)?;
         Ok(())
     }
@@ -784,6 +807,7 @@ notification-routing:
         );
 
         let config = AoConfig {
+            schema_url: None,
             port: project::default_port(),
             ready_threshold_ms: project::default_ready_threshold_ms(),
             poll_interval: project::default_poll_interval_secs(),
@@ -818,6 +842,7 @@ notification-routing:
     fn save_to_writes_valid_yaml() {
         let path = unique_temp_file("save-to");
         let config = AoConfig {
+            schema_url: None,
             port: project::default_port(),
             ready_threshold_ms: project::default_ready_threshold_ms(),
             poll_interval: project::default_poll_interval_secs(),
@@ -834,7 +859,48 @@ notification-routing:
         config.save_to(&path).unwrap();
 
         let loaded = AoConfig::load_from(&path).unwrap();
-        assert_eq!(config, loaded);
+        // save_to injects $schema; loaded config will have schema_url set.
+        let mut expected = config.clone();
+        expected.schema_url = Some(SCHEMA_URL.to_string());
+        assert_eq!(expected, loaded);
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_to_injects_schema_url() {
+        let path = unique_temp_file("schema-inject");
+        let config = AoConfig::default();
+        config.save_to(&path).unwrap();
+
+        let yaml = std::fs::read_to_string(&path).unwrap();
+        assert!(
+            yaml.contains("$schema:"),
+            "saved YAML must contain $schema key"
+        );
+        assert!(
+            yaml.contains(SCHEMA_URL),
+            "saved YAML must contain canonical schema URL"
+        );
+
+        let loaded = AoConfig::load_from(&path).unwrap();
+        assert_eq!(loaded.schema_url.as_deref(), Some(SCHEMA_URL));
+        let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn save_to_preserves_existing_schema_url() {
+        let path = unique_temp_file("schema-preserve");
+        let custom_url = "https://example.com/my-schema.json";
+        let mut config = AoConfig::default();
+        config.schema_url = Some(custom_url.to_string());
+        config.save_to(&path).unwrap();
+
+        let loaded = AoConfig::load_from(&path).unwrap();
+        assert_eq!(
+            loaded.schema_url.as_deref(),
+            Some(custom_url),
+            "custom schema URL must not be overwritten"
+        );
         let _ = std::fs::remove_file(&path);
     }
 
@@ -912,5 +978,54 @@ projects:
             "expected deserialization error for typo, got: {msg}"
         );
         let _ = std::fs::remove_file(&path);
+    }
+
+    #[test]
+    fn schema_file_matches_aconfig_derive() {
+        let schema = schemars::schema_for!(AoConfig);
+        let generated = serde_json::to_string_pretty(&schema).unwrap();
+
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap();
+        let schema_path = workspace_root.join("schema/ao-rs.schema.json");
+
+        if !schema_path.exists() {
+            panic!(
+                "schema/ao-rs.schema.json not found at {}.\n\
+                 Run: cargo t -p ao-core config::schema_regenerate_committed_file",
+                schema_path.display()
+            );
+        }
+
+        let committed = std::fs::read_to_string(&schema_path).unwrap();
+        assert_eq!(
+            generated.trim(),
+            committed.trim(),
+            "schema/ao-rs.schema.json is out of date.\n\
+             Run the `schema_regenerate_committed_file` test with UPDATE_SCHEMA=1 to regenerate:\n\
+             UPDATE_SCHEMA=1 cargo t -p ao-core config::schema_regenerate_committed_file"
+        );
+    }
+
+    /// Not a real test — run with `UPDATE_SCHEMA=1` to regenerate the schema file.
+    #[test]
+    fn schema_regenerate_committed_file() {
+        if std::env::var("UPDATE_SCHEMA").unwrap_or_default() != "1" {
+            return;
+        }
+        let schema = schemars::schema_for!(AoConfig);
+        let generated = serde_json::to_string_pretty(&schema).unwrap();
+
+        let workspace_root = std::path::Path::new(env!("CARGO_MANIFEST_DIR"))
+            .join("../..")
+            .canonicalize()
+            .unwrap();
+        let schema_dir = workspace_root.join("schema");
+        std::fs::create_dir_all(&schema_dir).unwrap();
+        let schema_path = schema_dir.join("ao-rs.schema.json");
+        std::fs::write(&schema_path, format!("{generated}\n")).unwrap();
+        println!("wrote {}", schema_path.display());
     }
 }

--- a/crates/ao-core/src/config/power.rs
+++ b/crates/ao-core/src/config/power.rs
@@ -2,6 +2,7 @@
 //! `PluginConfig`, `DefaultsConfig`, and `RoleAgentConfig`.
 
 use super::agent::{default_orchestrator_rules, AgentConfig};
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -35,7 +36,7 @@ fn default_prevent_idle_sleep() -> bool {
 /// behaviour (`enabled: webhook?.enabled !== false`). A zero-value
 /// `Default` would silently disable webhooks for anyone constructing
 /// this struct in Rust, which is the opposite of what the YAML path does.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ScmWebhookConfig {
     #[serde(default = "default_true", skip_serializing_if = "is_true")]
     pub enabled: bool,
@@ -93,7 +94,7 @@ impl Default for ScmWebhookConfig {
 }
 
 /// Shared plugin config shape (tracker/scm/notifier). Allows arbitrary extra keys.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PluginConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub plugin: Option<String>,
@@ -105,11 +106,12 @@ pub struct PluginConfig {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub webhook: Option<ScmWebhookConfig>,
     #[serde(flatten, default)]
+    #[schemars(skip)]
     pub extra: HashMap<String, serde_yaml::Value>,
 }
 
 /// Power management settings (TS: `power.preventIdleSleep`).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct PowerConfig {
     #[serde(
         default = "default_prevent_idle_sleep",
@@ -128,7 +130,7 @@ impl Default for PowerConfig {
 }
 
 /// Per-role agent config (TS `orchestrator` / `worker` blocks).
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct RoleAgentConfig {
     /// Override the agent plugin for this role (e.g. "claude-code", "codex", ...).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -145,7 +147,7 @@ pub struct RoleAgentConfig {
 }
 
 /// Orchestrator-wide defaults for plugin selection.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct DefaultsConfig {
     #[serde(default = "default_runtime")]
     pub runtime: String,

--- a/crates/ao-core/src/config/project.rs
+++ b/crates/ao-core/src/config/project.rs
@@ -11,6 +11,7 @@ use crate::{
     parity_session_strategy::{OpencodeIssueSessionStrategy, OrchestratorSessionStrategy},
     reactions::ReactionConfig,
 };
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{collections::HashMap, path::Path};
 
@@ -29,7 +30,7 @@ pub(super) fn default_poll_interval_secs() -> u64 {
 }
 
 /// Per-project configuration.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ProjectConfig {
     /// Friendly display name (TS: `name`).
     #[serde(default, skip_serializing_if = "Option::is_none")]
@@ -265,6 +266,7 @@ pub fn generate_config(cwd: &Path) -> Result<super::AoConfig> {
     );
 
     Ok(super::AoConfig {
+        schema_url: None,
         port: default_port(),
         ready_threshold_ms: default_ready_threshold_ms(),
         poll_interval: default_poll_interval_secs(),
@@ -434,6 +436,7 @@ mod tests {
                 },
             );
             AoConfig {
+                schema_url: None,
                 port: default_port(),
                 ready_threshold_ms: default_ready_threshold_ms(),
                 poll_interval: default_poll_interval_secs(),

--- a/crates/ao-core/src/notifier.rs
+++ b/crates/ao-core/src/notifier.rs
@@ -38,6 +38,7 @@ use crate::{
     types::SessionId,
 };
 use async_trait::async_trait;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 use std::{
     collections::{HashMap, HashSet},
@@ -195,7 +196,7 @@ pub trait Notifier: Send + Sync {
 /// (default-to-stdout when the table is empty) belongs one layer up
 /// at the `ao-cli` wiring site in Phase C, not inside the config
 /// type itself, so this module stays pure data.
-#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Default, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(transparent)]
 pub struct NotificationRouting(HashMap<EventPriority, Vec<String>>);
 

--- a/crates/ao-core/src/orchestrator_prompt.rs
+++ b/crates/ao-core/src/orchestrator_prompt.rs
@@ -313,6 +313,7 @@ mod tests {
 
     fn base_config() -> AoConfig {
         AoConfig {
+            schema_url: None,
             port: 3000,
             ready_threshold_ms: 300_000,
             poll_interval: 10,

--- a/crates/ao-core/src/parity_session_strategy.rs
+++ b/crates/ao-core/src/parity_session_strategy.rs
@@ -10,9 +10,10 @@
 //! its own strategy logic and does not call it. See
 //! `docs/ts-core-parity-report.md` → "Parity-only modules".
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum OrchestratorSessionStrategy {
     Reuse,
@@ -23,7 +24,7 @@ pub enum OrchestratorSessionStrategy {
     KillPrevious,
 }
 
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum OpencodeIssueSessionStrategy {
     Reuse,

--- a/crates/ao-core/src/reactions.rs
+++ b/crates/ao-core/src/reactions.rs
@@ -29,12 +29,13 @@
 //!   question to when we have a concrete use site.
 
 use crate::scm::MergeMethod;
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 /// What a reaction should actually do when it fires. Matches the TS
 /// union `"send-to-agent" | "notify" | "auto-merge"` — kebab-case on the
 /// wire so TS config files round-trip unchanged.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "kebab-case")]
 pub enum ReactionAction {
     /// Send a message to the agent, asking it to fix whatever broke.
@@ -68,7 +69,7 @@ impl std::fmt::Display for ReactionAction {
 
 /// Notification priority. Matches TS's four-value union verbatim so a
 /// TS `notificationRouting` table could be ported later without a rename.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum EventPriority {
     /// "Wake someone up." Paged/SMS-class.
@@ -132,7 +133,7 @@ pub fn default_priority_for_reaction_key(reaction_key: &str) -> EventPriority {
 /// Serde resolves the variants in order at parse time — `Attempts` is
 /// listed first, so a bare YAML number always goes there. Anything else
 /// falls through to `Duration`.
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 #[serde(untagged)]
 pub enum EscalateAfter {
     /// Retry `send-to-agent` this many times, then escalate to `notify`.
@@ -160,7 +161,7 @@ pub enum EscalateAfter {
 ///
 /// Everything else — retries, escalation, priority — falls back to a
 /// value the engine considers "reasonable for hobby use".
-#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
 pub struct ReactionConfig {
     /// Master on/off. `false` means the engine sees the reaction key but
     /// does nothing; useful for disabling individual rules without

--- a/crates/ao-core/src/scm.rs
+++ b/crates/ao-core/src/scm.rs
@@ -17,6 +17,7 @@
 //! These types are consumed by `Scm` and `Tracker` in `traits.rs`, and later
 //! by the reaction engine in `reactions.rs`.
 
+use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 // =============================================================================
@@ -67,7 +68,7 @@ pub enum PrState {
 /// key (see `ReactionConfig::merge_method`) or the project-level override.
 /// The decision record lives at
 /// `docs/plans/remaining-to-port/7-4-default-merge-method.md`.
-#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash, Serialize, Deserialize, Default, JsonSchema)]
 #[serde(rename_all = "snake_case")]
 pub enum MergeMethod {
     /// Default merge commit. Safe, preserves history.

--- a/schema/ao-rs.schema.json
+++ b/schema/ao-rs.schema.json
@@ -1,0 +1,725 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "AoConfig",
+  "description": "Top-level ao-rs config file shape. All fields use `#[serde(default)]` so partial config files parse without error.",
+  "type": "object",
+  "properties": {
+    "$schema": {
+      "description": "JSON Schema URL for editor IntelliSense/validation.",
+      "type": [
+        "string",
+        "null"
+      ]
+    },
+    "defaults": {
+      "description": "Orchestrator-wide plugin defaults.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/DefaultsConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "directTerminalPort": {
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "notification_routing": {
+      "description": "Priority-based notification routing table.",
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        }
+      }
+    },
+    "notifiers": {
+      "description": "Notifier plugin configurations (TS: `notifiers`).",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/PluginConfig"
+      }
+    },
+    "poll_interval": {
+      "description": "Lifecycle polling interval in seconds (default 10).",
+      "default": 10,
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "port": {
+      "description": "Dashboard port (TS: `port`).",
+      "default": 3000,
+      "type": "integer",
+      "format": "uint16",
+      "minimum": 0.0
+    },
+    "power": {
+      "description": "Power management settings.",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/PowerConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
+    "projects": {
+      "description": "Per-project configs keyed by project id.",
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ProjectConfig"
+      }
+    },
+    "reactions": {
+      "description": "Map from reaction key (e.g. `\"ci-failed\"`) to its config.",
+      "default": {},
+      "type": "object",
+      "additionalProperties": {
+        "$ref": "#/definitions/ReactionConfig"
+      }
+    },
+    "ready_threshold_ms": {
+      "description": "Milliseconds before a \"ready\" session becomes \"idle\" (TS: `readyThresholdMs`, default 300000).",
+      "default": 300000,
+      "type": "integer",
+      "format": "uint64",
+      "minimum": 0.0
+    },
+    "terminalPort": {
+      "description": "Terminal server ports (TS: `terminalPort`, `directTerminalPort`).",
+      "type": [
+        "integer",
+        "null"
+      ],
+      "format": "uint16",
+      "minimum": 0.0
+    }
+  },
+  "definitions": {
+    "AgentConfig": {
+      "description": "Agent-level overrides per project.",
+      "type": "object",
+      "properties": {
+        "model": {
+          "description": "Model override (TS: `agentConfig.model`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "opencodeSessionId": {
+          "description": "OpenCode session id (TS: `agentConfig.opencodeSessionId`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orchestratorModel": {
+          "description": "Orchestrator model override (TS: `agentConfig.orchestratorModel`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "permissions": {
+          "description": "Permission mode: permissionless, default, auto-edit, suggest.",
+          "default": "permissionless",
+          "allOf": [
+            {
+              "$ref": "#/definitions/PermissionsMode"
+            }
+          ]
+        },
+        "rules": {
+          "description": "System prompt rules appended via `--append-system-prompt`. Structured workflow instructions (dev-lifecycle phases, testing requirements, coding standards) that guide the agent's behavior.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "rules_file": {
+          "description": "Path to an external rules file (relative to project path). Takes precedence over inline `rules` if both are set.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "DefaultsConfig": {
+      "description": "Orchestrator-wide defaults for plugin selection.",
+      "type": "object",
+      "properties": {
+        "agent": {
+          "default": "claude-code",
+          "type": "string"
+        },
+        "branch_namespace": {
+          "description": "Optional branch namespace/prefix for agent-created worktree branches.\n\nIf set, `ao-rs spawn` will create branches like: - `<branch_namespace>/<short_id>` (task-first) - `<branch_namespace>/<short_id>/<issue_branch>` (issue-first)\n\nExample: `ao/agent/5c452025/feat-issue-30`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "notifiers": {
+          "default": [],
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "orchestrator": {
+          "description": "Role defaults (TS: `defaults.orchestrator`, `defaults.worker`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoleAgentConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "orchestrator_rules": {
+          "description": "Default system rules for the orchestrator session (TS: `defaults.orchestratorRules`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "runtime": {
+          "default": "tmux",
+          "type": "string"
+        },
+        "tracker": {
+          "default": "github",
+          "type": "string"
+        },
+        "worker": {
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoleAgentConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "workspace": {
+          "default": "worktree",
+          "type": "string"
+        }
+      }
+    },
+    "EscalateAfter": {
+      "description": "How long/how many attempts before a reaction escalates from `SendToAgent` → `Notify`. Untagged so YAML can use a bare number *or* a bare duration string:\n\n```yaml ci-failed: escalate-after: 3       # after 3 failed send attempts agent-stuck: escalate-after: 10m     # after 10 minutes of no progress ```\n\nSerde resolves the variants in order at parse time — `Attempts` is listed first, so a bare YAML number always goes there. Anything else falls through to `Duration`.",
+      "anyOf": [
+        {
+          "description": "Retry `send-to-agent` this many times, then escalate to `notify`.",
+          "type": "integer",
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        {
+          "description": "Wait this long after the first attempt before escalating. String form matching the TS regex `^\\d+(s|m|h)$` — e.g. `\"30s\"`, `\"10m\"`, `\"2h\"`. Compound or fractional forms (`\"1h30m\"`, `\"1.5m\"`) are rejected. Parsed lazily by `parse_duration` on each dispatch so a misconfigured value only logs once and does not poison the engine.",
+          "type": "string"
+        }
+      ]
+    },
+    "EventPriority": {
+      "description": "Notification priority. Matches TS's four-value union verbatim so a TS `notificationRouting` table could be ported later without a rename.",
+      "oneOf": [
+        {
+          "description": "\"Wake someone up.\" Paged/SMS-class.",
+          "type": "string",
+          "enum": [
+            "urgent"
+          ]
+        },
+        {
+          "description": "\"Needs human action soon.\" Default for send-to-agent failures.",
+          "type": "string",
+          "enum": [
+            "action"
+          ]
+        },
+        {
+          "description": "\"Something's off, check when you can.\" Fallback for unknown reaction keys.",
+          "type": "string",
+          "enum": [
+            "warning"
+          ]
+        },
+        {
+          "description": "\"FYI.\" Default for `approved-and-green` notifications.",
+          "type": "string",
+          "enum": [
+            "info"
+          ]
+        }
+      ]
+    },
+    "MergeMethod": {
+      "description": "How to merge a PR. Mirrors GitHub's three merge methods exactly.\n\n**Parity note (issue #109):** the default (`Merge`) diverges intentionally from the ao-ts reference, which defaults to `Squash`. Squash rewrites commit history, so ao-rs picks the safer default and asks users to opt into squash/rebase explicitly via the reaction config's `merge_method:` key (see `ReactionConfig::merge_method`) or the project-level override. The decision record lives at `docs/plans/remaining-to-port/7-4-default-merge-method.md`.",
+      "oneOf": [
+        {
+          "type": "string",
+          "enum": [
+            "squash",
+            "rebase"
+          ]
+        },
+        {
+          "description": "Default merge commit. Safe, preserves history.",
+          "type": "string",
+          "enum": [
+            "merge"
+          ]
+        }
+      ]
+    },
+    "OpencodeIssueSessionStrategy": {
+      "type": "string",
+      "enum": [
+        "reuse",
+        "delete",
+        "ignore"
+      ]
+    },
+    "OrchestratorSessionStrategy": {
+      "type": "string",
+      "enum": [
+        "reuse",
+        "delete",
+        "ignore",
+        "delete-new",
+        "ignore-new",
+        "kill-previous"
+      ]
+    },
+    "PermissionsMode": {
+      "description": "Permission mode for agent execution.\n\nStrict serde deserialization — unknown values fail at load time (TS parity: M4).",
+      "type": "string",
+      "enum": [
+        "permissionless",
+        "default",
+        "auto-edit",
+        "suggest"
+      ]
+    },
+    "PluginConfig": {
+      "description": "Shared plugin config shape (tracker/scm/notifier). Allows arbitrary extra keys.",
+      "type": "object",
+      "properties": {
+        "package": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "plugin": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "webhook": {
+          "description": "SCM-only: webhook configuration (TS: `scm.webhook`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/ScmWebhookConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "PowerConfig": {
+      "description": "Power management settings (TS: `power.preventIdleSleep`).",
+      "type": "object",
+      "properties": {
+        "preventIdleSleep": {
+          "default": true,
+          "type": "boolean"
+        }
+      }
+    },
+    "ProjectConfig": {
+      "description": "Per-project configuration.",
+      "type": "object",
+      "required": [
+        "path",
+        "repo"
+      ],
+      "properties": {
+        "agent": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "agent_config": {
+          "description": "Agent-specific overrides.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AgentConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "agent_rules": {
+          "description": "Inline rules/instructions passed to every agent prompt (TS: `agentRules`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "agent_rules_file": {
+          "description": "Path to a file containing agent rules, relative to project path (TS: `agentRulesFile`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "branch_namespace": {
+          "description": "Optional per-project override for branch namespace/prefix. See `defaults.branch_namespace`.",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "default_branch": {
+          "description": "Default branch to use as worktree base.",
+          "default": "main",
+          "type": "string"
+        },
+        "name": {
+          "description": "Friendly display name (TS: `name`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "opencode_issue_session_strategy": {
+          "description": "Strategy for handling existing opencode issue sessions (TS: `opencodeIssueSessionStrategy`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OpencodeIssueSessionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "orchestrator": {
+          "description": "Role overrides for the orchestrator agent (TS: `projects.<id>.orchestrator`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoleAgentConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "orchestrator_rules": {
+          "description": "System rules for the orchestrator session (TS: `orchestratorRules`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "orchestrator_session_strategy": {
+          "description": "Strategy for handling existing orchestrator sessions (TS: `orchestratorSessionStrategy`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/OrchestratorSessionStrategy"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "path": {
+          "description": "Absolute path on disk.",
+          "type": "string"
+        },
+        "postCreate": {
+          "description": "Commands to run after workspace creation (TS: `postCreate`).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "reactions": {
+          "description": "Per-project reaction overrides (TS: `projects.*.reactions`).",
+          "type": "object",
+          "additionalProperties": {
+            "$ref": "#/definitions/ReactionConfig"
+          }
+        },
+        "repo": {
+          "description": "GitHub-style `owner/repo`.",
+          "type": "string"
+        },
+        "runtime": {
+          "description": "Per-project plugin overrides (TS: `runtime`, `agent`, `workspace`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "scm": {
+          "description": "SCM config (TS: `scm`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PluginConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "sessionPrefix": {
+          "description": "Session prefix (TS: `sessionPrefix`).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "symlinks": {
+          "description": "Files to symlink into workspaces (TS: `symlinks`).",
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "tracker": {
+          "description": "Issue tracker plugin for `spawn --issue` (\"github\", \"linear\", ...).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/PluginConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "worker": {
+          "description": "Role overrides for worker agents (TS: `projects.<id>.worker`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/RoleAgentConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "workspace": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "ReactionAction": {
+      "description": "What a reaction should actually do when it fires. Matches the TS union `\"send-to-agent\" | \"notify\" | \"auto-merge\"` — kebab-case on the wire so TS config files round-trip unchanged.",
+      "oneOf": [
+        {
+          "description": "Send a message to the agent, asking it to fix whatever broke. Uses `ReactionConfig::message` as the payload.",
+          "type": "string",
+          "enum": [
+            "send-to-agent"
+          ]
+        },
+        {
+          "description": "Fire a notification at a human (stdout, Slack, desktop, …).",
+          "type": "string",
+          "enum": [
+            "notify"
+          ]
+        },
+        {
+          "description": "Merge the PR. Only makes sense for `approved-and-green`.",
+          "type": "string",
+          "enum": [
+            "auto-merge"
+          ]
+        }
+      ]
+    },
+    "ReactionConfig": {
+      "description": "A single reaction rule, typically read from `~/.ao-rs/config.yaml` under `reactions.<key>`. See `docs/reactions.md` for the full list of reaction keys and the matrix of which actions make sense for each.\n\nAll fields except `action` have sensible defaults, so the minimal valid config is one line:\n\n```yaml approved-and-green: action: notify ```\n\nEverything else — retries, escalation, priority — falls back to a value the engine considers \"reasonable for hobby use\".",
+      "type": "object",
+      "required": [
+        "action"
+      ],
+      "properties": {
+        "action": {
+          "description": "What to do when the reaction fires. No default — you have to pick.",
+          "allOf": [
+            {
+              "$ref": "#/definitions/ReactionAction"
+            }
+          ]
+        },
+        "auto": {
+          "description": "Master on/off. `false` means the engine sees the reaction key but does nothing; useful for disabling individual rules without deleting them. Defaults to `true` so newly-added rules are live.\n\nWe skip serializing when `true` so a round-tripped config stays terse: the common case (enabled) doesn't clutter the output. Pair with `include_summary` below — both default-valued fields omit on write so a user who hand-edited a minimal config reads back a minimal config.",
+          "type": "boolean"
+        },
+        "escalate_after": {
+          "description": "Escalate after N attempts or after a wall-clock duration, whichever the user configured. Absent means \"use `retries` as the only gate\".",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EscalateAfter"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "include_summary": {
+          "description": "Whether to attach a context summary to the notification. Defaults to `false` because the engine doesn't yet know how to produce one; Phase D might flip the default.",
+          "type": "boolean"
+        },
+        "merge_method": {
+          "description": "Merge method to use when `action: auto-merge`. If unset, the SCM plugin's default is used.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/MergeMethod"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "message": {
+          "description": "Body for `SendToAgent`, override text for `Notify`. Ignored by `AutoMerge`. Missing for `SendToAgent` falls back to an engine-supplied boilerplate (Phase D).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "priority": {
+          "description": "Priority for the resulting notification. Defaults to the reaction-key-specific default the engine picks (see `docs/reactions.md`).",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/EventPriority"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        },
+        "retries": {
+          "description": "Max attempts of `SendToAgent` before escalating to `Notify`. `None` means \"retry forever\", matching TS.",
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint32",
+          "minimum": 0.0
+        },
+        "threshold": {
+          "description": "Duration threshold for time-based triggers (e.g. `\"10m\"` for `agent-stuck`). Kept as an opaque string until Phase D adds a parser.",
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    },
+    "RoleAgentConfig": {
+      "description": "Per-role agent config (TS `orchestrator` / `worker` blocks).",
+      "type": "object",
+      "properties": {
+        "agent": {
+          "description": "Override the agent plugin for this role (e.g. \"claude-code\", \"codex\", ...).",
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "agent_config": {
+          "description": "Role-specific agent config overrides.",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/AgentConfig"
+            },
+            {
+              "type": "null"
+            }
+          ]
+        }
+      }
+    },
+    "ScmWebhookConfig": {
+      "description": "SCM webhook configuration (TS: `SCMWebhookConfig`).\n\n`Default` sets `enabled = true`, matching the serde default and TS behaviour (`enabled: webhook?.enabled !== false`). A zero-value `Default` would silently disable webhooks for anyone constructing this struct in Rust, which is the opposite of what the YAML path does.",
+      "type": "object",
+      "properties": {
+        "deliveryHeader": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "enabled": {
+          "type": "boolean"
+        },
+        "eventHeader": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "maxBodyBytes": {
+          "type": [
+            "integer",
+            "null"
+          ],
+          "format": "uint64",
+          "minimum": 0.0
+        },
+        "path": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "secretEnvVar": {
+          "type": [
+            "string",
+            "null"
+          ]
+        },
+        "signatureHeader": {
+          "type": [
+            "string",
+            "null"
+          ]
+        }
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- Add `schemars 0.8` to workspace; derive `JsonSchema` on all `AoConfig`-reachable types across `config/`, `reactions.rs`, `notifier.rs`, `scm.rs`, `parity_session_strategy.rs`
- Add optional `$schema` field (Rust name `schema_url`) to `AoConfig` with `SCHEMA_URL` constant pointing at the committed raw-GitHub schema URL
- `save_to()` now stamps `$schema:` automatically — idempotent (preserves non-empty existing values; replaces absent/blank with canonical URL)
- Commit `schema/ao-rs.schema.json` (21.8 KB, JSON Schema draft-07, generated from `AoConfig` via schemars)
- Add `schema_file_matches_aconfig_derive` drift-detection test that fails when the committed schema is stale
- Add `schema_regenerate_committed_file` helper test (run with `UPDATE_SCHEMA=1` to regenerate)

## How to use

VS Code with the YAML extension will pick up the schema automatically once `$schema:` is present in `ao-rs.yaml`. Any file written by `ao-rs init` or `ao-rs save` will include it.

To regenerate the schema after changing `AoConfig`:
```
UPDATE_SCHEMA=1 cargo t -p ao-core -- config::tests::schema_regenerate_committed_file
```

## Test plan

- [x] `cargo t -p ao-core -- config::tests::schema_file_matches_aconfig_derive` — drift detection passes
- [x] `cargo t -p ao-core -- config::tests::save_to_injects_schema_url` — injection works
- [x] `cargo t -p ao-core -- config::tests::save_to_preserves_existing_schema_url` — idempotency works
- [x] `cargo t --workspace --no-fail-fast` — 872/873 pass (1 pre-existing failure in `ao-plugin-agent-claude-code` unrelated to this PR)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] `cargo test --doc --workspace` — clean

Ports upstream agent-orchestrator PR #1373.

🤖 Generated with [Claude Code](https://claude.com/claude-code)