### PR TITLE
fix(ui): prevent kanban card blink on attention-level column changes (#217)

### DIFF
--- a/crates/ao-desktop/ui/src/components/SessionCard.test.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionCard.test.tsx
@@ -1,0 +1,84 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { cleanup, render } from "@testing-library/react";
+import { SessionCard, _clearEnteredSessionIds } from "./SessionCard";
+import type { DashboardSession } from "../lib/types";
+
+function makeSession(id: string, overrides: Partial<DashboardSession> = {}): DashboardSession {
+  return {
+    id,
+    projectId: "test-proj",
+    status: "active",
+    activity: "active",
+    agent: null,
+    branch: null,
+    summary: null,
+    summaryIsFallback: false,
+    issueTitle: null,
+    issueId: null,
+    issueUrl: null,
+    userPrompt: null,
+    pr: null,
+    claimedPrNumber: null,
+    claimedPrUrl: null,
+    attentionLevel: null,
+    metadata: {},
+    spawnedBy: null,
+    createdAt: null,
+    ...overrides,
+  };
+}
+
+describe("SessionCard entrance animation", () => {
+  let rafCallbacks: FrameRequestCallback[] = [];
+
+  beforeEach(() => {
+    _clearEnteredSessionIds();
+    rafCallbacks = [];
+    vi.spyOn(window, "requestAnimationFrame").mockImplementation((cb) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    });
+    vi.spyOn(window, "cancelAnimationFrame").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("applies card-enter class on first mount", () => {
+    const session = makeSession("sess-001");
+    const { container } = render(<SessionCard session={session} />);
+    const card = container.querySelector(".card");
+    expect(card?.classList.contains("card-enter")).toBe(true);
+  });
+
+  it("omits card-enter class when session already entered (remount after column change)", () => {
+    const session = makeSession("sess-002");
+
+    // First mount — rAF fires, registering the session
+    const { unmount } = render(<SessionCard session={session} />);
+    rafCallbacks.forEach((cb) => cb(0));
+    unmount();
+    cleanup();
+
+    // Remount (simulates column change causing React key to remount)
+    const { container } = render(<SessionCard session={session} />);
+    const card = container.querySelector(".card");
+    expect(card?.classList.contains("card-enter")).toBe(false);
+  });
+
+  it("cancels rAF registration when component unmounts before first paint", () => {
+    const session = makeSession("sess-003");
+    const { unmount } = render(<SessionCard session={session} />);
+    // Unmount before rAF fires — session should NOT be registered
+    unmount();
+    expect(window.cancelAnimationFrame).toHaveBeenCalled();
+
+    // rAF callback never ran, so re-render should still get card-enter
+    cleanup();
+    const { container } = render(<SessionCard session={session} />);
+    const card = container.querySelector(".card");
+    expect(card?.classList.contains("card-enter")).toBe(true);
+  });
+});

--- a/crates/ao-desktop/ui/src/components/SessionCard.tsx
+++ b/crates/ao-desktop/ui/src/components/SessionCard.tsx
@@ -1,10 +1,18 @@
-import { memo, useState, type CSSProperties, type KeyboardEvent, type MouseEvent } from "react";
+import { memo, useEffect, useState, type CSSProperties, type KeyboardEvent, type MouseEvent } from "react";
 import type { DashboardSession } from "../lib/types";
 import { getDashboardLane, isTerminalSession } from "../lib/types";
 import { formatCiStatus, formatReviewDecision, getSessionTitle } from "../lib/format";
 import { cn } from "../lib/cn";
 import { projectAccentStyle } from "../lib/projectColors";
 import { ConfirmModal } from "./ConfirmModal";
+
+// Tracks sessions that have already played their entrance animation. Module-scoped
+// so it survives component unmount/remount (e.g. when attention-level changes column).
+const enteredSessionIds = new Set<string>();
+
+export function _clearEnteredSessionIds() {
+  enteredSessionIds.clear();
+}
 
 interface SessionCardProps {
   session: DashboardSession;
@@ -49,6 +57,7 @@ function SessionCardView({ session, onClick, onOpen, onRestore, onSendMessage, o
   const pr = session.pr;
   const terminal = isTerminalSession(session);
   const restorable = terminal && (session.status ?? "").toLowerCase() !== "merged";
+  const [hasEntered] = useState(() => enteredSessionIds.has(session.id));
   const [restoring, setRestoring] = useState(false);
   const [respondReply, setRespondReply] = useState("");
   const [sending, setSending] = useState(false);
@@ -56,6 +65,14 @@ function SessionCardView({ session, onClick, onOpen, onRestore, onSendMessage, o
   const [confirmDeleteOpen, setConfirmDeleteOpen] = useState(false);
   const [merging, setMerging] = useState(false);
   const projectAccent = projectAccentStyle(session.projectId);
+
+  useEffect(() => {
+    if (hasEntered) return;
+    const frameId = window.requestAnimationFrame(() => {
+      enteredSessionIds.add(session.id);
+    });
+    return () => { window.cancelAnimationFrame(frameId); };
+  }, [hasEntered, session.id]);
 
   const ci = pr?.ciStatus ? formatCiStatus(pr.ciStatus) : null;
   const review = pr?.reviewDecision ? formatReviewDecision(pr.reviewDecision) : null;
@@ -140,7 +157,7 @@ function SessionCardView({ session, onClick, onOpen, onRestore, onSendMessage, o
         onConfirm={() => void doDelete()}
       />
       <div
-        className={cn("card")}
+        className={cn("card", !hasEntered && "card-enter")}
         data-tone={tone}
         data-level={lane}
         role="button"

--- a/crates/ao-desktop/ui/styles.css
+++ b/crates/ao-desktop/ui/styles.css
@@ -415,6 +415,19 @@ button { cursor: pointer; }
 .card[data-tone="done"]  { opacity: 0.7; }
 .card[data-tone="done"]:hover { opacity: 1; }
 
+.card-enter {
+  animation: card-enter 0.2s cubic-bezier(0.16, 1, 0.3, 1) both;
+}
+.col__body .card-enter:nth-child(1) { animation-delay: 0ms; }
+.col__body .card-enter:nth-child(2) { animation-delay: 40ms; }
+.col__body .card-enter:nth-child(3) { animation-delay: 80ms; }
+.col__body .card-enter:nth-child(4) { animation-delay: 120ms; }
+.col__body .card-enter:nth-child(5) { animation-delay: 160ms; }
+@keyframes card-enter {
+  from { opacity: 0; transform: translateY(8px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
 .card__head {
   display: flex;
   align-items: center;


### PR DESCRIPTION
Closes #217

## Summary

- Add module-scoped `enteredSessionIds: Set<string>` in `SessionCard.tsx` — survives component unmount/remount
- `hasEntered` initialised lazily via `useState(() => enteredSessionIds.has(session.id))`: true if the session has already played its entrance animation
- `useEffect` registers the session id via `requestAnimationFrame` after first paint; cleanup cancels the rAF so a component that unmounts before first paint is not registered (re-mount still gets the animation)
- `.card-enter` CSS class applied only when `!hasEntered`, so column changes that unmount/remount the card skip the animation entirely — no flash
- `@keyframes card-enter` (200ms cubic-bezier slide-up) + stagger delays for up to 5 cards in `.col__body`

Port of upstream agent-orchestrator#1450.

## Test plan

- [ ] All 75 existing UI tests pass
- [ ] 3 new tests in `SessionCard.test.tsx`:
  - First mount gets `card-enter` class
  - Remount after rAF fires omits `card-enter` class
  - Unmount before rAF fires cancels registration; re-render still gets animation
- [ ] TypeScript `--noEmit` clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)