### PR TITLE
feat(core): auto-terminate sessions on PR merge (#220)

### DIFF
--- a/crates/ao-cli/src/tests.rs
+++ b/crates/ao-cli/src/tests.rs
@@ -618,6 +618,7 @@ fn spawn_resolves_project_id_from_ao_rs_yaml_by_matching_repo_path() {
         reactions: HashMap::new(),
         notification_routing: Default::default(),
         notifiers: HashMap::new(),
+        lifecycle: None,
         plugins: vec![],
     };
 

--- a/crates/ao-core/src/config/lifecycle.rs
+++ b/crates/ao-core/src/config/lifecycle.rs
@@ -1,0 +1,29 @@
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+fn default_auto_terminate_on_merge() -> bool {
+    true
+}
+
+/// Lifecycle automation settings (TS: `LifecycleConfig`).
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+pub struct LifecycleConfig {
+    /// Auto-terminate sessions when their PR merges (default: `true`).
+    ///
+    /// When enabled, the runtime (tmux) and worktree are destroyed within
+    /// one tick of the PR state transitioning to `merged`. Set to `false`
+    /// to opt out and manage session lifetimes manually.
+    #[serde(
+        default = "default_auto_terminate_on_merge",
+        alias = "autoTerminateOnMerge"
+    )]
+    pub auto_terminate_on_merge: bool,
+}
+
+impl Default for LifecycleConfig {
+    fn default() -> Self {
+        Self {
+            auto_terminate_on_merge: true,
+        }
+    }
+}

--- a/crates/ao-core/src/config/mod.rs
+++ b/crates/ao-core/src/config/mod.rs
@@ -11,6 +11,7 @@
 //! first. Parse errors propagate — a broken config needs to be fixed.
 
 pub mod agent;
+pub mod lifecycle;
 pub mod power;
 pub mod project;
 pub mod reactions;
@@ -18,6 +19,7 @@ pub mod reactions;
 pub use agent::{
     default_agent_rules, default_orchestrator_rules, install_skills, AgentConfig, PermissionsMode,
 };
+pub use lifecycle::LifecycleConfig;
 pub use power::{DefaultsConfig, PluginConfig, PowerConfig, RoleAgentConfig, ScmWebhookConfig};
 pub use project::{detect_git_repo, generate_config, ProjectConfig};
 pub use reactions::{default_reactions, default_routing};
@@ -287,6 +289,10 @@ pub struct AoConfig {
     #[serde(default, skip_serializing_if = "HashMap::is_empty")]
     pub notifiers: HashMap<String, PluginConfig>,
 
+    /// Lifecycle automation settings (auto-terminate on merge, etc.).
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub lifecycle: Option<LifecycleConfig>,
+
     /// External plugins list (installer-managed). Currently stored for parity only.
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     #[schemars(skip)]
@@ -308,6 +314,7 @@ impl Default for AoConfig {
             reactions: HashMap::new(),
             notification_routing: Default::default(),
             notifiers: HashMap::new(),
+            lifecycle: None,
             plugins: vec![],
         }
     }
@@ -819,6 +826,7 @@ notification-routing:
             reactions: default_reactions(),
             notification_routing: default_routing(),
             notifiers: HashMap::new(),
+            lifecycle: None,
             plugins: vec![],
         };
 
@@ -854,6 +862,7 @@ notification-routing:
             reactions: default_reactions(),
             notification_routing: default_routing(),
             notifiers: HashMap::new(),
+            lifecycle: None,
             plugins: vec![],
         };
         config.save_to(&path).unwrap();

--- a/crates/ao-core/src/config/project.rs
+++ b/crates/ao-core/src/config/project.rs
@@ -296,6 +296,7 @@ pub fn generate_config(cwd: &Path) -> Result<super::AoConfig> {
         reactions: default_reactions(),
         notification_routing: default_routing(),
         notifiers: HashMap::new(),
+        lifecycle: None,
         plugins: vec![],
     })
 }
@@ -451,6 +452,7 @@ mod tests {
                 reactions: default_reactions(),
                 notification_routing: default_routing(),
                 notifiers: HashMap::new(),
+                lifecycle: None,
                 plugins: vec![],
             }
         });

--- a/crates/ao-core/src/events.rs
+++ b/crates/ao-core/src/events.rs
@@ -149,6 +149,8 @@ pub enum TerminationReason {
     AgentExited,
     /// Session had no runtime_handle to probe (e.g. crashed before create).
     NoHandle,
+    /// Session's PR was merged; auto-terminate on merge fired (issue #220).
+    PrMerged,
 }
 
 impl TerminationReason {
@@ -157,6 +159,7 @@ impl TerminationReason {
             Self::RuntimeGone => "runtime_gone",
             Self::AgentExited => "agent_exited",
             Self::NoHandle => "no_handle",
+            Self::PrMerged => "pr_merged",
         }
     }
 }
@@ -310,6 +313,10 @@ mod tests {
         assert_eq!(
             serde_json::to_value(TerminationReason::NoHandle).unwrap(),
             json!("no_handle")
+        );
+        assert_eq!(
+            serde_json::to_value(TerminationReason::PrMerged).unwrap(),
+            json!("pr_merged")
         );
     }
 }

--- a/crates/ao-core/src/lifecycle/mod.rs
+++ b/crates/ao-core/src/lifecycle/mod.rs
@@ -34,6 +34,7 @@
 //!   `SessionManager::list` on startup and then subscribe.
 
 use crate::{
+    config::LifecycleConfig,
     dashboard_payload::{attention_level, BatchedPrEnrichment, DashboardPr},
     error::Result,
     events::{OrchestratorEvent, TerminationReason},
@@ -147,6 +148,8 @@ pub struct LifecycleManager {
     /// Per-session timestamp of the last review backlog API check.
     /// Throttles `pending_comments` calls to at most once per 2 minutes.
     pub(super) last_review_backlog_check: Mutex<HashMap<SessionId, Instant>>,
+    /// Lifecycle automation config (auto-terminate on merge, etc.).
+    pub(super) lifecycle_config: LifecycleConfig,
     /// Per-tick branch adoption reservations for `refresh_tracked_branch`.
     ///
     /// Key: `"{project_id}:{branch_name}"`. Value: the session id that reserved
@@ -189,6 +192,7 @@ impl LifecycleManager {
             reaction_engine: None,
             scm: None,
             workspace: None,
+            lifecycle_config: LifecycleConfig::default(),
             idle_since: Mutex::new(HashMap::new()),
             pr_enrichment_cache: Mutex::new(HashMap::new()),
             pr_enrichment_prev: Mutex::new(HashMap::new()),
@@ -239,6 +243,14 @@ impl LifecycleManager {
     /// poll cycle. Sessions with `workspace_path: None` are unaffected.
     pub fn with_workspace(mut self, workspace: Arc<dyn Workspace>) -> Self {
         self.workspace = Some(workspace);
+        self
+    }
+
+    /// Override lifecycle automation config (e.g. to disable auto-terminate
+    /// on merge). When not called, `LifecycleConfig::default()` is used
+    /// (auto-terminate on merge enabled).
+    pub fn with_lifecycle_config(mut self, config: LifecycleConfig) -> Self {
+        self.lifecycle_config = config;
         self
     }
 

--- a/crates/ao-core/src/lifecycle/stuck.rs
+++ b/crates/ao-core/src/lifecycle/stuck.rs
@@ -921,7 +921,8 @@ mod tests {
         lifecycle.tick(&mut seen).await.unwrap();
 
         let persisted = sessions.list().await.unwrap();
-        assert_eq!(persisted[0].status, SessionStatus::Merged);
+        // auto_terminate_on_merge (default=true) transitions Merged → Killed.
+        assert_eq!(persisted[0].status, SessionStatus::Killed);
         assert_eq!(
             persisted[0].last_merge_conflict_dispatched, None,
             "clear branch must reset the flag on Merged"

--- a/crates/ao-core/src/lifecycle/tick.rs
+++ b/crates/ao-core/src/lifecycle/tick.rs
@@ -149,6 +149,14 @@ impl LifecycleManager {
                     }
                 }
             }
+
+            // Auto-terminate on merge (issue #220): transition to Killed and
+            // emit Terminated{PrMerged} so observers see a clean shutdown event.
+            if self.lifecycle_config.auto_terminate_on_merge {
+                self.terminate(&mut session, TerminationReason::PrMerged)
+                    .await?;
+                return Ok(());
+            }
         }
 
         // ---- 6. Agent-stuck detection (Phase H) ----
@@ -481,6 +489,166 @@ mod tests {
         handle.stop().await;
         assert!(!saw_restored, "fresh session must not surface as restored");
         assert!(saw_spawned, "fresh session never surfaced as Spawned");
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    // ---------- Auto-terminate on merge (issue #220) ---------- //
+
+    #[tokio::test]
+    async fn merged_pr_terminates_session_with_pr_merged_reason() {
+        use crate::lifecycle::tests::unique_temp_dir;
+        use crate::scm::{CiStatus, PrState, ReviewDecision};
+        use crate::session_manager::SessionManager;
+        let base = unique_temp_dir("auto-terminate-merged");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let scm = Arc::new(crate::lifecycle::tests::MockScm::new());
+
+        let lifecycle = Arc::new(
+            LifecycleManager::new(sessions.clone(), runtime, agent)
+                .with_scm(scm.clone() as Arc<dyn crate::traits::Scm>),
+        );
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::PrOpen;
+        sessions.save(&s).await.unwrap();
+
+        scm.set_pr(Some(crate::lifecycle::tests::fake_pr(42, "ao-s1")));
+        scm.set_state(PrState::Merged);
+        scm.set_ci(CiStatus::Passing);
+        scm.set_review(ReviewDecision::None);
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let mut events = Vec::new();
+        while let Some(e) = recv_timeout(&mut rx).await {
+            events.push(e);
+        }
+
+        assert!(
+            events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::Terminated {
+                    reason: TerminationReason::PrMerged,
+                    ..
+                }
+            )),
+            "expected Terminated(PrMerged), got {events:?}"
+        );
+
+        let persisted = sessions.find_by_prefix("s1").await.unwrap();
+        assert_eq!(persisted.status, SessionStatus::Killed);
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn auto_terminate_on_merge_opt_out_leaves_session_in_merged() {
+        use crate::config::LifecycleConfig;
+        use crate::lifecycle::tests::unique_temp_dir;
+        use crate::scm::{CiStatus, PrState, ReviewDecision};
+        use crate::session_manager::SessionManager;
+        let base = unique_temp_dir("auto-terminate-optout");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let scm = Arc::new(crate::lifecycle::tests::MockScm::new());
+
+        let lifecycle = Arc::new(
+            LifecycleManager::new(sessions.clone(), runtime, agent)
+                .with_scm(scm.clone() as Arc<dyn crate::traits::Scm>)
+                .with_lifecycle_config(LifecycleConfig {
+                    auto_terminate_on_merge: false,
+                }),
+        );
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::PrOpen;
+        sessions.save(&s).await.unwrap();
+
+        scm.set_pr(Some(crate::lifecycle::tests::fake_pr(42, "ao-s1")));
+        scm.set_state(PrState::Merged);
+        scm.set_ci(CiStatus::Passing);
+        scm.set_review(ReviewDecision::None);
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let mut events = Vec::new();
+        while let Some(e) = recv_timeout(&mut rx).await {
+            events.push(e);
+        }
+
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::Terminated {
+                    reason: TerminationReason::PrMerged,
+                    ..
+                }
+            )),
+            "Terminated(PrMerged) must not fire when auto_terminate_on_merge=false, got {events:?}"
+        );
+
+        let persisted = sessions.find_by_prefix("s1").await.unwrap();
+        assert_eq!(
+            persisted.status,
+            SessionStatus::Merged,
+            "session must stay Merged when opt-out"
+        );
+
+        let _ = std::fs::remove_dir_all(&base);
+    }
+
+    #[tokio::test]
+    async fn closed_without_merge_does_not_emit_pr_merged_termination() {
+        use crate::lifecycle::tests::unique_temp_dir;
+        use crate::scm::{CiStatus, PrState, ReviewDecision};
+        use crate::session_manager::SessionManager;
+        let base = unique_temp_dir("auto-terminate-closed");
+        let sessions = Arc::new(SessionManager::new(base.clone()));
+        let runtime: Arc<dyn Runtime> = Arc::new(MockRuntime::new(true));
+        let agent: Arc<dyn Agent> = Arc::new(MockAgent::new(ActivityState::Ready));
+        let scm = Arc::new(crate::lifecycle::tests::MockScm::new());
+
+        let lifecycle = Arc::new(
+            LifecycleManager::new(sessions.clone(), runtime, agent)
+                .with_scm(scm.clone() as Arc<dyn crate::traits::Scm>),
+        );
+        let mut rx = lifecycle.subscribe();
+
+        let mut s = fake_session("s1", "demo");
+        s.status = SessionStatus::PrOpen;
+        sessions.save(&s).await.unwrap();
+
+        scm.set_pr(Some(crate::lifecycle::tests::fake_pr(42, "ao-s1")));
+        scm.set_state(PrState::Closed);
+        scm.set_ci(CiStatus::Passing);
+        scm.set_review(ReviewDecision::None);
+
+        let mut seen = HashSet::new();
+        lifecycle.tick(&mut seen).await.unwrap();
+
+        let mut events = Vec::new();
+        while let Some(e) = recv_timeout(&mut rx).await {
+            events.push(e);
+        }
+
+        assert!(
+            !events.iter().any(|e| matches!(
+                e,
+                OrchestratorEvent::Terminated {
+                    reason: TerminationReason::PrMerged,
+                    ..
+                }
+            )),
+            "Terminated(PrMerged) must not fire for closed-not-merged PR, got {events:?}"
+        );
 
         let _ = std::fs::remove_dir_all(&base);
     }

--- a/crates/ao-core/src/lifecycle/transition.rs
+++ b/crates/ao-core/src/lifecycle/transition.rs
@@ -19,7 +19,8 @@ impl LifecycleManager {
         let terminal_status = match reason {
             TerminationReason::RuntimeGone
             | TerminationReason::AgentExited
-            | TerminationReason::NoHandle => SessionStatus::Killed,
+            | TerminationReason::NoHandle
+            | TerminationReason::PrMerged => SessionStatus::Killed,
         };
         if session.status != terminal_status {
             self.transition(session, terminal_status).await?;

--- a/crates/ao-core/src/orchestrator_prompt.rs
+++ b/crates/ao-core/src/orchestrator_prompt.rs
@@ -325,6 +325,7 @@ mod tests {
             reactions: HashMap::new(),
             notification_routing: Default::default(),
             notifiers: HashMap::new(),
+            lifecycle: None,
             plugins: vec![],
         }
     }

--- a/crates/ao-desktop/ui/src/lib/format.ts
+++ b/crates/ao-desktop/ui/src/lib/format.ts
@@ -111,6 +111,7 @@ export function formatEvent(evt: ApiEvent): string {
     }
     case "terminated": {
       const reason = str(rec, "reason");
+      if (reason === "pr_merged") return "terminated · PR merged";
       return reason ? `terminated · ${reason}` : "terminated";
     }
     case "tick_error": {

--- a/schema/ao-rs.schema.json
+++ b/schema/ao-rs.schema.json
@@ -30,6 +30,17 @@
       "format": "uint16",
       "minimum": 0.0
     },
+    "lifecycle": {
+      "description": "Lifecycle automation settings (auto-terminate on merge, etc.).",
+      "anyOf": [
+        {
+          "$ref": "#/definitions/LifecycleConfig"
+        },
+        {
+          "type": "null"
+        }
+      ]
+    },
     "notification_routing": {
       "description": "Priority-based notification routing table.",
       "default": {},
@@ -267,6 +278,17 @@
           ]
         }
       ]
+    },
+    "LifecycleConfig": {
+      "description": "Lifecycle automation settings (TS: `LifecycleConfig`).",
+      "type": "object",
+      "properties": {
+        "auto_terminate_on_merge": {
+          "description": "Auto-terminate sessions when their PR merges (default: `true`).\n\nWhen enabled, the runtime (tmux) and worktree are destroyed within one tick of the PR state transitioning to `merged`. Set to `false` to opt out and manage session lifetimes manually.",
+          "default": true,
+          "type": "boolean"
+        }
+      }
     },
     "MergeMethod": {
       "description": "How to merge a PR. Mirrors GitHub's three merge methods exactly.\n\n**Parity note (issue #109):** the default (`Merge`) diverges intentionally from the ao-ts reference, which defaults to `Squash`. Squash rewrites commit history, so ao-rs picks the safer default and asks users to opt into squash/rebase explicitly via the reaction config's `merge_method:` key (see `ReactionConfig::merge_method`) or the project-level override. The decision record lives at `docs/plans/remaining-to-port/7-4-default-merge-method.md`.",


### PR DESCRIPTION
## Summary

- Add `LifecycleConfig` with `auto_terminate_on_merge: bool` (default `true`) to `ao-rs.yaml`
- When enabled: sessions whose PR transitions to `merged` are terminated within the same lifecycle tick — runtime (tmux) killed, worktree removed, status → `killed`, `Terminated { reason: pr_merged }` event emitted
- New `TerminationReason::PrMerged` serialises as `"pr_merged"` on the SSE wire
- UI (`formatEvent`): renders `terminated · PR merged` as a distinct label
- Config opt-out: `lifecycle.autoTerminateOnMerge: false` in `ao-rs.yaml`
- JSON schema regenerated

Port of upstream agent-orchestrator #1311.

## Test plan

- [x] `merged_pr_terminates_session_with_pr_merged_reason` — default config, PR merged → `Terminated(PrMerged)`, status `Killed`
- [x] `auto_terminate_on_merge_opt_out_leaves_session_in_merged` — opt-out flag honored, session stays `Merged`
- [x] `closed_without_merge_does_not_emit_pr_merged_termination` — closed-not-merged PR → no `PrMerged` event
- [x] Wire form pinned: `"pr_merged"`
- [x] 889/890 workspace tests pass (1 pre-existing unrelated failure in `ao-plugin-agent-claude-code`)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all -- --check` clean
- [x] Schema regenerated and verified

Closes #220

🤖 Generated with [Claude Code](https://claude.ai/claude-code)